### PR TITLE
Test/benchmarking

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -174,29 +174,14 @@ jobs:
             echo "BASELINE_SOURCE=missing" >> "$GITHUB_ENV"
           fi
 
-      - name: Generate fallback baseline if none found
+      - name: Set baseline status if none found
         if: steps.find_baseline.outputs.found != 'true'
         shell: bash
         run: |
           set -euo pipefail
-          echo "📈 No baseline artifact found, generating fallback baseline..."
-          echo "   This baseline will be used for this comparison only."
-          echo ""
-
-          # Generate baseline using dev mode for faster execution
-          if uv run benchmark-utils generate-baseline --dev \
-            || uv run python -m scripts.benchmark_utils generate-baseline --dev; then
-            echo "BASELINE_EXISTS=true" >> "$GITHUB_ENV"
-            echo "BASELINE_SOURCE=generated" >> "$GITHUB_ENV"
-
-            echo "✅ Generated fallback baseline successfully"
-            echo "=== Generated Baseline Information ==="
-            head -n 3 benches/baseline_results.txt
-          else
-            echo "❌ Failed to generate fallback baseline"
-            echo "BASELINE_EXISTS=false" >> "$GITHUB_ENV"
-            echo "BASELINE_SOURCE=failed" >> "$GITHUB_ENV"
-          fi
+          echo "📈 No baseline artifact found for performance comparison"
+          echo "BASELINE_EXISTS=false" >> "$GITHUB_ENV"
+          echo "BASELINE_SOURCE=none" >> "$GITHUB_ENV"
 
       - name: Extract baseline commit SHA
         if: env.BASELINE_EXISTS == 'true'
@@ -254,18 +239,14 @@ jobs:
         run: |
           set -euo pipefail
           echo "⚠️ No performance baseline available for comparison."
-          if [[ "${BASELINE_SOURCE:-}" == "failed" ]]; then
-            echo "   - Failed to generate fallback baseline"
-            echo "   - Check the baseline generation workflow logs for issues"
-          else
-            echo "   - No baseline artifacts found in recent releases"
-            echo "   - Create a new release tag to generate a baseline"
-          fi
+          echo "   - No baseline artifacts found in recent releases"
+          echo "   - Performance regression testing requires a release baseline"
           echo ""
-          echo "💡 To resolve:"
-          echo "   1. Create a new release tag (e.g., v0.4.2)"
+          echo "💡 To enable performance regression testing:"
+          echo "   1. Create a new release tag (e.g., v0.4.3)"
           echo "   2. The baseline generation workflow will run automatically"
           echo "   3. Future PRs and pushes will use that baseline for comparison"
+          echo "   4. Baselines use full benchmark settings for accurate comparisons"
 
       - name: Run performance regression test
         if: env.BASELINE_EXISTS == 'true' && env.SKIP_BENCHMARKS == 'false'
@@ -276,16 +257,9 @@ jobs:
           echo "   Baseline source: ${BASELINE_SOURCE:-unknown}"
 
           # This will exit with code 1 if significant regressions are found
-          # Use --dev mode when comparing against a generated baseline to match settings
-          if [[ "${BASELINE_SOURCE:-}" == "generated" ]]; then
-            echo "   Using --dev mode to match generated baseline settings"
-            uv run benchmark-utils compare --baseline benches/baseline_results.txt --dev \
-              || uv run python -m scripts.benchmark_utils compare --baseline benches/baseline_results.txt --dev
-          else
-            echo "   Using full comparison mode against release baseline"
-            uv run benchmark-utils compare --baseline benches/baseline_results.txt \
-              || uv run python -m scripts.benchmark_utils compare --baseline benches/baseline_results.txt
-          fi
+          echo "   Using full comparison mode against release baseline"
+          uv run benchmark-utils compare --baseline benches/baseline_results.txt \
+            || uv run python -m scripts.benchmark_utils compare --baseline benches/baseline_results.txt
 
       - name: Display regression test results
         if: env.BASELINE_EXISTS == 'true' && env.SKIP_BENCHMARKS == 'false' && always()

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -74,6 +74,55 @@ jobs:
         with:
           script: |
             try {
+              // Fetch all successful generate-baseline.yml runs once (O(runs) API calls)
+              console.log('Fetching recent generate-baseline.yml runs...');
+              const runs = await github.paginate(
+                github.rest.actions.listWorkflowRuns,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: 'generate-baseline.yml',
+                  status: 'completed',
+                  conclusion: 'success',
+                  per_page: 100
+                },
+                (response, done) => {
+                  // Limit to 150 runs to avoid excessive API calls
+                  if (response.data.length >= 150) {
+                    done();
+                  }
+                  return response.data;
+                }
+              );
+
+              console.log(`Found ${runs.length} successful generate-baseline runs`);
+
+              // Build artifact cache: artifact name → {run_id, run_created_at}
+              const artifactCache = new Map();
+              for (const run of runs) {
+                try {
+                  const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: run.id
+                  });
+
+                  for (const artifact of artifacts.data.artifacts) {
+                    if (artifact.name.startsWith('performance-baseline-') && artifact.expired !== true) {
+                      artifactCache.set(artifact.name, {
+                        run_id: run.id,
+                        run_created_at: run.created_at
+                      });
+                    }
+                  }
+                } catch (error) {
+                  console.log(`Warning: Could not fetch artifacts for run ${run.id}: ${error.message}`);
+                  continue;
+                }
+              }
+
+              console.log(`Built cache of ${artifactCache.size} baseline artifacts`);
+
               // First, try to find baseline artifacts from release tags
               const releases = await github.paginate(
                 github.rest.repos.listReleases,
@@ -82,7 +131,7 @@ jobs:
 
               console.log(`Found ${releases.length} releases (paginated)`);
 
-              // Look for releases with baseline artifacts
+              // Look for releases with baseline artifacts (now O(releases) lookups)
               for (const release of releases) {
                 console.log(`Checking release ${release.tag_name}...`);
                 if (release.draft || release.prerelease) {
@@ -94,81 +143,48 @@ jobs:
                 const cleanTag = release.tag_name.replace(/[^a-zA-Z0-9._-]/g, '_');
                 const expectedName = `performance-baseline-${cleanTag}`;
 
-                // Search through recent generate-baseline.yml runs
-                for (let page = 1; page <= 3; page++) {
-                  const runs = await github.rest.actions.listWorkflowRuns({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    workflow_id: 'generate-baseline.yml',
-                    status: 'completed',
-                    conclusion: 'success',
-                    per_page: 50,
-                    page
-                  });
-
-                  for (const run of runs.data.workflow_runs) {
-                    const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      run_id: run.id
-                    });
-                    const baselineArtifact = artifacts.data.artifacts.find(
-                      a => a.name === expectedName && a.expired !== true
-                    );
-                    if (baselineArtifact) {
-                      console.log(
-                        `Found release baseline artifact ${expectedName} in run ${run.id} ` +
-                        `for release ${release.tag_name}`
-                      );
-                      core.setOutput('found', 'true');
-                      core.setOutput('release_tag', release.tag_name);
-                      core.setOutput('artifact_name', expectedName);
-                      core.setOutput('run_id', run.id.toString());
-                      core.setOutput('source_type', 'release');
-                      return;
-                    }
-                  }
+                if (artifactCache.has(expectedName)) {
+                  const artifactInfo = artifactCache.get(expectedName);
+                  console.log(
+                    `Found release baseline artifact ${expectedName} in run ${artifactInfo.run_id} ` +
+                    `for release ${release.tag_name}`
+                  );
+                  core.setOutput('found', 'true');
+                  core.setOutput('release_tag', release.tag_name);
+                  core.setOutput('artifact_name', expectedName);
+                  core.setOutput('run_id', artifactInfo.run_id.toString());
+                  core.setOutput('source_type', 'release');
+                  return;
                 }
               }
 
               console.log('No release baseline artifacts found, checking for any recent baselines...');
 
               // Fallback: look for any recent baseline artifact (including manual runs)
-              for (let page = 1; page <= 3; page++) {
-                const runs = await github.rest.actions.listWorkflowRuns({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: 'generate-baseline.yml',
-                  status: 'completed',
-                  conclusion: 'success',
-                  per_page: 50,
-                  page
-                });
+              if (artifactCache.size > 0) {
+                // Find the most recent artifact (by run creation time)
+                let mostRecentArtifact = null;
+                let mostRecentTime = null;
 
-                for (const run of runs.data.workflow_runs) {
-                  const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    run_id: run.id
-                  });
-
-                  // Look for any artifact starting with 'performance-baseline-'
-                  const baselineArtifact = artifacts.data.artifacts.find(a =>
-                    a.name.startsWith('performance-baseline-') && a.expired !== true
-                  );
-
-                  if (baselineArtifact) {
-                    console.log(
-                      `Found baseline artifact ${baselineArtifact.name} in run ${run.id} ` +
-                      `(created: ${run.created_at})`
-                    );
-                    core.setOutput('found', 'true');
-                    core.setOutput('release_tag', 'manual-baseline');
-                    core.setOutput('artifact_name', baselineArtifact.name);
-                    core.setOutput('run_id', run.id.toString());
-                    core.setOutput('source_type', 'manual');
-                    return;
+                for (const [artifactName, artifactInfo] of artifactCache.entries()) {
+                  const runTime = new Date(artifactInfo.run_created_at);
+                  if (!mostRecentTime || runTime > mostRecentTime) {
+                    mostRecentTime = runTime;
+                    mostRecentArtifact = { name: artifactName, ...artifactInfo };
                   }
+                }
+
+                if (mostRecentArtifact) {
+                  console.log(
+                    `Found baseline artifact ${mostRecentArtifact.name} in run ${mostRecentArtifact.run_id} ` +
+                    `(created: ${mostRecentArtifact.run_created_at})`
+                  );
+                  core.setOutput('found', 'true');
+                  core.setOutput('release_tag', 'manual-baseline');
+                  core.setOutput('artifact_name', mostRecentArtifact.name);
+                  core.setOutput('run_id', mostRecentArtifact.run_id.toString());
+                  core.setOutput('source_type', 'manual');
+                  return;
                 }
               }
 
@@ -300,8 +316,15 @@ jobs:
 
           # This will exit with code 1 if significant regressions are found
           echo "   Using full comparison mode against ${BASELINE_ORIGIN:-unknown} baseline"
-          uv run benchmark-utils compare --baseline benches/baseline_results.txt \
-            || uv run python -m scripts.benchmark_utils compare --baseline benches/baseline_results.txt
+          if uv run benchmark-utils --help >/dev/null 2>&1; then
+            uv run benchmark-utils compare --baseline benches/baseline_results.txt
+          elif uv run python -c "import importlib; importlib.import_module('scripts.benchmark_utils')" \
+               >/dev/null 2>&1; then
+            uv run python -m scripts.benchmark_utils compare --baseline benches/baseline_results.txt
+          else
+            echo "❌ benchmark-utils entrypoint and module not found" >&2
+            exit 2
+          fi
 
       - name: Display regression test results
         if: env.BASELINE_EXISTS == 'true' && env.SKIP_BENCHMARKS == 'false' && always()

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -90,7 +90,7 @@ jobs:
                   continue;
                 }
 
-                // Mirror sanitization in generate-baseline.yml (allow [A-Za-z0-9._-], replace others with _)
+                // Must match sanitize step in .github/workflows/generate-baseline.yml
                 const cleanTag = release.tag_name.replace(/[^a-zA-Z0-9._-]/g, '_');
                 const expectedName = `performance-baseline-${cleanTag}`;
 
@@ -112,7 +112,9 @@ jobs:
                       repo: context.repo.repo,
                       run_id: run.id
                     });
-                    const baselineArtifact = artifacts.data.artifacts.find(a => a.name === expectedName);
+                    const baselineArtifact = artifacts.data.artifacts.find(
+                      a => a.name === expectedName && a.expired !== true
+                    );
                     if (baselineArtifact) {
                       console.log(
                         `Found release baseline artifact ${expectedName} in run ${run.id} ` +
@@ -152,7 +154,7 @@ jobs:
 
                   // Look for any artifact starting with 'performance-baseline-'
                   const baselineArtifact = artifacts.data.artifacts.find(a =>
-                    a.name.startsWith('performance-baseline-')
+                    a.name.startsWith('performance-baseline-') && a.expired !== true
                   );
 
                   if (baselineArtifact) {
@@ -192,6 +194,7 @@ jobs:
         shell: bash
         env:
           RELEASE_TAG: ${{ steps.find_baseline.outputs.release_tag }}
+          SOURCE_TYPE: ${{ steps.find_baseline.outputs.source_type }}
         run: |
           set -euo pipefail
           if [[ -f "baseline-artifact/baseline_results.txt" ]]; then
@@ -200,6 +203,7 @@ jobs:
             cp "baseline-artifact/baseline_results.txt" "benches/baseline_results.txt"
             echo "BASELINE_EXISTS=true" >> "$GITHUB_ENV"
             echo "BASELINE_SOURCE=artifact" >> "$GITHUB_ENV"
+            echo "BASELINE_ORIGIN=${SOURCE_TYPE:-unknown}" >> "$GITHUB_ENV"
 
             # Show baseline metadata
             echo "=== Baseline Information (from artifact) ==="
@@ -218,6 +222,7 @@ jobs:
           echo "📈 No baseline artifact found for performance comparison"
           echo "BASELINE_EXISTS=false" >> "$GITHUB_ENV"
           echo "BASELINE_SOURCE=none" >> "$GITHUB_ENV"
+          echo "BASELINE_ORIGIN=none" >> "$GITHUB_ENV"
 
       - name: Extract baseline commit SHA
         if: env.BASELINE_EXISTS == 'true'
@@ -291,9 +296,10 @@ jobs:
           set -euo pipefail
           echo "🚀 Running performance regression test..."
           echo "   Baseline source: ${BASELINE_SOURCE:-unknown}"
+          echo "   Baseline origin: ${BASELINE_ORIGIN:-unknown}"
 
           # This will exit with code 1 if significant regressions are found
-          echo "   Using full comparison mode against release baseline"
+          echo "   Using full comparison mode against ${BASELINE_ORIGIN:-unknown} baseline"
           uv run benchmark-utils compare --baseline benches/baseline_results.txt \
             || uv run python -m scripts.benchmark_utils compare --baseline benches/baseline_results.txt
 
@@ -326,6 +332,7 @@ jobs:
           echo "📊 Performance Regression Testing Summary"
           echo "==========================================="
           echo "Baseline source: ${BASELINE_SOURCE:-none}"
+          echo "Baseline origin: ${BASELINE_ORIGIN:-unknown}"
           echo "Baseline exists: ${BASELINE_EXISTS:-false}"
           echo "Skip benchmarks: ${SKIP_BENCHMARKS:-unknown}"
           echo "Skip reason: ${SKIP_REASON:-n/a}"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -74,6 +74,21 @@ jobs:
         with:
           script: |
             try {
+              // Precompute expected baseline names for early-hit optimization
+              const releases = await github.paginate(
+                github.rest.repos.listReleases,
+                { owner: context.repo.owner, repo: context.repo.repo, per_page: 50 }
+              );
+
+              const expectedReleaseBaselines = new Set();
+              for (const release of releases) {
+                if (!release.draft && !release.prerelease) {
+                  const cleanTag = release.tag_name.replace(/[^a-zA-Z0-9._-]/g, '_');
+                  expectedReleaseBaselines.add(`performance-baseline-${cleanTag}`);
+                }
+              }
+              console.log(`Precomputed ${expectedReleaseBaselines.size} expected release baseline names`);
+
               // Fetch all successful generate-baseline.yml runs once (O(runs) API calls)
               console.log('Fetching recent generate-baseline.yml runs...');
               let count = 0;
@@ -88,10 +103,13 @@ jobs:
                   per_page: 100
                 },
                 (response, done) => {
-                  // Limit to 150 runs total across pages
-                  count += response.data.length;
+                  // Limit to 150 runs total across pages (no overshoot)
+                  const remaining = Math.max(0, 150 - count);
+                  if (remaining === 0) { done(); return []; }
+                  const slice = response.data.slice(0, remaining);
+                  count += slice.length;
                   if (count >= 150) done();
-                  return response.data;
+                  return slice;
                 }
               );
 
@@ -99,6 +117,7 @@ jobs:
 
               // Build artifact cache: artifact name → {run_id, run_created_at}
               const artifactCache = new Map();
+              let foundReleaseBaseline = false;
               for (const run of runs) {
                 try {
                   const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -114,9 +133,18 @@ jobs:
                           run_id: run.id,
                           run_created_at: run.created_at
                         });
+
+                        // Early-hit optimization: stop if we found a release baseline
+                        if (expectedReleaseBaselines.has(artifact.name)) {
+                          console.log(`Early hit: found release baseline ${artifact.name}, stopping search`);
+                          foundReleaseBaseline = true;
+                        }
                       }
                     }
                   }
+
+                  // Short-circuit if we found a release baseline
+                  if (foundReleaseBaseline) break;
                 } catch (error) {
                   console.log(`Warning: Could not fetch artifacts for run ${run.id}: ${error.message}`);
                   continue;
@@ -125,13 +153,7 @@ jobs:
 
               console.log(`Built cache of ${artifactCache.size} baseline artifacts`);
 
-              // First, try to find baseline artifacts from release tags
-              const releases = await github.paginate(
-                github.rest.repos.listReleases,
-                { owner: context.repo.owner, repo: context.repo.repo, per_page: 50 }
-              );
-
-              console.log(`Found ${releases.length} releases (paginated)`);
+              console.log(`Found ${releases.length} releases (already fetched)`);
 
               // Look for releases with baseline artifacts (now O(releases) lookups)
               for (const release of releases) {
@@ -222,6 +244,9 @@ jobs:
             echo "BASELINE_EXISTS=true" >> "$GITHUB_ENV"
             echo "BASELINE_SOURCE=artifact" >> "$GITHUB_ENV"
             echo "BASELINE_ORIGIN=${SOURCE_TYPE:-unknown}" >> "$GITHUB_ENV"
+            if [[ -n "${RELEASE_TAG:-}" ]]; then
+              echo "BASELINE_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
+            fi
 
             # Show baseline metadata
             echo "=== Baseline Information (from artifact) ==="
@@ -358,6 +383,7 @@ jobs:
           echo "==========================================="
           echo "Baseline source: ${BASELINE_SOURCE:-none}"
           echo "Baseline origin: ${BASELINE_ORIGIN:-unknown}"
+          echo "Baseline tag: ${BASELINE_TAG:-n/a}"
           echo "Baseline exists: ${BASELINE_EXISTS:-false}"
           echo "Skip benchmarks: ${SKIP_BENCHMARKS:-unknown}"
           echo "Skip reason: ${SKIP_REASON:-n/a}"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -68,16 +68,16 @@ jobs:
         run: uv --version
 
 
-      - name: Find latest release with baseline artifact
+      - name: Find baseline artifact
         id: find_baseline
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
             try {
-              // Get all releases with pagination to handle large repos
+              // First, try to find baseline artifacts from release tags
               const releases = await github.paginate(
                 github.rest.repos.listReleases,
-                { owner: context.repo.owner, repo: context.repo.repo, per_page: 100 }
+                { owner: context.repo.owner, repo: context.repo.repo, per_page: 50 }
               );
 
               console.log(`Found ${releases.length} releases (paginated)`);
@@ -90,51 +90,87 @@ jobs:
                   continue;
                 }
 
-                // List recent runs and look for an artifact matching the release tag
-                try {
-                  // Mirror sanitization in generate-baseline.yml (allow [A-Za-z0-9._-], replace others with _)
-                  const cleanTag = release.tag_name.replace(/[^a-zA-Z0-9._-]/g, '_');
-                  const expectedName = `performance-baseline-${cleanTag}`;
-                  let found = false;
-                  for (let page = 1; page <= 5 && !found; page++) {
-                    const runs = await github.rest.actions.listWorkflowRuns({
+                // Mirror sanitization in generate-baseline.yml (allow [A-Za-z0-9._-], replace others with _)
+                const cleanTag = release.tag_name.replace(/[^a-zA-Z0-9._-]/g, '_');
+                const expectedName = `performance-baseline-${cleanTag}`;
+
+                // Search through recent generate-baseline.yml runs
+                for (let page = 1; page <= 3; page++) {
+                  const runs = await github.rest.actions.listWorkflowRuns({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: 'generate-baseline.yml',
+                    status: 'completed',
+                    conclusion: 'success',
+                    per_page: 50,
+                    page
+                  });
+
+                  for (const run of runs.data.workflow_runs) {
+                    const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                       owner: context.repo.owner,
                       repo: context.repo.repo,
-                      workflow_id: 'generate-baseline.yml',
-                      status: 'completed',
-                      conclusion: 'success',
-                      per_page: 100,
-                      page
+                      run_id: run.id
                     });
-                    for (const run of runs.data.workflow_runs) {
-                      const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        run_id: run.id
-                      });
-                      const baselineArtifact = artifacts.data.artifacts.find(a => a.name === expectedName);
-                      if (baselineArtifact) {
-                        console.log(
-                          `Found baseline artifact ${expectedName} in run ${run.id} ` +
-                          `for release ${release.tag_name}`
-                        );
-                        core.setOutput('found', 'true');
-                        core.setOutput('release_tag', release.tag_name);
-                        core.setOutput('artifact_name', expectedName);
-                        core.setOutput('run_id', run.id.toString());
-                        found = true;
-                        break;
-                      }
+                    const baselineArtifact = artifacts.data.artifacts.find(a => a.name === expectedName);
+                    if (baselineArtifact) {
+                      console.log(
+                        `Found release baseline artifact ${expectedName} in run ${run.id} ` +
+                        `for release ${release.tag_name}`
+                      );
+                      core.setOutput('found', 'true');
+                      core.setOutput('release_tag', release.tag_name);
+                      core.setOutput('artifact_name', expectedName);
+                      core.setOutput('run_id', run.id.toString());
+                      core.setOutput('source_type', 'release');
+                      return;
                     }
                   }
-                  if (found) return;
-                } catch (error) {
-                  console.log(`Error checking release ${release.tag_name}: ${error.message}`);
-                  continue;
                 }
               }
 
-              console.log('No baseline artifacts found in any release');
+              console.log('No release baseline artifacts found, checking for any recent baselines...');
+
+              // Fallback: look for any recent baseline artifact (including manual runs)
+              for (let page = 1; page <= 3; page++) {
+                const runs = await github.rest.actions.listWorkflowRuns({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: 'generate-baseline.yml',
+                  status: 'completed',
+                  conclusion: 'success',
+                  per_page: 50,
+                  page
+                });
+
+                for (const run of runs.data.workflow_runs) {
+                  const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: run.id
+                  });
+
+                  // Look for any artifact starting with 'performance-baseline-'
+                  const baselineArtifact = artifacts.data.artifacts.find(a =>
+                    a.name.startsWith('performance-baseline-')
+                  );
+
+                  if (baselineArtifact) {
+                    console.log(
+                      `Found baseline artifact ${baselineArtifact.name} in run ${run.id} ` +
+                      `(created: ${run.created_at})`
+                    );
+                    core.setOutput('found', 'true');
+                    core.setOutput('release_tag', 'manual-baseline');
+                    core.setOutput('artifact_name', baselineArtifact.name);
+                    core.setOutput('run_id', run.id.toString());
+                    core.setOutput('source_type', 'manual');
+                    return;
+                  }
+                }
+              }
+
+              console.log('No baseline artifacts found in any recent runs');
               core.setOutput('found', 'false');
             } catch (error) {
               console.error(`Error searching for baseline artifacts: ${error.message}`);
@@ -239,12 +275,12 @@ jobs:
         run: |
           set -euo pipefail
           echo "⚠️ No performance baseline available for comparison."
-          echo "   - No baseline artifacts found in recent releases"
-          echo "   - Performance regression testing requires a release baseline"
+          echo "   - No baseline artifacts found in recent workflow runs"
+          echo "   - Performance regression testing requires a baseline"
           echo ""
           echo "💡 To enable performance regression testing:"
-          echo "   1. Create a new release tag (e.g., v0.4.3)"
-          echo "   2. The baseline generation workflow will run automatically"
+          echo "   1. Create a release tag (e.g., v0.4.3), or"
+          echo "   2. Manually trigger the 'Generate Performance Baseline' workflow"
           echo "   3. Future PRs and pushes will use that baseline for comparison"
           echo "   4. Baselines use full benchmark settings for accurate comparisons"
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -76,6 +76,7 @@ jobs:
             try {
               // Fetch all successful generate-baseline.yml runs once (O(runs) API calls)
               console.log('Fetching recent generate-baseline.yml runs...');
+              let count = 0;
               const runs = await github.paginate(
                 github.rest.actions.listWorkflowRuns,
                 {
@@ -87,10 +88,9 @@ jobs:
                   per_page: 100
                 },
                 (response, done) => {
-                  // Limit to 150 runs to avoid excessive API calls
-                  if (response.data.length >= 150) {
-                    done();
-                  }
+                  // Limit to 150 runs total across pages
+                  count += response.data.length;
+                  if (count >= 150) done();
                   return response.data;
                 }
               );
@@ -109,10 +109,12 @@ jobs:
 
                   for (const artifact of artifacts.data.artifacts) {
                     if (artifact.name.startsWith('performance-baseline-') && artifact.expired !== true) {
-                      artifactCache.set(artifact.name, {
-                        run_id: run.id,
-                        run_created_at: run.created_at
-                      });
+                      if (!artifactCache.has(artifact.name)) {
+                        artifactCache.set(artifact.name, {
+                          run_id: run.id,
+                          run_created_at: run.created_at
+                        });
+                      }
                     }
                   }
                 } catch (error) {

--- a/.github/workflows/generate-baseline.yml
+++ b/.github/workflows/generate-baseline.yml
@@ -141,7 +141,7 @@ jobs:
         with:
           name: ${{ steps.safe_name.outputs.artifact_name }}
           path: baseline-artifact/
-          retention-days: 90   # Keep baselines for 90 days (repository maximum)
+          retention-days: 90   # Keep baselines ~90 days (align with repo settings; adjust if needed)
           compression-level: 6  # Good balance of speed/compression
 
       - name: Display next steps

--- a/.github/workflows/generate-baseline.yml
+++ b/.github/workflows/generate-baseline.yml
@@ -141,7 +141,7 @@ jobs:
         with:
           name: ${{ steps.safe_name.outputs.artifact_name }}
           path: baseline-artifact/
-          retention-days: 365  # Keep baselines for 1 year
+          retention-days: 90   # Keep baselines for 90 days (repository maximum)
           compression-level: 6  # Good balance of speed/compression
 
       - name: Display next steps


### PR DESCRIPTION
This pull request updates the performance benchmarking workflow to improve how baseline artifacts are found and handled, and clarifies the messaging and artifact retention policy. The workflow now more reliably locates baseline artifacts, provides clearer instructions when no baseline is found, and aligns artifact retention with repository limits.

**Improvements to baseline artifact discovery and handling:**

* The baseline search logic in `.github/workflows/benchmarks.yml` was refactored to first look for release-tagged baseline artifacts, and if none are found, to search for any recent baseline artifacts from manual or other workflow runs. The search is now more robust and logs the source type of the found artifact (`release` or `manual`). [[1]](diffhunk://#diff-22eef62c9d7b36d02f5fd5aaada92702e22d6795c464239cb7b8fe0f26ea1e1cL71-R80) [[2]](diffhunk://#diff-22eef62c9d7b36d02f5fd5aaada92702e22d6795c464239cb7b8fe0f26ea1e1cL93-R108) [[3]](diffhunk://#diff-22eef62c9d7b36d02f5fd5aaada92702e22d6795c464239cb7b8fe0f26ea1e1cL118-R173)
* The fallback step was changed: if no baseline is found, the workflow now sets status variables and logs a message, rather than attempting to generate a new baseline on the fly.

**Messaging and instructions:**

* The messaging when no baseline is found has been improved to clarify the steps required to enable performance regression testing, including creating a release tag or manually triggering the baseline workflow.
* The regression test step was simplified to always use the full comparison mode, removing the special case for generated baselines.

**Artifact retention policy:**

* The baseline artifact retention period in `.github/workflows/generate-baseline.yml` was reduced from 365 days to 90 days to match the repository maximum.