### PR TITLE
Refactor/phase 3

### DIFF
--- a/examples/convex_hull_3d_50_points.rs
+++ b/examples/convex_hull_3d_50_points.rs
@@ -28,6 +28,8 @@
 //! - Validation results
 //! - Performance metrics
 
+#![allow(deprecated)]
+
 use delaunay::geometry::util::generate_random_triangulation;
 use delaunay::prelude::*;
 use num_traits::cast::cast;

--- a/examples/triangulation_3d_50_points.rs
+++ b/examples/triangulation_3d_50_points.rs
@@ -203,11 +203,17 @@ fn analyze_boundary_properties(tds: &Tds<f64, (), (), 3>) {
     let start = Instant::now();
 
     // Count boundary facets - use the trait method
-    let boundary_facets = tds.boundary_facets().unwrap_or_else(|e| {
-        println!("Warning: Failed to get boundary facets: {e}");
-        Vec::new()
-    });
-    let boundary_count = boundary_facets.len();
+    let boundary_facets = match tds.boundary_facets() {
+        Ok(iter) => iter,
+        Err(e) => {
+            println!("Warning: Failed to get boundary facets: {e}");
+            println!("  Boundary facets:     0");
+            println!("  Boundary computation: {:?}", start.elapsed());
+            println!();
+            return;
+        }
+    };
+    let boundary_count = boundary_facets.clone().count();
 
     let boundary_time = start.elapsed();
 
@@ -221,8 +227,8 @@ fn analyze_boundary_properties(tds: &Tds<f64, (), (), 3>) {
 
         // Analyze a few boundary facets
         let sample_size = std::cmp::min(3, boundary_count);
-        for (i, facet) in boundary_facets.iter().take(sample_size).enumerate() {
-            println!("    • Facet {}: key = {}", i + 1, facet.key());
+        for (i, facet) in boundary_facets.take(sample_size).enumerate() {
+            println!("    • Facet {}: key = {:?}", i + 1, facet.key());
         }
 
         if boundary_count > sample_size {
@@ -276,7 +282,10 @@ fn performance_analysis(tds: &Tds<f64, (), (), 3>) {
     let boundary_times: Vec<_> = (0..3)
         .map(|_| {
             let start = Instant::now();
-            let _ = tds.boundary_facets().unwrap_or_default();
+            let _ = tds
+                .boundary_facets()
+                .map(std::iter::Iterator::count)
+                .unwrap_or(0);
             start.elapsed()
         })
         .collect();

--- a/examples/triangulation_3d_50_points.rs
+++ b/examples/triangulation_3d_50_points.rs
@@ -25,6 +25,8 @@
 //! - Boundary analysis
 //! - Performance metrics
 
+#![allow(deprecated)]
+
 use delaunay::geometry::util::generate_random_triangulation;
 use delaunay::prelude::*;
 use num_traits::cast::cast;

--- a/src/core/algorithms/bowyer_watson.rs
+++ b/src/core/algorithms/bowyer_watson.rs
@@ -398,7 +398,8 @@ mod tests {
             eprintln!("  {label} - Boundary: {boundary}, Internal: {internal}, Invalid: {invalid}");
 
             if let Ok(bf) = tds.boundary_facets() {
-                eprintln!("  {} - boundary_facets() reports: {}", label, bf.len());
+                let bf_count = bf.count();
+                eprintln!("  {label} - boundary_facets() reports: {bf_count}");
             } else {
                 eprintln!("  {label} - boundary_facets() failed");
             }
@@ -529,12 +530,11 @@ mod tests {
             eprintln!("\n=== BOUNDARY ANALYSIS ===");
             match tds.boundary_facets() {
                 Ok(bf) => {
-                    eprintln!("Boundary facets found: {}", bf.len());
-                    if bf.len() != boundary_facets {
+                    let bf_count = bf.count();
+                    eprintln!("Boundary facets found: {bf_count}");
+                    if bf_count != boundary_facets {
                         eprintln!(
-                            "❌ MISMATCH: Direct count ({}) vs boundary_facets() ({})",
-                            boundary_facets,
-                            bf.len()
+                            "❌ MISMATCH: Direct count ({boundary_facets}) vs boundary_facets() ({bf_count})"
                         );
                     }
                 }
@@ -678,9 +678,9 @@ mod tests {
 
         // Boundary analysis should work
         let boundary_facets = tds.boundary_facets().expect("Should get boundary facets");
+        let boundary_count = boundary_facets.count();
         assert_eq!(
-            boundary_facets.len(),
-            4,
+            boundary_count, 4,
             "boundary_facets() should return 4 facets"
         );
 

--- a/src/core/algorithms/bowyer_watson.rs
+++ b/src/core/algorithms/bowyer_watson.rs
@@ -126,7 +126,7 @@ where
     T: CoordinateScalar,
     U: DataType,
     V: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     /// Unified statistics tracking
     stats: InsertionStatistics,
@@ -160,7 +160,7 @@ where
     U: DataType + DeserializeOwned,
     V: DataType + DeserializeOwned,
     for<'a> &'a T: Div<T>,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     /// Creates a new incremental Bowyer-Watson algorithm instance
     ///
@@ -225,7 +225,7 @@ where
     U: DataType + DeserializeOwned,
     V: DataType + DeserializeOwned,
     for<'a> &'a T: Div<T>,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     fn default() -> Self {
         Self::new()
@@ -238,7 +238,7 @@ where
     U: DataType + DeserializeOwned,
     V: DataType + DeserializeOwned,
     for<'a> &'a T: Div<T>,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     fn facet_cache(&self) -> &ArcSwapOption<FacetToCellsMap> {
         &self.facet_to_cells_cache
@@ -257,7 +257,7 @@ where
     U: DataType + DeserializeOwned,
     V: DataType + DeserializeOwned,
     for<'a> &'a T: Div<T>,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     /// Insert a single vertex into the triangulation
     fn insert_vertex(
@@ -1150,7 +1150,7 @@ mod tests {
             vertex!([0.0, 0.0, 1.0]),
         ];
 
-        let mut tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::default();
+        let mut tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::empty();
 
         // Test the triangulate method (this is where double counting would occur)
         algorithm.triangulate(&mut tds, &vertices).unwrap();

--- a/src/core/algorithms/robust_bowyer_watson.rs
+++ b/src/core/algorithms/robust_bowyer_watson.rs
@@ -44,7 +44,7 @@ where
     T: CoordinateScalar,
     U: crate::core::traits::data_type::DataType,
     V: crate::core::traits::data_type::DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     /// Configuration for robust predicates
     predicate_config: RobustPredicateConfig<T>,
@@ -70,7 +70,7 @@ where
     f64: From<T>,
     for<'a> &'a T: std::ops::Div<T>,
     ordered_float::OrderedFloat<f64>: From<T>,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
     [f64; D]: Default + DeserializeOwned + Serialize + Sized,
     na::OPoint<T, na::Const<D>>: From<[f64; D]>,
 {
@@ -87,7 +87,7 @@ where
     f64: From<T>,
     for<'a> &'a T: std::ops::Div<T>,
     ordered_float::OrderedFloat<f64>: From<T>,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
     [f64; D]: Default + DeserializeOwned + Serialize + Sized,
     na::OPoint<T, na::Const<D>>: From<[f64; D]>,
 {
@@ -1191,7 +1191,7 @@ where
     V: crate::core::traits::data_type::DataType + DeserializeOwned,
     f64: From<T>,
     for<'a> &'a T: std::ops::Div<T>,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
     ordered_float::OrderedFloat<f64>: From<T>,
 {
     fn facet_cache(&self) -> &ArcSwapOption<FacetToCellsMap> {
@@ -1226,7 +1226,7 @@ where
     f64: From<T>,
     for<'a> &'a T: std::ops::Div<T>,
     ordered_float::OrderedFloat<f64>: From<T>,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
     [f64; D]: Default + DeserializeOwned + Serialize + Sized,
     na::OPoint<T, na::Const<D>>: From<[f64; D]>,
 {
@@ -1314,7 +1314,7 @@ mod tests {
             + num_traits::cast::NumCast,
         U: crate::core::traits::data_type::DataType,
         V: crate::core::traits::data_type::DataType,
-        [T; D]: Copy + Default + serde::de::DeserializeOwned + serde::Serialize + Sized,
+        [T; D]: Copy + DeserializeOwned + Serialize + Sized,
     {
         use crate::core::util::derive_facet_key_from_vertices;
 

--- a/src/core/boundary.rs
+++ b/src/core/boundary.rs
@@ -34,7 +34,7 @@ where
     V: DataType + DeserializeOwned,
     f64: From<T>,
     for<'a> &'a T: Div<T>,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
     ordered_float::OrderedFloat<f64>: From<T>,
 {
     /// Identifies all boundary facets in the triangulation.

--- a/src/core/cell.rs
+++ b/src/core/cell.rs
@@ -198,7 +198,7 @@ fn sorted_vertices<T, U, const D: usize>(vertices: &[Vertex<T, U, D>]) -> Vec<Ve
 where
     T: CoordinateScalar,
     U: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     let mut sorted = vertices.to_vec();
     sorted.sort_by(|a, b| {
@@ -212,7 +212,7 @@ where
 // CELL STRUCT DEFINITION
 // =============================================================================
 
-#[derive(Builder, Clone, Debug, Default, Serialize)]
+#[derive(Builder, Clone, Debug, Serialize)]
 #[builder(build_fn(validate = "Self::validate"))]
 /// The [Cell] struct represents a d-dimensional
 /// [simplex](https://en.wikipedia.org/wiki/Simplex) with vertices, a unique
@@ -238,7 +238,7 @@ where
     T: CoordinateScalar,
     U: DataType,
     V: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     /// The vertices of the cell.
     vertices: Vec<Vertex<T, U, D>>,
@@ -274,7 +274,7 @@ where
     T: CoordinateScalar,
     U: DataType,
     V: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     fn deserialize<De>(deserializer: De) -> Result<Self, De::Error>
     where
@@ -285,7 +285,7 @@ where
             T: CoordinateScalar,
             U: DataType,
             V: DataType,
-            [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+            [T; D]: Copy + DeserializeOwned + Serialize + Sized,
         {
             _phantom: PhantomData<(T, U, V)>,
         }
@@ -295,7 +295,7 @@ where
             T: CoordinateScalar,
             U: DataType,
             V: DataType,
-            [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+            [T; D]: Copy + DeserializeOwned + Serialize + Sized,
         {
             type Value = Cell<T, U, V, D>;
 
@@ -380,7 +380,7 @@ where
     T: CoordinateScalar,
     U: DataType,
     V: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     fn validate(&self) -> Result<(), CellValidationError> {
         let vertices =
@@ -421,7 +421,7 @@ where
     T: CoordinateScalar,
     U: DataType,
     V: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     /// The function returns the number of vertices in the [Cell].
     ///
@@ -947,7 +947,7 @@ where
     T: CoordinateScalar + Clone + PartialEq + PartialOrd,
     U: DataType,
     V: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     /// Returns all facets (faces) of the cell.
     ///
@@ -1066,7 +1066,7 @@ where
     T: CoordinateScalar,
     U: DataType,
     V: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
@@ -1080,7 +1080,7 @@ where
     T: CoordinateScalar,
     U: DataType,
     V: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
@@ -1099,7 +1099,7 @@ where
     T: CoordinateScalar,
     U: DataType,
     V: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
 }
 
@@ -1115,7 +1115,7 @@ where
     T: CoordinateScalar,
     U: DataType,
     V: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
     Vertex<T, U, D>: Hash,
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -1162,7 +1162,7 @@ mod tests {
         T: CoordinateScalar,
         U: DataType,
         V: DataType,
-        [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+        [T; D]: Copy + DeserializeOwned + Serialize + Sized,
     {
         assert_eq!(cell.number_of_vertices(), expected_vertices);
         assert_eq!(cell.dim(), expected_dim);

--- a/src/core/facet.rs
+++ b/src/core/facet.rs
@@ -196,22 +196,28 @@ pub enum FacetError {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```rust,no_run
 /// use delaunay::core::facet::FacetView;
+/// use delaunay::core::triangulation_data_structure::{Tds, CellKey};
 ///
-/// // Create a facet view for the first facet of a cell
-/// let facet_view = FacetView::new(&tds, cell_key, 0)?;
+/// // This is a conceptual example showing FacetView usage
+/// // In practice, tds and cell_key would come from your triangulation
+/// fn example_usage<'a>(tds: &'a Tds<f64, Option<()>, Option<()>, 3>, cell_key: CellKey) -> Result<(), Box<dyn std::error::Error>> {
+///     // Create a facet view for the first facet of a cell
+///     let facet_view = FacetView::new(tds, cell_key, 0)?;
 ///
-/// // Access vertices through the view (lazy evaluation)
-/// for vertex in facet_view.vertices() {
-///     println!("Vertex: {:?}", vertex.point());
+///     // Access vertices through the view (lazy evaluation)
+///     for vertex in facet_view.vertices() {
+///         println!("Vertex: {:?}", vertex.point());
+///     }
+///
+///     // Get the opposite vertex
+///     let opposite = facet_view.opposite_vertex()?;
+///
+///     // Compute facet key
+///     let key = facet_view.key()?;
+///     Ok(())
 /// }
-///
-/// // Get the opposite vertex
-/// let opposite = facet_view.opposite_vertex()?;
-///
-/// // Compute facet key
-/// let key = facet_view.key()?;
 /// ```
 pub struct FacetView<'tds, T, U, V, const D: usize>
 where

--- a/src/core/traits/boundary_analysis.rs
+++ b/src/core/traits/boundary_analysis.rs
@@ -52,7 +52,7 @@ where
     V: DataType + DeserializeOwned,
     f64: From<T>,
     for<'a> &'a T: Div<T>,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
     ordered_float::OrderedFloat<f64>: From<T>,
 {
     /// Identifies all boundary facets in the triangulation.

--- a/src/core/traits/facet_cache.rs
+++ b/src/core/traits/facet_cache.rs
@@ -79,7 +79,7 @@ where
     U: DataType + DeserializeOwned,
     V: DataType + DeserializeOwned,
     for<'a> &'a T: Div<T>,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     /// Returns a reference to the facet cache storage.
     fn facet_cache(&self) -> &ArcSwapOption<FacetToCellsMap>;

--- a/src/core/traits/insertion_algorithm.rs
+++ b/src/core/traits/insertion_algorithm.rs
@@ -385,7 +385,7 @@ where
     T: CoordinateScalar,
     U: crate::core::traits::data_type::DataType,
     V: crate::core::traits::data_type::DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     /// Buffer for storing bad cell keys during cavity detection
     bad_cells_buffer: SmallBuffer<crate::core::triangulation_data_structure::CellKey, 16>,
@@ -402,7 +402,7 @@ where
     T: CoordinateScalar,
     U: crate::core::traits::data_type::DataType,
     V: crate::core::traits::data_type::DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     fn default() -> Self {
         Self::new()
@@ -414,7 +414,7 @@ where
     T: CoordinateScalar,
     U: crate::core::traits::data_type::DataType,
     V: crate::core::traits::data_type::DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     /// Create new empty buffers
     #[must_use]
@@ -594,7 +594,7 @@ where
     T: CoordinateScalar,
     U: crate::core::traits::data_type::DataType,
     V: crate::core::traits::data_type::DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     /// Insert a single vertex into the triangulation
     ///
@@ -752,7 +752,7 @@ where
     fn is_vertex_interior(&self, tds: &Tds<T, U, V, D>, vertex: &Vertex<T, U, D>) -> bool
     where
         T: AddAssign<T> + SubAssign<T> + Sum + NumCast,
-        [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+        [T; D]: Copy + DeserializeOwned + Serialize + Sized,
     {
         use crate::geometry::predicates::{InSphere, insphere};
 
@@ -1201,7 +1201,7 @@ where
     where
         T: AddAssign<T> + SubAssign<T> + Sum + NumCast,
         for<'a> &'a T: Div<T>,
-        [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+        [T; D]: Copy + DeserializeOwned + Serialize + Sized,
     {
         // Default implementation delegates to the static helper method
         Self::is_facet_visible_from_vertex_impl(tds, facet, vertex, adjacent_cell_key)
@@ -1355,7 +1355,7 @@ where
     where
         T: AddAssign<T> + SubAssign<T> + Sum + NumCast,
         for<'a> &'a T: Div<T>,
-        [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+        [T; D]: Copy + DeserializeOwned + Serialize + Sized,
     {
         // Get visible boundary facets
         let visible_facets = self.find_visible_boundary_facets(tds, vertex)?;
@@ -1421,7 +1421,7 @@ where
     where
         T: AddAssign<T> + SubAssign<T> + Sum + NumCast,
         for<'a> &'a T: Div<T>,
-        [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+        [T; D]: Copy + DeserializeOwned + Serialize + Sized,
     {
         // Conservative fallback: try to connect to any existing boundary facet
         // This avoids creating invalid geometry by arbitrary vertex replacement
@@ -1557,7 +1557,7 @@ where
         U: DeserializeOwned,
         V: DeserializeOwned,
         for<'a> &'a T: Div<T>,
-        [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+        [T; D]: Copy + DeserializeOwned + Serialize + Sized,
     {
         if vertices.is_empty() {
             return Ok(());
@@ -1747,7 +1747,7 @@ where
     where
         T: AddAssign<T> + SubAssign<T> + Sum + NumCast,
         for<'a> &'a T: Div<T>,
-        [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+        [T; D]: Copy + DeserializeOwned + Serialize + Sized,
     {
         let mut visible_facets = Vec::new();
 
@@ -1843,7 +1843,7 @@ where
     where
         T: AddAssign<T> + SubAssign<T> + Sum + NumCast,
         for<'a> &'a T: Div<T>,
-        [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+        [T; D]: Copy + DeserializeOwned + Serialize + Sized,
     {
         // Get the adjacent cell to this boundary facet
         let Some(adjacent_cell) = tds.cells().get(adjacent_cell_key) else {
@@ -1977,7 +1977,7 @@ where
         U: DeserializeOwned,
         V: DeserializeOwned,
         for<'a> &'a T: Div<T>,
-        [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+        [T; D]: Copy + DeserializeOwned + Serialize + Sized,
     {
         // Default implementation: use the regular Tds::new constructor
         Tds::new(vertices)
@@ -2707,7 +2707,7 @@ mod tests {
         println!("Testing find_bad_cells error cases");
 
         // Create an empty triangulation to test NoCells error
-        let empty_tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::default();
+        let empty_tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::empty();
         let mut algorithm = IncrementalBowyerWatson::new();
         let vertex = vertex!([0.25, 0.25, 0.25]);
 
@@ -3519,7 +3519,7 @@ mod tests {
         println!("Testing InsertionStrategy determination edge cases");
 
         // Test with empty TDS
-        let empty_tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::default();
+        let empty_tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::empty();
         let test_vertex = vertex!([1.0, 1.0, 1.0]);
 
         let strategy =
@@ -3733,7 +3733,7 @@ mod tests {
         println!("Testing insertion strategies with potentially corrupted TDS");
 
         // Create an empty TDS to simulate corruption scenarios
-        let mut empty_tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::default();
+        let mut empty_tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::empty();
         let mut algorithm = IncrementalBowyerWatson::new();
         let test_vertex = vertex!([1.0, 1.0, 1.0]);
 
@@ -3808,7 +3808,7 @@ mod tests {
             vertex!([0.0, 1.0, 0.0]),
             // Missing one vertex for 3D (need D+1 = 4)
         ];
-        let mut empty_tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::default();
+        let mut empty_tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::empty();
         let result = algorithm.triangulate(&mut empty_tds, &insufficient_vertices);
 
         match result {
@@ -3830,7 +3830,7 @@ mod tests {
             vertex!([0.0, 0.0, 1.0]),
             vertex!([1.0, 1.0, 1.0]), // Additional vertex for testing incremental insertion
         ];
-        let mut tds = Tds::default();
+        let mut tds = Tds::empty();
         let result = algorithm.triangulate(&mut tds, &sufficient_vertices);
 
         match result {
@@ -3851,7 +3851,7 @@ mod tests {
 
         // Test triangulate with empty vertex list
         let empty_vertices = vec![];
-        let mut empty_tds = Tds::default();
+        let mut empty_tds = Tds::empty();
         let result = algorithm.triangulate(&mut empty_tds, &empty_vertices);
         assert!(
             result.is_ok(),
@@ -3868,7 +3868,7 @@ mod tests {
         println!("Testing create_initial_simplex edge cases");
 
         // Test with wrong number of vertices
-        let mut tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::default();
+        let mut tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::empty();
 
         // Too few vertices
         let too_few_vertices = vec![
@@ -3968,7 +3968,7 @@ mod tests {
         println!("  ✓ Finalization succeeded on valid TDS");
 
         // Test finalization on empty TDS (should handle gracefully)
-        let mut empty_tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::default();
+        let mut empty_tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::empty();
         let result =
             IncrementalBowyerWatson::<f64, Option<()>, Option<()>, 3>::finalize_triangulation(
                 &mut empty_tds,
@@ -3992,7 +3992,7 @@ mod tests {
         println!("Testing utility methods error handling");
 
         // Test ensure_vertex_in_tds
-        let mut tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::default();
+        let mut tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::empty();
         let test_vertex = vertex!([1.0, 1.0, 1.0]);
 
         // Test successful vertex insertion
@@ -4104,7 +4104,7 @@ mod tests {
         println!("  ✓ finalize_after_insertion succeeded on valid TDS");
 
         // Test with empty TDS (should handle gracefully)
-        let mut empty_tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::default();
+        let mut empty_tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::empty();
         let result =
             IncrementalBowyerWatson::<f64, Option<()>, Option<()>, 3>::finalize_after_insertion(
                 &mut empty_tds,
@@ -4182,7 +4182,7 @@ mod tests {
         let algorithm = IncrementalBowyerWatson::new();
 
         // Test find_visible_boundary_facets with empty TDS
-        let empty_tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::default();
+        let empty_tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::empty();
         let test_vertex = vertex!([1.0, 1.0, 1.0]);
 
         let result = algorithm.find_visible_boundary_facets(&empty_tds, &test_vertex);
@@ -4373,7 +4373,7 @@ mod tests {
         let mut algorithm = IncrementalBowyerWatson::new();
 
         // Test NoCells error with empty TDS
-        let empty_tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::default();
+        let empty_tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::empty();
         let test_vertex = vertex!([1.0, 1.0, 1.0]);
 
         let result = algorithm.find_bad_cells(&empty_tds, &test_vertex);

--- a/src/core/triangulation_data_structure.rs
+++ b/src/core/triangulation_data_structure.rs
@@ -7420,7 +7420,7 @@ mod tests {
         // All 4 facets of the tetrahedron should be on the boundary
         let boundary_facets = tds.boundary_facets().expect("Should get boundary facets");
         assert_eq!(
-            boundary_facets.len(),
+            boundary_facets.clone().count(),
             4,
             "A single tetrahedron should have 4 boundary facets"
         );
@@ -7465,15 +7465,15 @@ mod tests {
         // Get all boundary facets
         let boundary_facets = tds.boundary_facets().expect("Should get boundary facets");
         assert_eq!(
-            boundary_facets.len(),
+            boundary_facets.clone().count(),
             6,
             "Two adjacent tetrahedra should have 6 boundary facets"
         );
 
         // Test that all facets from boundary_facets() are indeed boundary facets
-        for boundary_facet in &boundary_facets {
+        for boundary_facet in boundary_facets {
             assert!(
-                tds.is_boundary_facet(boundary_facet)
+                tds.is_boundary_facet(&boundary_facet)
                     .expect("Should not fail to check boundary facet"),
                 "All facets from boundary_facets() should be boundary facets"
             );

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -141,7 +141,7 @@ where
     T: CoordinateScalar,
     U: DataType,
     V: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     use crate::core::collections::FastHashSet;
     let vertices1: FastHashSet<_> = facet1.vertices().into_iter().collect();
@@ -193,7 +193,7 @@ pub fn generate_combinations<T, U, const D: usize>(
 where
     T: CoordinateScalar,
     U: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     let mut combinations = Vec::new();
 
@@ -374,7 +374,7 @@ where
     T: crate::geometry::traits::coordinate::CoordinateScalar,
     U: crate::core::traits::data_type::DataType,
     V: crate::core::traits::data_type::DataType,
-    [T; D]: Copy + Default + serde::de::DeserializeOwned + serde::Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     use crate::core::collections::SmallBuffer;
     use crate::core::facet::{FacetError, facet_key_from_vertex_keys};

--- a/src/core/vertex.rs
+++ b/src/core/vertex.rs
@@ -139,7 +139,7 @@ pub use crate::vertex;
 // VERTEX STRUCT DEFINITION
 // =============================================================================
 
-#[derive(Builder, Clone, Copy, Debug, Default, Serialize)]
+#[derive(Builder, Clone, Copy, Debug, Serialize)]
 /// The `Vertex` struct represents a vertex in a triangulation with geometric
 /// coordinates, unique identification, and optional metadata.
 ///
@@ -176,7 +176,7 @@ pub struct Vertex<T, U, const D: usize>
 where
     T: CoordinateScalar,
     U: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     /// The coordinates of the vertex as a D-dimensional Point.
     point: Point<T, D>,
@@ -203,7 +203,7 @@ impl<'de, T, U, const D: usize> Deserialize<'de> for Vertex<T, U, D>
 where
     T: CoordinateScalar,
     U: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     fn deserialize<De>(deserializer: De) -> Result<Self, De::Error>
     where
@@ -213,7 +213,7 @@ where
         where
             T: CoordinateScalar,
             U: DataType,
-            [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+            [T; D]: Copy + DeserializeOwned + Serialize + Sized,
         {
             _phantom: PhantomData<(T, U)>,
         }
@@ -222,7 +222,7 @@ where
         where
             T: CoordinateScalar,
             U: DataType,
-            [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+            [T; D]: Copy + DeserializeOwned + Serialize + Sized,
         {
             type Value = Vertex<T, U, D>;
 
@@ -311,8 +311,45 @@ impl<T, U, const D: usize> Vertex<T, U, D>
 where
     T: CoordinateScalar,
     U: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
+    /// Creates an empty vertex at the origin with nil UUID and default data.
+    ///
+    /// This method creates a vertex with coordinates all set to `T::default()` (typically zero),
+    /// a nil UUID, and default data. This is useful for creating placeholder vertices or
+    /// for testing purposes.
+    ///
+    /// Note: A vertex created with `empty()` will fail validation due to the nil UUID.
+    /// Use the `vertex!` macro or `new()` constructor for creating valid vertices.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use delaunay::core::vertex::Vertex;
+    /// use approx::assert_relative_eq;
+    ///
+    /// let empty_vertex: Vertex<f64, Option<()>, 3> = Vertex::empty();
+    /// assert_relative_eq!(
+    ///     empty_vertex.point().to_array().as_slice(),
+    ///     [0.0, 0.0, 0.0].as_slice(),
+    ///     epsilon = 1e-9
+    /// );
+    /// assert!(empty_vertex.uuid().is_nil());
+    /// assert!(empty_vertex.data.is_none());
+    /// ```
+    #[must_use]
+    pub fn empty() -> Self
+    where
+        T: Default,
+    {
+        Self {
+            point: Point::default(),
+            uuid: Uuid::nil(),
+            incident_cell: None,
+            data: None,
+        }
+    }
+
     /// The function `from_points` takes a vector of points and returns a
     /// vector of vertices, using the `new` method.
     ///
@@ -529,8 +566,8 @@ where
     /// let vertex: Vertex<f64, Option<()>, 3> = vertex!([1.0, 2.0, 3.0]);
     /// assert!(vertex.is_valid().is_ok());
     ///
-    /// // Test with default vertex (which has nil UUID) to show validation
-    /// let default_vertex: Vertex<f64, Option<()>, 3> = Vertex::default();
+    /// // Test with empty vertex (which has nil UUID) to show validation
+    /// let default_vertex: Vertex<f64, Option<()>, 3> = Vertex::empty();
     /// match default_vertex.is_valid() {
     ///     Err(VertexValidationError::InvalidUuid { .. }) => (), // Expected - nil UUID
     ///     other => panic!("Expected InvalidUuid error, got: {:?}", other),
@@ -562,7 +599,7 @@ impl<T, U, const D: usize> PartialEq for Vertex<T, U, D>
 where
     T: CoordinateScalar,
     U: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     /// Equality of vertices is based on ordered equality of coordinates using the Coordinate trait.
     #[inline]
@@ -578,7 +615,7 @@ impl<T, U, const D: usize> PartialOrd for Vertex<T, U, D>
 where
     T: CoordinateScalar,
     U: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     /// Order of vertices is based on lexicographic order of coordinates using Point's `partial_cmp`.
     /// This ensures consistent ordering with special floating-point values (NaN, infinity)
@@ -595,7 +632,7 @@ impl<T, U, const D: usize> From<Vertex<T, U, D>> for [T; D]
 where
     T: CoordinateScalar,
     U: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     #[inline]
     fn from(vertex: Vertex<T, U, D>) -> [T; D] {
@@ -609,7 +646,7 @@ impl<T, U, const D: usize> From<&Vertex<T, U, D>> for [T; D]
 where
     T: CoordinateScalar,
     U: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     #[inline]
     fn from(vertex: &Vertex<T, U, D>) -> [T; D] {
@@ -623,7 +660,7 @@ impl<T, U, const D: usize> From<&Vertex<T, U, D>> for Point<T, D>
 where
     T: CoordinateScalar,
     U: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     #[inline]
     fn from(vertex: &Vertex<T, U, D>) -> Self {
@@ -638,7 +675,7 @@ impl<T, U, const D: usize> Eq for Vertex<T, U, D>
 where
     T: CoordinateScalar,
     U: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     // Generic Eq implementation for Vertex based on point equality
 }
@@ -647,7 +684,7 @@ impl<T, U, const D: usize> Hash for Vertex<T, U, D>
 where
     T: CoordinateScalar,
     U: DataType,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
     Point<T, D>: Hash,
 {
     /// Hash implementation for Vertex using only coordinates for consistency with `PartialEq`.
@@ -688,12 +725,18 @@ mod tests {
         Corner = 3,
     }
 
+    impl From<PointType> for u8 {
+        fn from(point_type: PointType) -> Self {
+            point_type as Self
+        }
+    }
+
     impl Serialize for PointType {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: serde::Serializer,
         {
-            serializer.serialize_u8(*self as u8)
+            serializer.serialize_u8(u8::from(*self))
         }
     }
 
@@ -726,7 +769,7 @@ mod tests {
     ) where
         T: CoordinateScalar,
         U: DataType,
-        [T; D]: Copy + Default + serde::de::DeserializeOwned + serde::Serialize + Sized,
+        [T; D]: Copy + DeserializeOwned + Serialize + Sized,
     {
         assert_eq!(vertex.point().to_array(), expected_coords);
         assert_eq!(vertex.dim(), D);
@@ -774,12 +817,40 @@ mod tests {
     }
 
     // =============================================================================
+    // POINTTYPE CONVERSION TESTS
+    // =============================================================================
+
+    #[test]
+    fn test_pointtype_u8_conversion() {
+        // Test u8::from conversion for each PointType variant
+        assert_eq!(u8::from(PointType::Origin), 0);
+        assert_eq!(u8::from(PointType::Boundary), 1);
+        assert_eq!(u8::from(PointType::Interior), 2);
+        assert_eq!(u8::from(PointType::Corner), 3);
+
+        // Test serialization uses the From trait correctly
+        let origin_json = serde_json::to_string(&PointType::Origin).unwrap();
+        assert_eq!(origin_json, "0");
+
+        let corner_json = serde_json::to_string(&PointType::Corner).unwrap();
+        assert_eq!(corner_json, "3");
+
+        // Test round-trip serialization/deserialization
+        let original = PointType::Boundary;
+        let serialized = serde_json::to_string(&original).unwrap();
+        let deserialized: PointType = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(original, deserialized);
+
+        println!("✓ PointType u8::from conversion works correctly");
+    }
+
+    // =============================================================================
     // BASIC VERTEX FUNCTIONALITY
     // =============================================================================
 
     #[test]
-    fn vertex_default() {
-        let vertex: Vertex<f64, Option<()>, 3> = Vertex::default();
+    fn vertex_empty() {
+        let vertex: Vertex<f64, Option<()>, 3> = Vertex::empty();
 
         assert_relative_eq!(
             vertex.point().to_array().as_slice(),
@@ -1579,8 +1650,8 @@ mod tests {
         assert!(valid_vertex.is_valid().is_ok());
         assert!(!valid_vertex.uuid().is_nil());
 
-        // Test that default vertex (which has nil UUID) is invalid
-        let default_vertex: Vertex<f64, Option<()>, 3> = Vertex::default();
+        // Test that empty vertex (which has nil UUID) is invalid
+        let default_vertex: Vertex<f64, Option<()>, 3> = Vertex::empty();
         match default_vertex.is_valid() {
             Err(VertexValidationError::InvalidUuid { source: _ }) => (), // Expected
             other => panic!("Expected InvalidUuid error, got: {other:?}"),

--- a/src/core/vertex.rs
+++ b/src/core/vertex.rs
@@ -326,6 +326,7 @@ where
     ///
     /// ```
     /// use delaunay::core::vertex::Vertex;
+    /// use delaunay::geometry::traits::coordinate::Coordinate;
     /// use approx::assert_relative_eq;
     ///
     /// let empty_vertex: Vertex<f64, Option<()>, 3> = Vertex::empty();

--- a/src/geometry/algorithms/convex_hull.rs
+++ b/src/geometry/algorithms/convex_hull.rs
@@ -172,7 +172,7 @@ where
     T: CoordinateScalar,
     U: DataType,
     V: DataType,
-    [T; D]: Copy + Default + Sized + Serialize + DeserializeOwned,
+    [T; D]: Copy + Sized + Serialize + DeserializeOwned,
 {
     /// The boundary facets that form the convex hull
     pub hull_facets: Vec<Facet<T, U, V, D>>,
@@ -203,7 +203,7 @@ where
         + From<f64>,
     U: DataType,
     V: DataType,
-    [T; D]: Copy + Default + Sized + Serialize + DeserializeOwned,
+    [T; D]: Copy + Sized + Serialize + DeserializeOwned,
     f64: From<T>,
     for<'a> &'a T: std::ops::Div<T>,
     OrderedFloat<f64>: From<T>,
@@ -1149,7 +1149,7 @@ where
     U: DataType + DeserializeOwned,
     V: DataType + DeserializeOwned,
     for<'a> &'a T: Div<T>,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     fn facet_cache(&self) -> &ArcSwapOption<FacetToCellsMap> {
         &self.facet_to_cells_cache
@@ -1165,7 +1165,7 @@ where
     T: CoordinateScalar,
     U: DataType,
     V: DataType,
-    [T; D]: Copy + Default + Sized + Serialize + DeserializeOwned,
+    [T; D]: Copy + Sized + Serialize + DeserializeOwned,
 {
     fn default() -> Self {
         Self {
@@ -2487,7 +2487,7 @@ mod tests {
     #[test]
     fn test_from_triangulation_empty_vertices_error() {
         // Test error path when triangulation has no vertices
-        let empty_tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::default();
+        let empty_tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::empty();
         let result = ConvexHull::from_triangulation(&empty_tds);
 
         assert!(result.is_err());
@@ -2502,7 +2502,7 @@ mod tests {
     #[test]
     fn test_from_triangulation_no_cells_error() {
         // Create a TDS with vertices but no cells (manually constructed)
-        let mut tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::default();
+        let mut tds: Tds<f64, Option<()>, Option<()>, 3> = Tds::empty();
         let vertex = vertex!([0.0, 0.0, 0.0]);
         let _ = tds.insert_vertex_with_mapping(vertex);
 

--- a/src/geometry/robust_predicates.rs
+++ b/src/geometry/robust_predicates.rs
@@ -155,7 +155,7 @@ pub fn robust_insphere<T, const D: usize>(
 ) -> Result<InSphere, CoordinateConversionError>
 where
     T: CoordinateScalar + std::iter::Sum + num_traits::Zero,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     if simplex_points.len() != D + 1 {
         return Err(CoordinateConversionError::ConversionFailed {
@@ -205,7 +205,7 @@ fn adaptive_tolerance_insphere<T, const D: usize>(
 ) -> Result<InSphere, CoordinateConversionError>
 where
     T: CoordinateScalar,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     // Build the insphere determinant matrix
     let matrix = build_insphere_matrix(simplex_points, test_point)?;
@@ -240,7 +240,7 @@ fn conditioned_insphere<T, const D: usize>(
 ) -> Result<InSphere, CoordinateConversionError>
 where
     T: CoordinateScalar,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     // Build matrix and apply conditioning
     let matrix = build_insphere_matrix(simplex_points, test_point)?;
@@ -269,7 +269,7 @@ fn symbolic_perturbation_insphere<T, const D: usize>(
 ) -> InSphere
 where
     T: CoordinateScalar + std::iter::Sum + num_traits::Zero,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     // Try with small perturbations in different directions
     let perturbation_directions = generate_perturbation_directions::<T, D>();
@@ -301,7 +301,7 @@ pub fn robust_orientation<T, const D: usize>(
 ) -> Result<Orientation, CoordinateConversionError>
 where
     T: CoordinateScalar,
-    [T; D]: Copy + Default + Sized,
+    [T; D]: Copy + Sized,
 {
     if simplex_points.len() != D + 1 {
         return Err(CoordinateConversionError::ConversionFailed {
@@ -342,7 +342,7 @@ fn build_insphere_matrix<T, const D: usize>(
 ) -> Result<na::DMatrix<f64>, CoordinateConversionError>
 where
     T: CoordinateScalar,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     use na::DMatrix;
 
@@ -389,7 +389,7 @@ fn build_orientation_matrix<T, const D: usize>(
 ) -> Result<na::DMatrix<f64>, CoordinateConversionError>
 where
     T: CoordinateScalar,
-    [T; D]: Copy + Default + Sized,
+    [T; D]: Copy + Sized,
 {
     use na::DMatrix;
 
@@ -520,7 +520,7 @@ fn verify_insphere_consistency<T, const D: usize>(
 ) -> ConsistencyResult
 where
     T: CoordinateScalar + std::iter::Sum + num_traits::Zero,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     // Use the existing distance-based insphere test for verification
     super::predicates::insphere_distance(simplex_points, *test_point).map_or(ConsistencyResult::Unverifiable, |distance_result| match (determinant_result, distance_result) {
@@ -581,7 +581,7 @@ fn apply_perturbation<T, const D: usize>(
 ) -> Point<T, D>
 where
     T: CoordinateScalar,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     let mut coords: [T; D] = (*point).into();
 
@@ -607,7 +607,7 @@ fn geometric_deterministic_tie_breaking<T, const D: usize>(
 ) -> InSphere
 where
     T: CoordinateScalar + std::iter::Sum + num_traits::Zero,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     // Implement Simulation of Simplicity for insphere predicate
     // We assign symbolic indices: simplex points get indices 0..D, test point gets D+1
@@ -666,7 +666,7 @@ fn centroid_based_tie_breaking<T, const D: usize>(
 ) -> InSphere
 where
     T: CoordinateScalar + std::iter::Sum + num_traits::Zero,
-    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     // Calculate simplex centroid
     let mut centroid_coords = [T::zero(); D];

--- a/src/geometry/util.rs
+++ b/src/geometry/util.rs
@@ -9,6 +9,7 @@ use peroxide::fuga::{LinearAlgebra, MatrixTrait, zeros};
 use peroxide::statistics::ops::factorial;
 use rand::Rng;
 use rand::distr::uniform::SampleUniform;
+use serde::{Serialize, de::DeserializeOwned};
 use std::iter::Sum;
 
 use crate::core::traits::data_type::DataType;
@@ -1159,7 +1160,7 @@ where
     T: CoordinateScalar + Sum + Zero,
     U: crate::core::traits::data_type::DataType,
     V: crate::core::traits::data_type::DataType,
-    [T; D]: Copy + Default + serde::de::DeserializeOwned + serde::Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     let mut total_measure = T::zero();
 
@@ -1682,7 +1683,7 @@ where
     U: DataType,
     V: DataType,
     for<'a> &'a T: std::ops::Div<T>,
-    [T; D]: Copy + Default + serde::de::DeserializeOwned + serde::Serialize + Sized,
+    [T; D]: Copy + DeserializeOwned + Serialize + Sized,
 {
     // Generate random points (seeded or unseeded)
     let points: Vec<Point<T, D>> = match seed {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,8 @@
 
 // Allow multiple crate versions due to transitive dependencies
 #![allow(clippy::multiple_crate_versions)]
+// Temporarily allow deprecated warnings during Facet -> FacetView migration
+#![allow(deprecated)]
 // Forbid unsafe code throughout the entire crate
 #![forbid(unsafe_code)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! use delaunay::vertex;
 //!
 //! // Create a 4D triangulation (4-dimensional space!)
-//! let mut tds: Tds<f64, Option<()>, Option<()>, 4> = Tds::default();
+//! let mut tds: Tds<f64, Option<()>, Option<()>, 4> = Tds::empty();
 //!
 //! // Add vertices incrementally - triangulation evolves automatically
 //! tds.add(vertex!([0.0, 0.0, 0.0, 0.0])).unwrap();  // 1 vertex, 0 cells

--- a/tests/allocation_api.rs
+++ b/tests/allocation_api.rs
@@ -87,7 +87,7 @@ pub mod test_helpers {
     #[must_use]
     pub fn create_test_tds() -> Tds<f64, Option<()>, Option<()>, 4> {
         // Create an empty TDS with no vertices
-        Tds::default()
+        Tds::empty()
     }
 
     /// Create a triangulation with some test vertices


### PR DESCRIPTION
This pull request refactors how boundary facets are handled and counted throughout the codebase, moving away from deprecated collection-based APIs in favor of iterator-based approaches. It also removes unnecessary trait bounds, replaces uses of `.len()` and `.is_empty()` with `.count()`, and updates test and example code for compatibility with these changes.

**FacetView replacement of Facet**

We have a new lightweight FacetView struct based on CellKeys and VertexKeys that is 18x smaller in memory and uses iterators for better performance.

**Boundary Facet API Refactoring**

* Replaces deprecated `.len()`/`.is_empty()` methods on boundary facet collections with `.count()` on iterators in both core logic and tests, ensuring compatibility with the new iterator-based API (`src/core/algorithms/bowyer_watson.rs`, `src/core/algorithms/robust_bowyer_watson.rs`, `examples/triangulation_3d_50_points.rs`) [[1]](diffhunk://#diff-74aaca0478b039734c68f0abb205d552270ba550f48e69b1afc436e941cf9f5eL206-R218) [[2]](diffhunk://#diff-5ea174b187a14dcd7b3ed1158eac2a18c3bbb94ff84121e8d1c2daac23cca81dL401-R402) [[3]](diffhunk://#diff-5ea174b187a14dcd7b3ed1158eac2a18c3bbb94ff84121e8d1c2daac23cca81dL532-R537) [[4]](diffhunk://#diff-5ea174b187a14dcd7b3ed1158eac2a18c3bbb94ff84121e8d1c2daac23cca81dR681-R683) [[5]](diffhunk://#diff-46c54f0f46a8c4f3f0005e76031a57cee136797a886ed58e3254da0965ba9259L1517-R1521) [[6]](diffhunk://#diff-46c54f0f46a8c4f3f0005e76031a57cee136797a886ed58e3254da0965ba9259L1547-R1556) [[7]](diffhunk://#diff-46c54f0f46a8c4f3f0005e76031a57cee136797a886ed58e3254da0965ba9259L1707-R1716) [[8]](diffhunk://#diff-46c54f0f46a8c4f3f0005e76031a57cee136797a886ed58e3254da0965ba9259L1762-R1766) [[9]](diffhunk://#diff-46c54f0f46a8c4f3f0005e76031a57cee136797a886ed58e3254da0965ba9259L1860-R1873).
* Updates test code to collect boundary facet iterators into vectors where necessary for backward compatibility, especially when passing to legacy validation and visibility methods (`src/core/algorithms/robust_bowyer_watson.rs`) [[1]](diffhunk://#diff-46c54f0f46a8c4f3f0005e76031a57cee136797a886ed58e3254da0965ba9259L3125-R3139) [[2]](diffhunk://#diff-46c54f0f46a8c4f3f0005e76031a57cee136797a886ed58e3254da0965ba9259L3184-R3205) [[3]](diffhunk://#diff-46c54f0f46a8c4f3f0005e76031a57cee136797a886ed58e3254da0965ba9259R3216-R3223) [[4]](diffhunk://#diff-46c54f0f46a8c4f3f0005e76031a57cee136797a886ed58e3254da0965ba9259L3231-R3257).

**Trait Bound Simplification**

* Removes unnecessary `Default` trait bounds from `[T; D]` in generic constraints throughout Bowyer-Watson and Robust Bowyer-Watson implementations, simplifying type requirements (`src/core/algorithms/bowyer_watson.rs`, `src/core/algorithms/robust_bowyer_watson.rs`) [[1]](diffhunk://#diff-5ea174b187a14dcd7b3ed1158eac2a18c3bbb94ff84121e8d1c2daac23cca81dL129-R129) [[2]](diffhunk://#diff-5ea174b187a14dcd7b3ed1158eac2a18c3bbb94ff84121e8d1c2daac23cca81dL163-R163) [[3]](diffhunk://#diff-5ea174b187a14dcd7b3ed1158eac2a18c3bbb94ff84121e8d1c2daac23cca81dL228-R228) [[4]](diffhunk://#diff-5ea174b187a14dcd7b3ed1158eac2a18c3bbb94ff84121e8d1c2daac23cca81dL241-R241) [[5]](diffhunk://#diff-5ea174b187a14dcd7b3ed1158eac2a18c3bbb94ff84121e8d1c2daac23cca81dL260-R260) [[6]](diffhunk://#diff-46c54f0f46a8c4f3f0005e76031a57cee136797a886ed58e3254da0965ba9259L47-R47) [[7]](diffhunk://#diff-46c54f0f46a8c4f3f0005e76031a57cee136797a886ed58e3254da0965ba9259L73-R73) [[8]](diffhunk://#diff-46c54f0f46a8c4f3f0005e76031a57cee136797a886ed58e3254da0965ba9259L90-R90) [[9]](diffhunk://#diff-46c54f0f46a8c4f3f0005e76031a57cee136797a886ed58e3254da0965ba9259L1194-R1194) [[10]](diffhunk://#diff-46c54f0f46a8c4f3f0005e76031a57cee136797a886ed58e3254da0965ba9259L1229-R1229) [[11]](diffhunk://#diff-46c54f0f46a8c4f3f0005e76031a57cee136797a886ed58e3254da0965ba9259L1317-R1317).

**Test and Example Code Updates**

* Updates example files to allow deprecated warnings, and refactors boundary facet analysis to use iterators and handle errors gracefully (`examples/convex_hull_3d_50_points.rs`, `examples/triangulation_3d_50_points.rs`) [[1]](diffhunk://#diff-91a017c0717a51a44023e2aa5fcc71fb1452d00d889093e96feedb1f8832a5ccR31-R32) [[2]](diffhunk://#diff-74aaca0478b039734c68f0abb205d552270ba550f48e69b1afc436e941cf9f5eR28-R29) [[3]](diffhunk://#diff-74aaca0478b039734c68f0abb205d552270ba550f48e69b1afc436e941cf9f5eL206-R218) [[4]](diffhunk://#diff-74aaca0478b039734c68f0abb205d552270ba550f48e69b1afc436e941cf9f5eL224-R233) [[5]](diffhunk://#diff-74aaca0478b039734c68f0abb205d552270ba550f48e69b1afc436e941cf9f5eL279-R290).
* Replaces `Tds::default()` with `Tds::empty()` in test initialization for clarity and compatibility (`src/core/algorithms/bowyer_watson.rs`).

**Performance and Error Handling Improvements**

* Refactors performance analysis and boundary property functions to use iterator-based counting and to handle errors without panicking, improving robustness in example and test code (`examples/triangulation_3d_50_points.rs`) [[1]](diffhunk://#diff-74aaca0478b039734c68f0abb205d552270ba550f48e69b1afc436e941cf9f5eL206-R218) [[2]](diffhunk://#diff-74aaca0478b039734c68f0abb205d552270ba550f48e69b1afc436e941cf9f5eL279-R290).

Let me know if you have questions about how these changes affect boundary facet handling or test compatibility!