### PR TITLE
feat(tooling)!: automate transactional release preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![DOI](https://badgen.net/badge/DOI/10.5281%2Fzenodo.16931097/blue)](https://doi.org/10.5281/zenodo.16931097)
 [![Crates.io](https://badgen.net/crates/v/delaunay)](https://crates.io/crates/delaunay)
 [![Downloads](https://badgen.net/crates/d/delaunay)](https://crates.io/crates/delaunay)
-[![License](https://badgen.net/github/license/acgetchell/delaunay)](https://github.com/acgetchell/delaunay/blob/main/LICENSE)
+[![License](https://badgen.net/github/license/acgetchell/delaunay)](https://github.com/acgetchell/delaunay/blob/v0.8.0/LICENSE)
 [![Docs.rs](https://docs.rs/delaunay/badge.svg)](https://docs.rs/delaunay)
 [![CI][ci-badge]][ci-workflow]
 [![CodeQL][codeql-badge]][codeql-workflow]
@@ -332,6 +332,16 @@ just bench-perf-summary
 See [`benches/README.md`](benches/README.md) for benchmark selection, fixture sizes, release baselines,
 and large-scale profiling guidance.
 
+Release PRs publish a compact group-level snapshot from the validated retained
+CSV/provenance bundle. The geometric-mean ratios are descriptive summaries;
+the full report retains every benchmark and confidence interval.
+
+<!-- PERFORMANCE_RELEASE_TABLE:BEGIN -->
+
+No retained release-comparison bundle has been published to the README yet.
+
+<!-- PERFORMANCE_RELEASE_TABLE:END -->
+
 ## 🛣️ Limitations and Roadmap
 
 Current routine construction coverage targets 2D through 5D. Exact orientation, relative in-sphere,
@@ -414,7 +424,7 @@ section of [REFERENCES.md](REFERENCES.md).
 
 ## 📜 License
 
-This project is licensed under the [BSD 3-Clause License](https://github.com/acgetchell/delaunay/blob/main/LICENSE).
+This project is licensed under the [BSD 3-Clause License](https://github.com/acgetchell/delaunay/blob/v0.8.0/LICENSE).
 
 ---
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -48,8 +48,9 @@ Common maintainer flows:
 - Before pushing performance-sensitive Rust or benchmark changes: run
   `just perf-large-scale-smoke`, then `just perf-no-regressions` when the work
   is PR-ready.
-- During release PR preparation: run `just performance-release` to update
-  `docs/PERFORMANCE.md` and archive the previous curated report.
+- During release PR preparation: run `just performance-release`, then
+  `just performance-readme`, to update the curated report, archive its
+  predecessor, and publish the matching README snapshot.
 - After a GitHub Release publishes: confirm the release benchmark workflow
   attached `delaunay-vX.Y.Z-criterion-baseline.tar.gz`; use
   `just performance-github-assets 'current-tag' 'baseline-tag'` when you need a
@@ -84,15 +85,20 @@ published release assets, or retained inputs:
   only the documentation promotion. It runs no Cargo benchmarks or measurement
   worktrees and rejects incomplete, invalid, stale, same-version, or
   scientifically non-comparable inputs.
+- `just performance-readme` validates the retained promoted bundle, then
+  atomically publishes a compact README table and the canonical README-owned
+  CSV/provenance pair. It runs no benchmarks.
 
 Promotion uses per-file atomic replacement and rolls back caught failures. A
-hard process or machine interruption can stop between replacements; inspect
-`docs/PERFORMANCE.md`, `docs/archive/performance/`, and its `data/` directory,
-then rerun the idempotent command.
+hard process or machine interruption can stop between replacements. Inspect
+`docs/PERFORMANCE.md`, `docs/archive/performance/` and its `data/` directory,
+`README.md`, and `docs/assets/bench/`, then rerun the owning idempotent command:
+`just performance-doc` or `just performance-readme` for an already-retained
+bundle.
 
-The `perf-local`, `perf-github-assets`, and `perf-release` names remain thin
-compatibility aliases; new documentation and automation use the canonical
-names.
+Exact-renaming `perf-*` compatibility aliases are intentionally absent. The
+remaining `perf-*` recipes are Delaunay-specific regression, stress, and
+profiling workflows with distinct semantics.
 
 Use explicit tag pairs only for release repair or regeneration. Both tags are
 required together; a partial pair fails before fetching or benchmarking:
@@ -121,6 +127,8 @@ Artifact ownership is deliberately narrow:
 | `docs/PERFORMANCE.md` | Yes | `performance-release`, `performance-doc` | Latest curated distinct-release report |
 | `docs/archive/performance/` | Yes | `performance-release`, `performance-doc` | Older curated distinct-release reports |
 | `docs/archive/performance/data/` | Yes | `performance-release`, `performance-doc` | Exact CSV/provenance evidence for each new promoted report |
+| `README.md` | Yes | `performance-readme` | Compact snapshot of the latest retained and promoted comparison |
+| `docs/assets/bench/release-performance.*` | Yes | `performance-readme` | Exact README-owned CSV/provenance snapshot |
 | `delaunay-vX.Y.Z-criterion-baseline.tar.gz` | Release asset | release benchmark workflow | Raw Criterion data and versioned measurement metadata |
 
 CSV, not Parquet, is canonical for the retained comparison because this dataset
@@ -190,6 +198,7 @@ allocation checks, or targeted diagnostics.
 | Compare current tree against latest published release locally | `just performance-local` |
 | Compare stored GitHub Release benchmark assets | `just performance-github-assets [current-tag baseline-tag]` |
 | Measure, retain, validate, and promote release docs | `just performance-release [current-tag baseline-tag]` |
+| Publish the retained comparison snapshot to the README | `just performance-readme` |
 | Promote docs from a retained CSV/provenance pair | `just performance-doc` |
 | Allocation-contract microbenchmarks | `just bench-allocations` |
 | Persist/update the default local baseline artifact | `just perf-baseline` |
@@ -331,6 +340,7 @@ Use the `performance-*` family for retained release-to-release reports:
 just performance-local
 just performance-github-assets
 just performance-release
+just performance-readme
 just performance-doc
 just performance-release "$TAG" "$PREVIOUS_TAG"
 ```
@@ -338,8 +348,10 @@ just performance-release "$TAG" "$PREVIOUS_TAG"
 `performance-local` and `performance-github-assets` retain Markdown, CSV, and
 provenance JSON bundles without changing tracked documentation.
 `performance-release` measures locally, retains and reload-validates the bundle,
-then promotes tracked docs. `performance-doc` performs only the reload,
-rendering, and promotion from retained inputs. Explicit `<current-tag>
+then promotes tracked docs. The canonical release flow immediately follows it
+with `performance-readme` to publish the matching README table and durable
+assets. `performance-doc` performs only the reload, rendering, and promotion
+from retained inputs. Explicit `<current-tag>
 <baseline-tag>` arguments repair or regenerate a specific distinct release
 pair; neither tag may be supplied alone.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,371 +1,323 @@
 # Releasing delaunay
 
-This guide documents the release flow for `vX.Y.Z`: prepare a dedicated
-release PR, merge it, create the final annotated tag from the generated
-changelog, publish to crates.io, and create the GitHub release.
+Prepare each `vX.Y.Z` release in a dedicated PR. After that PR is merged,
+create the annotated tag, publish to crates.io, create the GitHub release, and
+verify its durable benchmark asset.
 
-The release changelog is generated with `git-cliff --tag` through
-`just changelog-unreleased`, so no temporary local tag is needed.
+The changelog is generated for the target tag before the tag exists, so the
+release process does not require a temporary local tag.
 
-Applies to versions `vX.Y.Z`. Prefer updating documentation before publishing
-to crates.io.
+Release recipes are content-idempotent where their inputs permit it. Repeating
+`update-version` on the same UTC day or repeating `performance-readme` for the
+same retained bundle produces no file changes. `performance-release` is the
+explicit exception because new measurements may vary. If publication moves to
+another UTC day, rerun the release metadata and changelog steps before merge or
+publication so both record the new date.
 
----
+## Prepare the environment
 
-## Conventions and environment
-
-Set these variables to avoid repeating the version string:
+Set the target tag once:
 
 ```bash
-# tag has the leading v, version does not
 TAG=vX.Y.Z
-VERSION=${TAG#v}
-PREVIOUS_TAG=vA.B.C
 ```
 
-Verify your git remotes:
+No `VERSION`, previous-tag, or release-date variable is required. The release
+tooling derives the version history from `TAG` and published GitHub Releases
+and records the current UTC date when release metadata is updated.
+
+Verify GitHub authentication and the repository remotes, then synchronize
+`main`:
 
 ```bash
+gh auth status
 git remote -v
-```
-
-Ensure your local `main` is up to date before beginning:
-
-```bash
 git switch main
 git pull --ff-only
 ```
 
----
+Install or verify the development tools before running maintenance recipes.
+GitHub CLI is an external prerequisite. Setup installs the pinned Rust CLI
+tools and the intentionally unpinned `cargo-update` bootstrap package that
+provides `cargo-install-update` for `just update`, then verifies both `gh` and
+`cargo-install-update`:
 
-## Step 1: Create a clean release PR
+```bash
+just setup
+```
 
-This PR should primarily include version bumps, changelog updates, benchmark
-summary updates, and documentation updates. All major code changes should
+Refresh Cargo dependency requirements, exact direct Python development-tool
+pins, lockfiles, and repository-owned Cargo tool pins before creating the
+release branch:
+
+```bash
+just update
+```
+
+`just update` resolves exact pins under `[dependency-groups].dev` together for
+the repository's supported Python version before refreshing `uv.lock`. It does
+not change ranged development requirements, runtime or optional dependencies,
+or `[build-system].requires` through that exact-pin step. Its
+`cargo-install-update` preflight runs before either dependency updater can
+change declarations or lockfiles.
+
+Review any tracked dependency or tool changes and land them separately before
+continuing with the release PR, then synchronize `main` again. Dependency and
+tool upgrades remain independently reviewable; `just update-version`
+deliberately does not run `just update`.
+
+`update-version` and the release performance recipes use published, non-draft,
+non-prerelease GitHub Releases as the authoritative stable release history.
+
+## Step 1: Prepare the release PR
+
+Keep the release PR focused on version metadata, the generated changelog,
+benchmark artifacts, and release documentation. Major code changes should
 already be on `main`.
 
-Finalize release-facing metadata and documentation in this dedicated release
-PR. Ordinary feature, fix, review, and hygiene work should not preemptively
-bump versions or prepare release artifacts.
-
-Small, critical fixes discovered during the release process may be included,
-but keep them minimal and release-critical.
-
-Update release-facing documentation on this PR branch before publishing. Do not
-defer README, `docs/`, or benchmark documentation fixes until after the release:
-crates.io, docs.rs, and the generated benchmark summary are all versioned with
-the release artifacts.
-
-1. Create the release branch
+### 1. Create the release branch
 
 ```bash
 git switch -c "release/$TAG"
 ```
 
-2. Bump versions
-
-Preferred, if `cargo-edit` is installed:
+### 2. Update release metadata
 
 ```bash
-cargo set-version "$VERSION"
+just update-version "$TAG"
 ```
 
-Alternative: edit `Cargo.toml` manually and update `version = "..."` under
-`[package]`.
+The recipe requires one stable `vX.Y.Z` target that is not older than a
+published stable GitHub Release and that has at least one earlier stable
+release. It infers the previous release and atomically synchronizes:
 
-Update release metadata to match the crate version:
+- `Cargo.toml`, `Cargo.lock`, `pyproject.toml`, and `uv.lock` package versions;
+- `CITATION.cff` version and current UTC `date-released`;
+- README dependency examples and non-performance tag-pinned links;
+- active documentation dependency, `cargo add`, and explicit performance-pair
+  examples; and
+- the target changelog heading date when that generated heading already
+  exists.
 
-- `CITATION.cff`: update `version` and `date-released`.
-- `CITATION.cff`: keep `abstract` synchronized with the first paragraph under
-  `README.md`'s Introduction; update both together when either changes.
-- `pyproject.toml`: update `[project] version` for the Python utility package.
+The complete edit is planned before any file is replaced and caught failures
+roll every changed file back. The recipe preserves the Zenodo all-versions
+concept DOI `10.5281/zenodo.16931097`; it does not add or rotate a
+version-specific DOI. It does not generate the changelog, run benchmarks, or
+upgrade dependencies.
 
-Review the citation identity fields at the same time: author, ORCID,
-repository, license, and DOI. Keep the Zenodo concept DOI
-`10.5281/zenodo.16931097` unchanged across releases; do not replace it with a
-version-specific DOI.
+Review the resulting metadata diff before continuing.
 
-Refresh both committed lockfiles after manual metadata edits:
+If the publication day changes, rerun this step and
+`just changelog-unreleased "$TAG"`, then amend the release PR before merging.
+Never keep a stale date merely to preserve an earlier run.
 
-```bash
-cargo metadata --format-version 1 --no-deps > /dev/null
-uv lock
-```
-
-Review version references in active documentation and package metadata:
-
-```bash
-just docs-version-check
-```
-
-The automated check covers package metadata, lockfiles, citation version,
-release-pinned README links, active documentation dependency and `cargo add`
-snippets, and current-tag arguments in benchmark workflow examples. Historical
-prose, archived reports, baseline arguments, and tool versions intentionally
-remain independent of the current package version.
-
-3. Generate the release changelog
+### 3. Generate the release changelog
 
 ```bash
-# Generates CHANGELOG.md as though TAG already exists, then applies
-# markdown hygiene and archives completed minor release series.
 just changelog-unreleased "$TAG"
 ```
 
-`just changelog-unreleased` runs
-`GIT_CLIFF_OFFLINE=true git-cliff --tag "$TAG" -o CHANGELOG.md`, then
-`postprocess-changelog`, then `archive-changelog`. The root changelog keeps
-Unreleased plus the active minor series; older completed minor series live
-under `docs/archive/changelog/`.
+This generates `CHANGELOG.md` as though the target tag already existed,
+archives completed minor series under `docs/archive/changelog/`, and
+synchronizes the target heading with the intended date recorded in
+`CITATION.cff`. Before writing, it rejects a non-stable tag or a tag that does
+not match the Cargo package version. Review the generated changelog and archive
+changes. Do not edit generated changelog files manually.
 
-4. Refresh checked-in performance results, if needed
+### 4. Generate the release performance comparison
 
-Per-version benchmark storage is handled by the release-published benchmark
-workflow in Step 2; do not run this only to preserve release benchmark data.
-Run it only when the release PR intentionally updates public performance claims
-or the checked-in human-readable `benches/PERFORMANCE_RESULTS.md` summary:
-
-```bash
-just bench-perf-summary
-```
-
-Run it after the version bump so the generated file reports the current Cargo
-package version. The recipe already runs `benchmark-utils generate-summary
---run-benchmarks --profile perf`, which refreshes the perf-profile Criterion
-`ci_performance_suite` data, captures the generated construction simplex counts
-emitted by the benchmark harness, records current Criterion run metadata,
-reruns the circumsphere benchmark, and regenerates
-`benches/PERFORMANCE_RESULTS.md`. No separate Criterion refresh step is
-required.
-
-Review generated benchmark docs before committing them. Confirm the file shows
-`Version $VERSION Results`, `Current Criterion Run Information`, and
-`Simplices Generated`, and does not retain `Historical Version Comparison`,
-`Circumsphere Predicate Analysis`, `Method Disagreements`, or
-`Baseline Artifact Information`. Treat benchmark output as release evidence only
-when the underlying harnesses maintain their scientific invariants; a faster
-invariant-violating run is release-blocking, not a publishable improvement.
-
-When the release PR needs a curated release-to-release comparison in active
-docs, run the temp-worktree promotion workflow after the version bump:
+Run this after the package version has been updated:
 
 ```bash
 just performance-release
 ```
 
-This compares the current package version against the previous stable published
-release, retains Markdown, versioned CSV, and provenance JSON under
-`target/bench-reports/`, reload-validates the retained pair, writes the curated
-report to `docs/PERFORMANCE.md`, and archives the previous curated report under
-`docs/archive/performance/`. It also copies the exact promoted CSV/provenance
-bytes into `docs/archive/performance/data/`. Review the scratch artifacts and
-all tracked documentation/evidence changes. Each destination uses atomic file
-replacement and caught failures roll back; a hard interruption can stop between
-files, so inspect the destinations and rerun the idempotent command. To repair a
-specific pair, pass both tags explicitly:
+The no-argument form compares the current package version with the previous
+stable published release. It runs the release-signal Criterion measurements,
+retains `target/bench-reports/performance.{md,csv,provenance.json}`, validates
+the CSV/provenance pair after reloading it, promotes `docs/PERFORMANCE.md`, and
+archives the prior report plus the exact promoted evidence under
+`docs/archive/performance/`.
+
+The temporary current worktree includes staged and unstaged changes to tracked
+files but excludes untracked files. Stage any new benchmark-relevant file
+before running the comparison. Do not run `just clean` or `cargo clean` until
+the retained inputs have been reviewed and the README publication succeeds.
+
+If measurement succeeded and only report promotion must be retried, use
+`just performance-doc`. It reads the retained CSV/provenance pair and runs no
+Cargo benchmarks or measurement worktrees. Explicit current/baseline tag pairs
+are reserved for repair paths and must always be supplied together.
+
+Treat performance output as release evidence only when the measured workflow
+preserves Delaunay's numerical and topological invariants. A faster
+invariant-violating run is a failed release check.
+
+### 5. Publish the README performance snapshot
 
 ```bash
-just performance-release "$TAG" "$PREVIOUS_TAG"
+just performance-readme
 ```
 
-Supplying only one tag fails before fetch or benchmark side effects. If the
-measurements are already retained and only report formatting or promotion must
-be retried, run `just performance-doc`. It reads the canonical CSV and
-provenance JSON, runs no Cargo benchmarks or measurement worktrees, and rejects
-incomplete, invalid, stale, same-version, or scientifically non-comparable
-inputs.
+This command consumes the validated bundle retained and promoted by
+`performance-release`; it never invokes Cargo or Criterion. It atomically
+updates the compact group-level table in `README.md` and the exact canonical
+CSV/provenance pair under `docs/assets/bench/`. README links are pinned to
+`TAG`, so they resolve to the reviewed release artifacts after the tag is
+published. Caught publication failures restore every prior README-owned file.
 
-For manual investigation only, `DELAUNAY_BENCH_EXPORT_METRICS=1` can print the
-construction vertex/simplex metric lines without Criterion sampling. Prefer
-pairing it with a `tds_new` Criterion filter, for example:
+### 6. Validate the release branch
 
 ```bash
-DELAUNAY_BENCH_EXPORT_METRICS=1 \
-  cargo bench --profile perf --bench ci_performance_suite -- \
-  "tds_new_3d/tds_new/750"
-```
-
-This helper is not a replacement for `just bench-perf-summary` in the release
-flow.
-
-5. Validate the release branch
-
-```bash
-just docs-version-check
-just cargo-lock-check
 just ci
+just release-version-check
 just publish-check
 ```
 
-6. Review, stage, and commit the release branch
+`just ci` includes lockfile, citation, documentation, Python tooling, tests,
+and benchmark-compilation checks. `release-version-check` invokes the strict
+`check-docs-version-sync --final-release` gate, requiring exactly one current
+changelog heading whose date matches `CITATION.cff`. `publish-check` validates
+crates.io metadata and dry-runs the exact package from the intentionally dirty
+release worktree.
 
-Release workflows can update tracked files and create new archive files, and a
-critical release fix may legitimately touch source or tooling outside a fixed
-metadata list. Keep the dedicated release branch clean of unrelated work,
-review the complete release delta, and then stage all intended changes:
+### 7. Review, stage, and commit the release artifacts
+
+Inspect all changes before staging:
 
 ```bash
 git status --short
-git diff HEAD --check
-git --no-pager diff HEAD --stat
+git --no-pager diff
+```
 
-# After confirming every changed and untracked path belongs in the release PR:
-git add --all
-git status --short
-git diff --cached --check
-git --no-pager diff --cached --stat
+Expected release artifacts include package metadata and lockfiles,
+`CITATION.cff`, `CHANGELOG.md`, `README.md`, `docs/PERFORMANCE.md`, and generated
+files under `docs/archive/` and `docs/assets/bench/`. Stage only reviewed paths;
+do not stage unrelated work or the entire `docs/` tree without inspecting it.
+
+Then inspect and commit the staged release delta:
+
+```bash
 git --no-pager diff --cached
-
-benchmark_bullet=""
-if ! git diff --cached --quiet -- benches/PERFORMANCE_RESULTS.md; then
-    benchmark_bullet=$'\n- Refresh release benchmark summary'
-fi
 
 git commit -m "chore(release): release $TAG
 
 - Bump version to $TAG
 - Update citation and utility package metadata
-- Update changelog with latest changes
-- Update documentation for release${benchmark_bullet}"
+- Generate the release changelog
+- Update benchmark and performance artifacts
+- Update release documentation"
 ```
 
-If the initial status includes unrelated work, stop and separate it before
-running `git add --all`; do not stage a mixed worktree merely because it is on a
-release branch.
-
-The commit template adds its benchmark bullet only when
-`benches/PERFORMANCE_RESULTS.md` is present in the staged diff. If no checked-in
-benchmark summary changed, ensure that file is absent from the staged diff; the
-file and its benchmark bullet are then both omitted.
-
-7. Push the branch and open a PR
+### 8. Push the branch and open the PR
 
 ```bash
 git push -u origin "release/$TAG"
 ```
 
-PR metadata:
+Use `chore(release): release $TAG` as the PR title and describe the PR as a
+focused release preparation without feature work.
 
-- Title: `chore(release): release $TAG`
-- Description: Clean release PR with version bump, changelog, benchmark
-  summary if applicable, and documentation updates. No feature work.
+### Handling fixes found during preparation
 
-### Handling fixes discovered during the release process
+For a critical fix that must be included, make and commit the fix. If it changes
+measured code, benchmark harnesses, toolchain or dependency inputs, or benchmark
+configuration, rerun `just performance-release "$TAG" "vA.B.C"` with the same
+baseline used for the release comparison, then rerun `just performance-readme`.
+Rerun `just changelog-unreleased "$TAG"`, review and stage only the regenerated
+release outputs, commit that update separately, and rerun the final release and
+publish gates.
 
-If you discover issues after generating the changelog:
+For a non-critical fix, file an issue and defer it. Do not hand-edit the
+generated changelog to add a known-issue note.
 
-1. For critical fixes that must be in this release, make and commit the fix,
-   then regenerate the release changelog:
+Retries on the same UTC day keep the recorded release date unchanged. If
+publication moves to a different UTC day, rerun `just update-version "$TAG"`
+and `just changelog-unreleased "$TAG"`, then rerun the final release and
+publish checks before merge or publication.
 
-   ```bash
-   just changelog-unreleased "$TAG"
-   git add CHANGELOG.md docs/archive/changelog/
-   git commit -m "docs: update changelog with release fixes"
-   ```
+## Step 2: Publish after the PR is merged
 
-2. For non-critical fixes, document them as known issues in the release notes
-   or include them in the next release.
-
----
-
-## Step 2: After the PR is merged into main
-
-1. Sync your local `main` to the merge commit
+### 1. Synchronize `main`
 
 ```bash
 git switch main
 git pull --ff-only
 ```
 
-2. Create the final annotated tag using the changelog content
+### 2. Create and verify the annotated tag
 
 ```bash
-# Creates the annotated tag from the matching CHANGELOG.md section.
-# Archived versions are read from docs/archive/changelog/ automatically.
-# For large changelogs (>125KB), the tag message points to the changelog
-# section instead of embedding the full content.
 just tag "$TAG"
+git --no-pager tag -l --format='%(contents)' "$TAG"
 ```
 
-3. Optional: verify the tag message content
+`just tag` first runs `release-version-check`, then builds the annotation from
+the matching active or archived changelog section. For a changelog larger than
+125 kB, the annotation points to that section instead of embedding it. It fails
+before any Git tag query or mutation unless the `CITATION.cff` intended
+publication date equals the current UTC day. If the day changed after the
+original PR merged, prepare and merge a corrective release-metadata PR by
+rerunning `just update-version "$TAG"` on the new UTC day, then resynchronize
+local `main` and rerun the gates before tagging. Do not force the stale date
+through.
 
-```bash
-git tag -l --format='%(contents)' "$TAG"
-```
-
-4. Push the tag
+### 3. Push the tag
 
 ```bash
 git push origin "$TAG"
 ```
 
-5. Publish to crates.io
+### 4. Publish to crates.io
 
 ```bash
-# Publish the crate. Ensure docs are already updated on main via the PR.
 cargo publish --locked
 ```
 
-6. Create the GitHub release with notes from the tag annotation
+### 5. Create the GitHub release
 
 ```bash
 gh release create "$TAG" --title "$TAG" --notes-from-tag
 ```
 
-Always set the GitHub release title to the exact tag string, including the
-leading `v`.
+Keep the release title identical to the tag, including its leading `v`.
 
-Publishing the release triggers `.github/workflows/release-benchmarks.yml`, which
-runs fresh perf-profile release-signal benchmarks on `ubuntu-latest`, packages
-`baseline_results.txt`, `PERFORMANCE_RESULTS.md`, raw Criterion data, and
-metadata, then attaches
-`delaunay-$TAG-criterion-baseline.tar.gz` to the GitHub Release. That release
-asset is for GitHub Actions CI comparisons; keep local same-machine timing
-baselines under the ignored `baseline-artifact/` or `baseline-artifacts/` paths.
-Use `just performance-github-assets "$TAG" "vX.Y.Z"` to compare two stored
-release assets without local benchmark runs. New archives carry a versioned
-measurement sidecar binding source revision, measurement commands, toolchain,
-host, completed targets, normalized measurement plan, Criterion sample, and
-content digest to the requested clean release tag; acquisition commands and
-archive digests are retained separately. Because the two GitHub-hosted release
-runs are separate measurement sessions, their report retains absolute intervals
-but never emits before/after ratios. Existing legacy archives remain usable as
-provenance-limited absolute timing evidence, with unavailable facts explicit
-and promotion disabled. Raw Criterion evidence remains in the `.tar.gz` release
-assets.
+### 6. Verify the durable Criterion baseline
 
-7. Confirm release benchmark assets
-
-After the release benchmark workflow completes, verify that the GitHub Release
-has the durable benchmark baseline asset:
+Publishing the GitHub release triggers the `Release Benchmarks` workflow.
+After it completes, verify that the release contains its long-lived baseline
+archive:
 
 ```bash
 gh release view "$TAG" --json assets \
   --jq ".assets[] | select(.name == \"delaunay-$TAG-criterion-baseline.tar.gz\") | .name" | cat
 ```
 
-The command must print `delaunay-$TAG-criterion-baseline.tar.gz`. An Actions
-artifact alone is not a durable release baseline.
+The command must print `delaunay-$TAG-criterion-baseline.tar.gz`. A short-lived
+Actions artifact is not a substitute for this release asset. The archive binds
+the requested clean release tag to its source revision, measurement commands,
+toolchain, host, normalized measurement plan, completed benchmark targets,
+Criterion sample, and content digest.
 
-8. Clean up the release branch
+Use `just performance-github-assets "$TAG" "vA.B.C"` only when comparing two
+stored release archives. Because those runs are separate measurement sessions,
+the resulting report retains absolute intervals but suppresses ratios.
+
+### 7. Verify the Zenodo release metadata
+
+After the GitHub release has been archived by Zenodo, open the new
+version-specific Zenodo record reached from the repository's concept DOI. Check
+that its software version exactly matches `$TAG` (including the leading `v`)
+and its publication date exactly matches `date-released` in `CITATION.cff`.
+Do not treat the all-versions concept
+landing page alone as evidence for the new record. Correct a mismatch before
+declaring the release complete.
+
+### 8. Remove the merged release branch
+
+After crates.io, GitHub, benchmark-asset, and Zenodo verification succeed:
 
 ```bash
 git branch -d "release/$TAG"
 git push origin --delete "release/$TAG"
 ```
-
----
-
-## Notes and tips
-
-- Do not create a temporary local release tag for changelog generation; use
-  `just changelog-unreleased "$TAG"`.
-- Keep the release PR scoped to version, changelog, archive, benchmark summary,
-  and documentation changes.
-- `just changelog` regenerates the current changelog from existing tags and may
-  update `docs/archive/changelog/`.
-- `just changelog-unreleased "$TAG"` is for release PR preparation before the
-  final tag exists.
-- `just tag "$TAG"` is for the final post-merge annotated tag.
-- If multiple files reference the version, confirm all of them are updated
-  consistently.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -37,10 +37,10 @@ git pull --ff-only
 ```
 
 Install or verify the development tools before running maintenance recipes.
-GitHub CLI is an external prerequisite. Setup installs the pinned Rust CLI
-tools and the intentionally unpinned `cargo-update` bootstrap package that
-provides `cargo-install-update` for `just update`, then verifies both `gh` and
-`cargo-install-update`:
+`just setup` requires `uv`, `jq`, `rustup`, Cargo, `chktex`, and GitHub CLI
+(`gh`) on `PATH`. Setup installs the pinned Rust CLI tools and the intentionally
+unpinned `cargo-update` bootstrap package that provides `cargo-install-update`
+for `just update`, then verifies both `gh` and `cargo-install-update`:
 
 ```bash
 just setup

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -123,23 +123,29 @@ parameterized implementation helpers live in `just/helpers.just`.
 
 Tool-version variables in the root `justfile` are the source of truth for both
 local setup and GitHub Actions. `just setup-tools` installs or synchronizes the
-repository toolchain, while private `_ensure-*` dependencies fail fast when a
+repository toolchain. It requires `uv`, `gh`, `jq`, `rustup`, Cargo, and
+`chktex` on `PATH`, installs the pinned Rust CLI tools, and provisions the
+unpinned `cargo-update` bootstrap package that supplies
+`cargo-install-update`. Its final inventory verifies both `gh` and
+`cargo-install-update`. Private `_ensure-*` dependencies fail fast when a
 required tool or pinned version is unavailable during an individual recipe.
 `just setup` composes `setup-tools` with the development build.
 
 Use `just update` for deliberate dependency and tool maintenance. It composes
-`just update-dependencies`, which advances compatible and incompatible
-dependency requirements in `Cargo.toml`, updates `Cargo.lock`, and upgrades all
-uv-locked dependency groups within the constraints declared by
-`pyproject.toml`, with
+`just update-dependencies`, which advances compatible and incompatible Cargo
+requirements and `Cargo.lock`, resolves any exact direct pins under
+`[dependency-groups].dev` as one universal set for the supported Python
+version, then upgrades `uv.lock`, with
 `just update-cargo-tools`, which upgrades only the locally installed Cargo CLI
 packages owned by `setup-tools` and atomically reconciles their root `justfile`
 pins after every requested package updates successfully. The Cargo tool updater requires
 `cargo-install-update` from the `cargo-update` package and does not touch other
 Cargo-installed executables or uv's user-global tool environments. `setup-tools`
-and CI consume the reconciled declarations. Intentional exact
-uv overrides remain pinned until their declarations are changed explicitly;
-reproducible development tool versions otherwise come from `uv.lock`.
+and CI consume the reconciled declarations. The exact-pin step leaves ranged
+development requirements, project/runtime dependencies, optional dependencies,
+build requirements, and intentional uv overrides unchanged.
+The aggregate `just update` runs its `cargo-install-update` preflight before
+either dependency updater can change declarations or lockfiles.
 
 Agents should **prefer running `just` commands instead of invoking the
 underlying tools directly**. The justfile ensures the correct flags,
@@ -239,6 +245,15 @@ This compares the Cargo package version against `Cargo.lock`, `pyproject.toml`,
 dependency and `cargo add` snippets, and current-tag benchmark workflow
 examples.
 
+After generating a release changelog, run the strict final release gate:
+
+```bash
+just release-version-check
+```
+
+It invokes `check-docs-version-sync --final-release`, requiring exactly one
+current-version changelog heading whose date matches `CITATION.cff`.
+
 ---
 
 ## Full CI Validation
@@ -328,8 +343,9 @@ just notebook-check
 just bench-compile
 ```
 
-Commands that run benchmarks and produce performance data use the `perf`
-profile:
+Performance workflows use the following command surface. Commands that perform
+measurements use the `perf` profile; `performance-doc` and
+`performance-readme` only consume retained evidence:
 
 ```bash
 just bench
@@ -342,6 +358,7 @@ just performance-local
 just performance-github-assets
 just performance-release
 just performance-doc
+just performance-readme
 just perf-baseline
 just perf-compare
 just perf-vs-ref
@@ -458,6 +475,12 @@ asset and release-promotion recipes accept explicit `<current-tag>
 before any fetch or benchmark side effect. Temp-worktree release commands apply
 tracked checkout changes by default; untracked files must be added to git before
 they affect the generated report.
+
+Use `just performance-readme` after `performance-release` to validate that the
+retained bundle exactly matches the promoted durable evidence, then publish a
+compact group-level README table and the canonical CSV/provenance pair under
+`docs/assets/bench/`. It runs no benchmarks, updates tag-pinned evidence links,
+and rolls back every README-owned destination on caught failures.
 
 Scratch Markdown identifies the adjacent CSV/provenance pair under
 `target/bench-reports/`. A promoted report instead identifies the exact durable
@@ -854,6 +877,7 @@ just action-lint
 | Apply formatters/auto-fixes | `just fix` |
 | Validate Markdown-only changes | `just check-docs` |
 | Validate release-version references | `just docs-version-check` |
+| Validate final release changelog/citation synchronization | `just release-version-check` |
 | Validate `Cargo.toml`/`Cargo.lock` synchronization | `just cargo-lock-check` |
 | Validate configuration-only changes | `just check-config` |
 | Validate Python scripts/tests | `just python-check` and `just test-python` |
@@ -870,7 +894,9 @@ just action-lint
 | Compile release integration tests without running | `just test-integration-compile` |
 | Run examples | `just examples` |
 | Update dependency declarations, locks, and repo-owned Cargo tools | `just update` |
-| Update Cargo declarations and Cargo/uv dependency locks | `just update-dependencies` |
+| Update Cargo declarations and Cargo/Python dependency locks | `just update-dependencies` |
+| Update release metadata with the current UTC date | `just update-version vX.Y.Z` |
+| Validate crates.io metadata and dry-run the package | `just publish-check` |
 | Run full GitHub-equivalent CI | `just ci` |
 | Run perf-profile benchmarks | `just bench` |
 
@@ -941,6 +967,20 @@ exists with:
 ```bash
 just changelog-unreleased vX.Y.Z
 ```
+
+First set release metadata; the updater records the current UTC date:
+
+```bash
+just update-version vX.Y.Z
+```
+
+Same-day retries are content-idempotent; a retry after UTC midnight updates
+`CITATION.cff` and any existing target changelog heading together.
+`changelog-unreleased` first rejects a non-stable tag or a tag that differs
+from Cargo metadata, before `git-cliff` writes the changelog, then synchronizes
+the generated heading from `CITATION.cff`. Finish with
+`just release-version-check` and `just publish-check` before merge or
+publication.
 
 Create annotated release tags from the generated changelog after the release PR
 is merged with:

--- a/just/helpers.just
+++ b/just/helpers.just
@@ -30,7 +30,21 @@ _ensure-actionlint: _ensure-uv
     set -euo pipefail
     uv run --locked actionlint -version >/dev/null
 
+_ensure-cargo:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v cargo >/dev/null || { echo "❌ 'cargo' not found. Install Rust via https://rustup.rs and ensure cargo is on PATH."; exit 1; }
+
 _ensure-cargo-edit: (_ensure-pinned-cargo-tool "cargo-upgrade" "cargo-edit" cargo_edit_version "upgrade")
+
+_ensure-cargo-install-update:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v cargo-install-update >/dev/null || {
+        echo "❌ 'cargo-install-update' not found. Run 'just setup-tools' or install it with:"
+        echo "   cargo install --locked cargo-update"
+        exit 1
+    }
 
 _ensure-cargo-llvm-cov: (_ensure-pinned-cargo-tool "cargo-llvm-cov" "cargo-llvm-cov" cargo_llvm_cov_version "llvm-cov")
 
@@ -45,6 +59,11 @@ _ensure-chktex:
     }
 
 _ensure-dprint: (_ensure-pinned-cargo-tool "dprint" "dprint" dprint_version)
+
+_ensure-gh:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v gh >/dev/null || { echo "❌ 'gh' not found. Install GitHub CLI and ensure it is on PATH."; exit 1; }
 
 _ensure-git-cliff: (_ensure-pinned-cargo-tool "git-cliff" "git-cliff" git_cliff_version)
 
@@ -73,6 +92,11 @@ _ensure-pinned-cargo-tool binary package version cargo_subcommand="":
     fi
 
 _ensure-rumdl: (_ensure-pinned-cargo-tool "rumdl" "rumdl" rumdl_version)
+
+_ensure-rustup:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v rustup >/dev/null || { echo "❌ 'rustup' not found. Install Rust via https://rustup.rs and ensure rustup is on PATH."; exit 1; }
 
 _ensure-samply: (_ensure-pinned-cargo-tool "samply" "samply" samply_version)
 
@@ -162,8 +186,8 @@ _pachner-stress-dim label vertices attempts validate_every output_dir mode:
 _performance-tag-pair-state current_tag baseline_tag:
     #!/usr/bin/env bash
     set -euo pipefail
-    current_tag="{{ current_tag }}"
-    baseline_tag="{{ baseline_tag }}"
+    current_tag={{ quote(current_tag) }}
+    baseline_tag={{ quote(baseline_tag) }}
     if [[ -n "$current_tag" || -n "$baseline_tag" ]]; then
         if [[ -z "$current_tag" || -z "$baseline_tag" ]]; then
             echo "current_tag and baseline_tag must be provided together" >&2

--- a/justfile
+++ b/justfile
@@ -171,12 +171,28 @@ changelog: _ensure-git-cliff _ensure-rumdl python-sync
 
 # Generate the changelog as if releasing the requested version.
 [group('release')]
-changelog-unreleased version: _ensure-git-cliff _ensure-rumdl python-sync
+changelog-unreleased version: _ensure-gh _ensure-git-cliff _ensure-rumdl python-sync
     #!/usr/bin/env bash
     set -euo pipefail
-    GIT_CLIFF_OFFLINE=true git-cliff --tag {{ version }} -o CHANGELOG.md
+    version={{ quote(version) }}
+    if [[ ! "$version" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+        echo "❌ Release tag must use stable vX.Y.Z form, got: $version" >&2
+        exit 2
+    fi
+    package_version="$(
+        cargo metadata --locked --format-version 1 --no-deps \
+            | uv run --locked python -c 'import json, sys; print(json.load(sys.stdin)["packages"][0]["version"])'
+    )"
+    if [[ "$version" != "v$package_version" ]]; then
+        echo "❌ Release tag $version does not match Cargo package version $package_version." >&2
+        echo "   Run 'just update-version $version' before generating the changelog." >&2
+        exit 2
+    fi
+    previous_release="$(uv run --locked update-release-version "$version" --print-previous-release)"
+    GIT_CLIFF_OFFLINE=true git-cliff --tag "$version" -o CHANGELOG.md
     uv run --locked postprocess-changelog
     uv run --locked archive-changelog
+    uv run --locked update-release-version "$version" --sync-changelog-date --previous-release "$previous_release"
     rumdl fmt --silent CHANGELOG.md docs/archive/changelog/*.md
 
 # Run every non-mutating validator outside the test suites.
@@ -353,6 +369,7 @@ help-workflows:
     @echo "Canonical performance workflows:"
     @echo "  just performance-local  # Measure current tree vs latest release; retain bundle"
     @echo "  just performance-release # Measure, retain, validate, and promote release docs"
+    @echo "  just performance-readme # Publish retained release data to README assets/table"
     @echo "  just performance-doc    # Promote docs from retained CSV/JSON; no benchmarks"
     @echo "  just performance-github-assets # Compare stored release assets; retain bundle"
     @echo ""
@@ -373,6 +390,8 @@ help-workflows:
     @echo "Release and optional workflows:"
     @echo "  just publish-check      # Validate metadata and cargo publish --dry-run"
     @echo "  just changelog          # Regenerate and format changelog artifacts"
+    @echo "  just release-version-check # Require final changelog/citation synchronization"
+    @echo "  just update-version <tag>        # Synchronize release metadata using the current UTC date"
     @echo "  just ci-slow            # Default CI plus slow correctness tests"
     @echo "  just ci-baseline        # Default CI plus persistent perf baseline refresh"
     @echo "  just coverage           # Generate local HTML coverage"
@@ -701,11 +720,6 @@ perf-baseline-to out ref="main": _ensure-uv
 perf-compare file threshold="7.5": _ensure-uv
     uv run --locked benchmark-utils compare --baseline "{{ file }}" --threshold {{ threshold }} --dev
 
-# Compare stored GitHub Release benchmark assets without local cargo runs.
-[group('benchmarks and performance')]
-perf-github-assets current_tag="" baseline_tag="":
-    just performance-github-assets "{{ current_tag }}" "{{ baseline_tag }}"
-
 # Show detailed performance-check, benchmark, and profiling workflows.
 [group('benchmarks and performance')]
 perf-help:
@@ -719,6 +733,7 @@ perf-help:
     @echo "  just performance-github-assets # Compare stored GitHub Release benchmark assets"
     @echo "  just performance-release  # Measure, retain, and promote release performance docs"
     @echo "  just performance-doc      # Promote docs from retained CSV/JSON without benchmarks"
+    @echo "  just performance-readme   # Publish retained release data to README assets/table"
     @echo "  just perf-large-scale-smoke # Quick pre-push 2D-5D wall-clock smoke guard"
     @echo "  just perf-no-regressions   # Fast pre-PR guard with a cached same-machine main baseline"
     @echo "  just perf-vs-ref <ref> [threshold] # Compare current tree vs a cached same-machine ref baseline"
@@ -854,20 +869,10 @@ perf-large-scale-smoke max_secs="60": _ensure-nextest
     echo ""
     echo "✅ Large-scale smoke guard passed for 2D-5D"
 
-# Compare the current tree against the latest published release in temp worktrees.
-[group('benchmarks and performance')]
-perf-local:
-    just performance-local
-
 # Fast pre-PR performance guard against a cached same-machine main baseline.
 [group('benchmarks and performance')]
 perf-no-regressions threshold="7.5": _ensure-uv
     uv run --locked benchmark-utils compare-ref --ref main --threshold {{ threshold }} --dev --output benches/worktree_vs_main_compare_results.txt
-
-# Generate local release-signal measurements in temp worktrees, then promote/archive docs.
-[group('benchmarks and performance')]
-perf-release current_tag="" baseline_tag="":
-    just performance-release "{{ current_tag }}" "{{ baseline_tag }}"
 
 # Compare the current tree against a cached same-machine ref baseline.
 [group('benchmarks and performance')]
@@ -884,8 +889,8 @@ performance-doc: _ensure-uv
 performance-github-assets current_tag="" baseline_tag="": _ensure-uv
     #!/usr/bin/env bash
     set -euo pipefail
-    current_tag="{{ current_tag }}"
-    baseline_tag="{{ baseline_tag }}"
+    current_tag={{ quote(current_tag) }}
+    baseline_tag={{ quote(baseline_tag) }}
     tag_pair_state="$(just --quiet _performance-tag-pair-state "$current_tag" "$baseline_tag")"
     if [[ "$tag_pair_state" == "invalid" ]]; then
         exit 2
@@ -901,13 +906,18 @@ performance-github-assets current_tag="" baseline_tag="": _ensure-uv
 performance-local: _ensure-uv
     uv run --locked benchmark-utils performance-local
 
+# Validate retained release measurements and atomically publish README assets/table.
+[group('benchmarks and performance')]
+performance-readme: _ensure-uv
+    uv run --locked publish-readme-performance
+
 # Measure, retain, reload-validate, and promote release performance documentation.
 [group('benchmarks and performance')]
 performance-release current_tag="" baseline_tag="": _ensure-uv
     #!/usr/bin/env bash
     set -euo pipefail
-    current_tag="{{ current_tag }}"
-    baseline_tag="{{ baseline_tag }}"
+    current_tag={{ quote(current_tag) }}
+    baseline_tag={{ quote(baseline_tag) }}
     tag_pair_state="$(just --quiet _performance-tag-pair-state "$current_tag" "$baseline_tag")"
     if [[ "$tag_pair_state" == "invalid" ]]; then
         exit 2
@@ -1113,6 +1123,11 @@ python-sync: _ensure-uv
 python-typecheck: _ensure-uv
     uv run --locked --group notebooks ty check scripts/ --error all
 
+# Require final release versions plus matching changelog and citation dates.
+[group('release')]
+release-version-check: _ensure-uv
+    uv run --locked check-docs-version-sync --final-release
+
 # Run the opt-in companion binary with the CLI feature and perf profile.
 [group('build and setup')]
 run *args:
@@ -1176,10 +1191,10 @@ semgrep-test: _ensure-uv
 setup: setup-tools build
     echo "✅ Setup complete! Run 'just help-workflows' to see available commands."
 
-# Install and verify pinned repository development tools.
-[doc('Install and verify pinned repository development tools.')]
+# Install and verify repository development tools.
+[doc('Install and verify repository development tools.')]
 [group('build and setup')]
-setup-tools: _ensure-uv
+setup-tools: _ensure-cargo _ensure-chktex _ensure-gh _ensure-jq _ensure-rustup _ensure-uv
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -1201,6 +1216,15 @@ setup-tools: _ensure-uv
             cargo install --locked "$package" --version "$expected_version"
         else
             echo "  ✓ $binary $expected_version"
+        fi
+    }
+
+    ensure_cargo_install_update() {
+        if ! have cargo-install-update; then
+            echo "  ⏳ Installing cargo-update (cargo)..."
+            cargo install --locked cargo-update
+        else
+            echo "  ✓ cargo-install-update"
         fi
     }
 
@@ -1272,8 +1296,8 @@ setup-tools: _ensure-uv
         cargo install --locked tectonic --version "$expected_version"
     }
 
-    echo "This recipe installs pinned Rust CLI tools through cargo."
-    echo "External prerequisites that must already be on PATH: uv, jq, rustup, cargo, and chktex."
+    echo "This recipe installs pinned Rust CLI tools and the unpinned cargo-update bootstrap helper through cargo."
+    echo "External prerequisites that must already be on PATH: uv, gh, jq, rustup, cargo, and chktex."
     echo "pkg-config, plus native development files, is required only when the pinned Tectonic version must be installed."
     echo ""
 
@@ -1297,6 +1321,7 @@ setup-tools: _ensure-uv
         echo "  ✓ llvm-tools-preview"
     fi
 
+    ensure_cargo_install_update
     ensure_pinned_cargo_tool cargo-llvm-cov cargo-llvm-cov "{{ cargo_llvm_cov_version }}" llvm-cov
     ensure_pinned_cargo_tool cargo-upgrade cargo-edit "{{ cargo_edit_version }}" upgrade
     ensure_pinned_cargo_tool cargo-machete cargo-machete "{{ cargo_machete_version }}"
@@ -1316,8 +1341,8 @@ setup-tools: _ensure-uv
     echo "Verifying required commands are available..."
     missing=0
 
-    cmds=(uv jq taplo dprint tectonic tex-fmt rumdl git-cliff typos zizmor chktex samply)
-    cmds+=(cargo-nextest cargo-llvm-cov cargo-upgrade cargo-machete)
+    cmds=(uv gh jq taplo dprint tectonic tex-fmt rumdl git-cliff typos zizmor chktex samply)
+    cmds+=(cargo-install-update cargo-nextest cargo-llvm-cov cargo-upgrade cargo-machete)
 
     for cmd in "${cmds[@]}"; do
         if have "$cmd"; then
@@ -1427,13 +1452,13 @@ spherical-readme-hero: _ensure-uv paper-cli
 
 # Create an annotated git tag from the CHANGELOG.md section for the given version
 [group('release')]
-tag version: python-sync
-    uv run --locked tag-release {{ version }}
+tag version: python-sync release-version-check
+    uv run --locked tag-release {{ quote(version) }}
 
 # Replace an existing annotated tag from the CHANGELOG.md section.
 [group('release')]
-tag-force version: python-sync
-    uv run --locked tag-release {{ version }} --force
+tag-force version: python-sync release-version-check
+    uv run --locked tag-release {{ quote(version) }} --force
 
 # Run every default Rust and Python test bucket once.
 [group('workflows')]
@@ -1579,21 +1604,22 @@ unused-deps: _ensure-cargo-machete
 
 # Update dependency requirements, locks, and locally installed Cargo tools owned by this repository.
 [group('build and setup')]
-update: update-dependencies update-cargo-tools
+update: _ensure-cargo-install-update update-dependencies update-cargo-tools
     @echo "✅ Repository dependencies and tools updated."
+
+# Advance Cargo dependency declarations and lockfile entries.
+[doc('Update Cargo.toml dependency requirements and Cargo.lock.')]
+[group('build and setup')]
+update-cargo-dependencies: _ensure-cargo-edit
+    cargo upgrade --incompatible allow
+    cargo update
 
 # Update locally installed Cargo CLI tools owned by `setup-tools` and reconcile their pins.
 [doc('Update Cargo CLI tools owned by setup-tools and reconcile their root justfile pins.')]
 [group('build and setup')]
-update-cargo-tools: _ensure-uv
+update-cargo-tools: _ensure-cargo-install-update _ensure-uv
     #!/usr/bin/env bash
     set -euo pipefail
-
-    if ! command -v cargo-install-update >/dev/null 2>&1; then
-        echo "❌ 'cargo-install-update' not found. Install it with:"
-        echo "   cargo install --locked cargo-update"
-        exit 1
-    fi
 
     packages=(
         cargo-edit
@@ -1614,14 +1640,26 @@ update-cargo-tools: _ensure-uv
     cargo install-update --locked "${packages[@]}"
     uv run --locked update-cargo-tool-pins
 
-# Advance Cargo dependency declarations, update Cargo and uv locks, then sync uv dev tools.
-[doc('Update Cargo.toml dependency requirements and all Cargo/uv locked dependencies.')]
+# Advance Cargo and exact Python development requirements plus their lockfiles.
+[doc('Update Cargo and Python development requirements plus all Cargo/uv locked dependencies.')]
 [group('build and setup')]
-update-dependencies: _ensure-uv _ensure-cargo-edit
-    cargo upgrade --incompatible allow
-    cargo update
+update-dependencies: _ensure-cargo-edit _ensure-uv update-cargo-dependencies update-python-dependencies
+
+# Resolve latest exact Python development tools, retain ranged requirements, and sync.
+[doc('Update exact dependency-groups.dev pins and uv.lock through uv.')]
+[group('build and setup')]
+update-python-dependencies: _ensure-uv
+    uv run --locked update-python-dev-pins
     uv lock --upgrade
     uv sync --locked --group dev
+
+# Update release metadata with the current UTC date and infer the prior stable published release.
+[doc('Update package, citation, lockfile, and non-artifact documentation release versions.')]
+[group('release')]
+update-version tag: _ensure-gh _ensure-uv
+    uv run --locked update-release-version {{ quote(tag) }}
+    cargo metadata --locked --format-version 1 --no-deps > /dev/null
+    uv run --locked check-docs-version-sync
 
 # Refresh reviewer-facing validation diagrams from the reproducible notebook.
 [group('notebooks and papers')]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,11 @@ paper-pdf-check = "paper_check:main"
 paper-pdf-normalize = "paper_pdf_normalize:main"
 paper-source-date-epoch = "paper_source_date:main"
 postprocess-changelog = "postprocess_changelog:main"
+publish-readme-performance = "publish_readme_performance:main"
 tag-release = "tag_release:main"
 update-cargo-tool-pins = "update_cargo_tool_pins:main"
+update-python-dev-pins = "update_python_dev_pins:main"
+update-release-version = "update_release_version:main"
 
 # Configure setuptools to find packages in scripts/ directory
 [tool.setuptools]
@@ -69,9 +72,12 @@ py-modules = [
     "paper_source_date",
     "performance_artifacts",
     "postprocess_changelog",
+    "publish_readme_performance",
     "subprocess_utils",
     "tag_release",
     "update_cargo_tool_pins",
+    "update_python_dev_pins",
+    "update_release_version",
 ]
 
 [tool.ruff]
@@ -198,9 +204,12 @@ known-first-party = [
     "paper_source_date",
     "performance_artifacts",
     "postprocess_changelog",
+    "publish_readme_performance",
     "subprocess_utils",
     "tag_release",
     "update_cargo_tool_pins",
+    "update_python_dev_pins",
+    "update_release_version",
 ]
 force-single-line = false
 split-on-trailing-comma = true

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,12 +25,16 @@ These commands are exposed by `pyproject.toml`; all support `--help`.
 ```bash
 just changelog
 just changelog-unreleased vX.Y.Z
+just release-version-check
 just tag vX.Y.Z
+just update-version vX.Y.Z
 
 uv run --locked check-docs-version-sync --help
+uv run --locked check-docs-version-sync --final-release
 uv run --locked postprocess-changelog --help
 uv run --locked archive-changelog --help
 uv run --locked tag-release vX.Y.Z --help
+uv run --locked update-release-version vX.Y.Z
 ```
 
 `just changelog` runs `git-cliff`, applies markdown hygiene, and archives
@@ -42,6 +46,12 @@ Cargo package version against release-facing docs and metadata.
 Use `just changelog-unreleased vX.Y.Z` while preparing a release PR before the
 final tag exists. Use `just tag vX.Y.Z` after the release PR is merged to
 create the annotated release tag from the matching changelog section.
+`just update-version vX.Y.Z` infers the previous stable published GitHub
+Release and atomically synchronizes release metadata with the current UTC date.
+Same-day retries are content-idempotent; later-day retries advance citation and
+existing target changelog dates together.
+`just release-version-check` runs the strict final gate, which requires one
+current-version changelog heading whose date matches `CITATION.cff`.
 
 ### Notebook utilities
 
@@ -73,6 +83,7 @@ uv run --locked benchmark-utils performance-local
 uv run --locked benchmark-utils performance-github-assets
 uv run --locked benchmark-utils performance-release
 uv run --locked benchmark-utils performance-doc
+uv run --locked publish-readme-performance
 ```
 
 `benchmark-utils` handles Criterion baseline generation and packaging,
@@ -114,6 +125,11 @@ analyses, but those caches are not promotion inputs and must be reproducible
 from the validated CSV. Raw Criterion data remains in the release
 `delaunay-vX.Y.Z-criterion-baseline.tar.gz` assets.
 
+`publish-readme-performance` consumes the retained bundle after promotion and
+atomically publishes the compact README table plus the canonical
+`docs/assets/bench/release-performance.{csv,provenance.json}` pair. It never
+runs Cargo or Criterion.
+
 ### Hardware utilities
 
 ```bash
@@ -133,11 +149,25 @@ just coverage-ci
 
 ### Tool-pin maintenance
 
+Prefer the repository recipes for coordinated updates. The direct locked
+Python-pin updater is also available for focused diagnosis:
+
+```bash
+just update-python-dependencies
+uv run --locked update-python-dev-pins --help
+```
+
 `just update` upgrades the Cargo CLI packages owned by `setup-tools`, then runs
 `update-cargo-tool-pins` to atomically reconcile their installed versions with
 the root `justfile`. The updater validates the complete managed package set
 before replacing the pin source, so missing or malformed Cargo output leaves
 the existing declarations unchanged.
+
+Before `uv.lock` is refreshed, `update-python-dev-pins` discovers exact simple
+pins under `[dependency-groups].dev`, resolves their latest mutually compatible
+universal set for the supported Python version, and replaces them together.
+Ranged development requirements and runtime/build requirements remain outside
+that rewrite.
 
 ## Shell helpers
 

--- a/scripts/benchmark_utils.py
+++ b/scripts/benchmark_utils.py
@@ -4964,10 +4964,16 @@ def _preflight_performance_destinations(
         durable = _durable_performance_artifact_paths(archive_dir, report_id)
         paths["durable CSV"] = durable.csv
         paths["durable provenance"] = durable.provenance
+        tracked_destinations = {
+            current,
+            archive_dir / "README.md",
+            archive_dir / report_id.archive_name,
+            durable.csv,
+            durable.provenance,
+        }
         for label, path in paths.items():
-            if label in {"Markdown output", "artifact CSV", "artifact provenance"}:
-                continue
-            _repository_relative_path(project_root, path, label=label)
+            if path in tracked_destinations:
+                _repository_relative_path(project_root, path, label=label)
         if current.exists():
             current_id = parse_performance_report_id(_normalize_how_to_update(_read_text(current)))
             if current_id != report_id:

--- a/scripts/benchmark_utils.py
+++ b/scripts/benchmark_utils.py
@@ -443,6 +443,15 @@ class PerformanceReportId:
 
 
 @dataclass(frozen=True)
+class PerformancePromotionDestinations:
+    """Explicit repository boundary and tracked performance destinations."""
+
+    project_root: Path
+    current: Path
+    archive_dir: Path
+
+
+@dataclass(frozen=True)
 class PerformancePromotionPlan:
     """Validated file payloads and destinations for one report promotion."""
 
@@ -3369,17 +3378,47 @@ def _durable_performance_artifact_paths(archive_dir: Path, report_id: Performanc
     return ArtifactPaths(csv=data_dir / f"{stem}.csv", provenance=data_dir / f"{stem}.provenance.json")
 
 
+def _repository_relative_path(project_root: Path, path: Path, *, label: str) -> Path:
+    """Resolve *path* and return its location relative to the repository root."""
+    resolved_root = project_root.resolve(strict=False)
+    resolved_path = path.resolve(strict=False)
+    try:
+        return resolved_path.relative_to(resolved_root)
+    except ValueError as error:
+        msg = f"{label} must be contained by repository root {resolved_root}, got {resolved_path}"
+        raise ValueError(msg) from error
+
+
+def _promoted_evidence_paths(durable: ArtifactPaths, *, project_root: Path) -> ArtifactPaths:
+    """Return validated repository-relative evidence paths for tracked reports."""
+    return ArtifactPaths(
+        csv=_repository_relative_path(project_root, durable.csv, label="promoted performance CSV"),
+        provenance=_repository_relative_path(
+            project_root,
+            durable.provenance,
+            label="promoted performance provenance",
+        ),
+    )
+
+
 def _validated_promotion_source(
     source: Path,
     artifacts: ArtifactPaths,
     expected: PerformanceReportId,
     durable_artifacts: ArtifactPaths,
+    project_root: Path,
 ) -> tuple[PerformanceBundle, str, PerformanceReportId]:
     """Validate one canonical report and its independently expected identity."""
     bundle = load_bundle(artifacts)
     bundle.require_promotable()
     source_text = _normalize_how_to_update(_read_text(source))
-    rendered_text = _normalize_how_to_update(render_performance_bundle(bundle, evidence_paths=durable_artifacts, evidence_state="promoted"))
+    rendered_text = _normalize_how_to_update(
+        render_performance_bundle(
+            bundle,
+            evidence_paths=_promoted_evidence_paths(durable_artifacts, project_root=project_root),
+            evidence_state="promoted",
+        )
+    )
     if source_text != rendered_text:
         msg = "benchmark report is not the canonical rendering of its retained artifact pair"
         raise ValueError(msg)
@@ -3433,17 +3472,25 @@ def _plan_performance_promotion(
     *,
     source: Path,
     artifacts: ArtifactPaths,
-    current: Path,
-    archive_dir: Path,
+    destinations: PerformancePromotionDestinations,
     expected: PerformanceReportId,
 ) -> PerformancePromotionPlan:
     """Validate all promotion inputs and conflicts before the first mutation."""
+    current = destinations.current
+    archive_dir = destinations.archive_dir
+    project_root = destinations.project_root
     normalized_expected = PerformanceReportId(
         current_tag=normalize_release_tag(expected.current_tag),
         baseline_tag=normalize_release_tag(expected.baseline_tag),
     )
     durable_artifacts = _durable_performance_artifact_paths(archive_dir, normalized_expected)
-    _, source_text, source_id = _validated_promotion_source(source, artifacts, expected, durable_artifacts)
+    _, source_text, source_id = _validated_promotion_source(
+        source,
+        artifacts,
+        expected,
+        durable_artifacts,
+        project_root,
+    )
     current_text, archive_path = _promotion_archive_destination(current, archive_dir, source_id)
 
     index_path = archive_dir / "README.md"
@@ -3484,6 +3531,14 @@ def _plan_performance_promotion(
         durable_artifacts.provenance,
         *(() if archive_path is None else (archive_path,)),
     )
+    for label, path in (
+        ("current performance report", current),
+        ("performance archive index", index_path),
+        ("durable performance CSV", durable_artifacts.csv),
+        ("durable performance provenance", durable_artifacts.provenance),
+        *(() if archive_path is None else (("archived performance report", archive_path),)),
+    ):
+        _repository_relative_path(project_root, path, label=label)
     return PerformancePromotionPlan(
         report_id=source_id,
         source_text=source_text,
@@ -3525,19 +3580,21 @@ def promote_performance_report(
     *,
     source: Path,
     artifacts: ArtifactPaths,
-    current: Path,
-    archive_dir: Path,
+    destinations: PerformancePromotionDestinations,
     expected: PerformanceReportId,
 ) -> PerformanceReportId:
     """Archive the old report and durably promote its exact evidence pair."""
     plan = _plan_performance_promotion(
         source=source,
         artifacts=artifacts,
-        current=current,
-        archive_dir=archive_dir,
+        destinations=destinations,
         expected=expected,
     )
-    _apply_performance_promotion(plan, current=current, archive_dir=archive_dir)
+    _apply_performance_promotion(
+        plan,
+        current=destinations.current,
+        archive_dir=destinations.archive_dir,
+    )
     return plan.report_id
 
 
@@ -3630,6 +3687,11 @@ def _stable_published_releases(releases: object) -> list[PublishedRelease]:
 def _published_stable_releases(repo_root: Path) -> list[PublishedRelease]:
     """Return stable published releases for the current GitHub repository."""
     return _stable_published_releases(_github_release_list(repo_root))
+
+
+def published_stable_release_tags(repo_root: Path) -> list[str]:
+    """Return stable tag names from published, non-draft GitHub releases."""
+    return [release.tag for release in _published_stable_releases(repo_root)]
 
 
 def _latest_published_release(repo_root: Path) -> PublishedRelease:
@@ -4880,6 +4942,7 @@ def _preflight_performance_destinations(
     report_id: PerformanceReportId,
     current: Path | None = None,
     archive_dir: Path | None = None,
+    project_root: Path | None = None,
 ) -> None:
     """Reject deterministic output aliases before fetches or measurements."""
     artifacts = _artifact_paths_for_output(output)
@@ -4887,6 +4950,9 @@ def _preflight_performance_destinations(
     if current is not None:
         if archive_dir is None:
             msg = "archive_dir is required when preflighting a promotion"
+            raise ValueError(msg)
+        if project_root is None:
+            msg = "project_root is required when preflighting a promotion"
             raise ValueError(msg)
         paths.update(
             {
@@ -4898,10 +4964,16 @@ def _preflight_performance_destinations(
         durable = _durable_performance_artifact_paths(archive_dir, report_id)
         paths["durable CSV"] = durable.csv
         paths["durable provenance"] = durable.provenance
+        for label, path in paths.items():
+            if label in {"Markdown output", "artifact CSV", "artifact provenance"}:
+                continue
+            _repository_relative_path(project_root, path, label=label)
         if current.exists():
             current_id = parse_performance_report_id(_normalize_how_to_update(_read_text(current)))
             if current_id != report_id:
-                paths["prior report archive"] = archive_dir / current_id.archive_name
+                prior_archive = archive_dir / current_id.archive_name
+                _repository_relative_path(project_root, prior_archive, label="prior report archive")
+                paths["prior report archive"] = prior_archive
     ensure_distinct_paths(paths)
 
 
@@ -4911,6 +4983,7 @@ def _publish_performance_bundle(
     output: Path,
     current: Path | None = None,
     archive_dir: Path | None = None,
+    project_root: Path | None = None,
 ) -> PerformanceReportId:
     """Publish artifacts, reload-render Markdown, and optionally promote docs."""
     artifacts = _artifact_paths_for_output(output)
@@ -4931,10 +5004,13 @@ def _publish_performance_bundle(
                 if archive_dir is None:
                     msg = "archive_dir is required when promoting performance documentation"
                     raise ValueError(msg)
+                if project_root is None:
+                    msg = "project_root is required when promoting performance documentation"
+                    raise ValueError(msg)
                 durable_artifacts = _durable_performance_artifact_paths(archive_dir, report_id)
                 rendered = render_performance_bundle(
                     load_bundle(artifacts),
-                    evidence_paths=durable_artifacts,
+                    evidence_paths=_promoted_evidence_paths(durable_artifacts, project_root=project_root),
                     evidence_state="promoted",
                 )
             _write_text_atomic(output, rendered)
@@ -4942,11 +5018,17 @@ def _publish_performance_bundle(
                 if archive_dir is None:
                     msg = "archive_dir is required when promoting performance documentation"
                     raise ValueError(msg)
+                if project_root is None:
+                    msg = "project_root is required when promoting performance documentation"
+                    raise ValueError(msg)
                 report_id = promote_performance_report(
                     source=output,
                     artifacts=artifacts,
-                    current=current,
-                    archive_dir=archive_dir,
+                    destinations=PerformancePromotionDestinations(
+                        project_root=project_root,
+                        current=current,
+                        archive_dir=archive_dir,
+                    ),
                     expected=report_id,
                 )
             return report_id
@@ -4996,6 +5078,7 @@ def generate_and_promote_performance_report(
         report_id=PerformanceReportId(current_tag=current_tag, baseline_tag=baseline_tag),
         current=current,
         archive_dir=archive_dir,
+        project_root=config.repo_root,
     )
     bundle = _build_performance_bundle_in_temp_worktree(
         config=ReleaseReportConfig(
@@ -5010,18 +5093,26 @@ def generate_and_promote_performance_report(
             baseline_source=config.baseline_source,
         )
     )
-    return _publish_performance_bundle(bundle=bundle, output=output, current=current, archive_dir=archive_dir)
+    return _publish_performance_bundle(
+        bundle=bundle,
+        output=output,
+        current=current,
+        archive_dir=archive_dir,
+        project_root=config.repo_root,
+    )
 
 
 def render_and_promote_performance_artifacts(
     *,
     output: Path,
     artifacts: ArtifactPaths,
-    current: Path,
-    archive_dir: Path,
+    destinations: PerformancePromotionDestinations,
     expected_current_tag: str,
 ) -> PerformanceReportId:
     """Render and promote retained artifacts without Cargo or worktrees."""
+    current = destinations.current
+    archive_dir = destinations.archive_dir
+    project_root = destinations.project_root
     ensure_distinct_paths(
         {
             "Markdown output": output,
@@ -5047,6 +5138,7 @@ def render_and_promote_performance_artifacts(
         ),
         current=current,
         archive_dir=archive_dir,
+        project_root=project_root,
     )
     prior_output = output.read_bytes() if output.exists() else None
     try:
@@ -5057,13 +5149,16 @@ def render_and_promote_performance_artifacts(
         durable_artifacts = _durable_performance_artifact_paths(archive_dir, report_id)
         _write_text_atomic(
             output,
-            render_performance_bundle(bundle, evidence_paths=durable_artifacts, evidence_state="promoted"),
+            render_performance_bundle(
+                bundle,
+                evidence_paths=_promoted_evidence_paths(durable_artifacts, project_root=project_root),
+                evidence_state="promoted",
+            ),
         )
         return promote_performance_report(
             source=output,
             artifacts=artifacts,
-            current=current,
-            archive_dir=archive_dir,
+            destinations=destinations,
             expected=report_id,
         )
     except BaseException:
@@ -8194,6 +8289,7 @@ def _cmd_performance_release(args: argparse.Namespace, project_root: Path) -> No
             report_id=PerformanceReportId(current_tag=request.current_tag, baseline_tag=request.baseline_tag),
             current=current,
             archive_dir=archive_dir,
+            project_root=project_root,
         )
         _fetch_for_performance_request(project_root=project_root, request=request, include_current=False)
         config = _release_config_from_args(
@@ -8228,8 +8324,11 @@ def _cmd_performance_doc(args: argparse.Namespace, project_root: Path) -> None:
         report_id = render_and_promote_performance_artifacts(
             output=output,
             artifacts=artifacts,
-            current=current,
-            archive_dir=archive_dir,
+            destinations=PerformancePromotionDestinations(
+                project_root=project_root,
+                current=current,
+                archive_dir=archive_dir,
+            ),
             expected_current_tag=_current_package_tag(project_root),
         )
     except _RECOVERABLE_CLI_ERRORS as exc:

--- a/scripts/check_docs_version_sync.py
+++ b/scripts/check_docs_version_sync.py
@@ -224,7 +224,7 @@ def _uv_lock_reference(path: Path, project: PythonProjectInfo) -> VersionReferen
     candidate_indices: list[int] = []
     for index, entry in enumerate(entries):
         source = entry.get("source")
-        if entry.get("name") == project.name and _is_parsed_object(source) and isinstance(source.get("editable"), str):
+        if entry.get("name") == project.name and _is_parsed_object(source) and source.get("editable") == ".":
             candidate_indices.append(index)
     return _single_package_reference(path, entries, candidate_indices, project.name, ReferenceKind.UV_LOCK)
 
@@ -308,35 +308,47 @@ def _validate_citation_doi(path: Path) -> None:
         raise TypeError(msg)
 
 
-def _validate_release_date_sync(root: Path, package: PackageInfo) -> None:
-    """Require citation metadata and the generated release heading to agree."""
-    citation = root / "CITATION.cff"
-    citation_line, citation_date = _citation_release_date(citation)
-    changelog = root / "CHANGELOG.md"
-    if not changelog.is_file():
-        return
-
-    heading_prefix = re.compile(rf"^## \[v?{re.escape(package.version)}\]")
-    heading = re.compile(rf"^## \[v?{re.escape(package.version)}\] - (?P<date>\d{{4}}-\d{{2}}-\d{{2}})$")
-    changelog_matches: list[tuple[int, str]] = []
-    for line_number, line in enumerate(changelog.read_text(encoding="utf-8").splitlines(), start=1):
+def changelog_release_date(path: Path, version: str) -> tuple[int, str] | None:
+    """Return one generated release-heading date, or ``None`` before generation."""
+    heading_prefix = re.compile(rf"^## \[v?{re.escape(version)}\]")
+    heading = re.compile(rf"^## \[v?{re.escape(version)}\] - (?P<date>\d{{4}}-\d{{2}}-\d{{2}})$")
+    matches: list[tuple[int, str]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
         if heading_prefix.match(line) is None:
             continue
         match = heading.fullmatch(line)
         if match is None:
-            msg = f"{changelog}:{line_number}: release heading for {package.version} must end with YYYY-MM-DD"
+            msg = f"{path}:{line_number}: release heading for {version} must end with YYYY-MM-DD"
             raise TypeError(msg)
         value = match.group("date")
-        _require_iso_date(value, path=changelog, line=line_number, field=f"release heading date for {package.version}")
-        changelog_matches.append((line_number, value))
-    if not changelog_matches:
-        msg = f"{changelog}: missing release heading for {package.version}; expected exactly one"
+        _require_iso_date(value, path=path, line=line_number, field=f"release heading date for {version}")
+        matches.append((line_number, value))
+    if not matches:
+        return None
+    if len(matches) != 1:
+        locations = ", ".join(f"{path}:{line}" for line, _value in matches)
+        msg = f"{locations}: duplicate release headings for {version}; expected exactly one"
         raise TypeError(msg)
-    if len(changelog_matches) != 1:
-        locations = ", ".join(f"{changelog}:{line}" for line, _value in changelog_matches)
-        msg = f"{locations}: duplicate release headings for {package.version}; expected exactly one"
-        raise TypeError(msg)
-    changelog_line, changelog_date = changelog_matches[0]
+    return matches[0]
+
+
+def _validate_release_date_sync(root: Path, package: PackageInfo, *, final_release: bool) -> None:
+    """Require citation metadata and the applicable generated release heading to agree."""
+    citation = root / "CITATION.cff"
+    citation_line, citation_date = _citation_release_date(citation)
+    changelog = root / "CHANGELOG.md"
+    if not changelog.is_file():
+        if final_release:
+            msg = f"{changelog}: final release validation requires a generated heading for {package.version}"
+            raise TypeError(msg)
+        return
+    changelog_match = changelog_release_date(changelog, package.version)
+    if changelog_match is None:
+        if final_release:
+            msg = f"{changelog}: final release validation requires exactly one generated heading for {package.version}"
+            raise TypeError(msg)
+        return
+    changelog_line, changelog_date = changelog_match
     if citation_date != changelog_date:
         msg = (
             f"release date mismatch: {citation}:{citation_line} has {citation_date}, "
@@ -354,10 +366,30 @@ def _iter_markdown_files(root: Path) -> list[Path]:
     return sorted(markdown_files)
 
 
+# The transactional release updater consumes the checker's parsers so the
+# writer and validator cannot drift onto different release surfaces.
+read_cargo_package_info = _read_cargo_package_info
+read_python_project_info = _read_python_project_info
+toml_table_key_line = _toml_table_key_line
+cargo_lock_reference = _cargo_lock_reference
+pyproject_reference = _pyproject_reference
+uv_lock_reference = _uv_lock_reference
+citation_reference = _citation_reference
+citation_release_date = _citation_release_date
+iter_active_markdown_files = _iter_markdown_files
+
+
 def _dependency_regex(package_name: str) -> re.Pattern[str]:
     """Build a regex for Cargo dependency snippets naming *package_name*."""
     escaped_name = re.escape(package_name)
-    return re.compile(rf'(?<![\w.-]){escaped_name}\s*=\s*(?:"(?P<plain>[^"]+)"|\{{[^}}]*version\s*=\s*"(?P<table>[^"]+)"[^}}]*\}})')
+    return re.compile(
+        rf"(?<![\w.-]){escaped_name}\s*=\s*(?:"
+        rf'"(?P<plain>[^\"]+)"|\'(?P<plain_literal>[^\']+)\'|'
+        rf"\{{[^}}]*version\s*=\s*(?:\"(?P<table>[^\"]+)\"|'(?P<table_literal>[^']+)')[^}}]*\}})"
+    )
+
+
+dependency_regex = _dependency_regex
 
 
 def _dependency_references(path: Path, package_name: str) -> list[VersionReference]:
@@ -366,7 +398,7 @@ def _dependency_references(path: Path, package_name: str) -> list[VersionReferen
     references: list[VersionReference] = []
     for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
         for match in dependency_re.finditer(line):
-            version = match.group("plain") or match.group("table")
+            version = match.group("plain") or match.group("plain_literal") or match.group("table") or match.group("table_literal")
             references.append(
                 VersionReference(
                     path=path,
@@ -383,6 +415,9 @@ def _cargo_add_regex(package_name: str) -> re.Pattern[str]:
     """Build a regex for cargo-add commands naming *package_name*."""
     escaped_name = re.escape(package_name)
     return re.compile(rf"(?<![\w.-])cargo\s+add\b[^`\n]*?(?<![\w.-]){escaped_name}@(?P<version>[^\s`]+)")
+
+
+cargo_add_regex = _cargo_add_regex
 
 
 def _cargo_add_references(path: Path, package_name: str) -> list[VersionReference]:
@@ -403,11 +438,17 @@ def _cargo_add_references(path: Path, package_name: str) -> list[VersionReferenc
     return references
 
 
-_README_TAG_LINK_RE = re.compile(
+README_TAG_LINK_RE = re.compile(
     r"https://(?:github\.com/acgetchell/delaunay/(?:blob|raw|tree)/|raw\.githubusercontent\.com/acgetchell/delaunay/)"
     r"(?:v(?P<version>[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)"
-    r"|(?P<revision>[0-9a-f]{7,40}))(?=/|$|[^0-9A-Za-z._+-])"
+    r"|(?P<revision>[0-9a-f]{7,40}))(?P<path>/[^)\s]*)?(?=$|[)\s])"
 )
+
+
+def readme_tag_link_is_performance_asset(match: re.Match[str]) -> bool:
+    """Return whether a README link is owned by ``performance-readme``."""
+    path = str(match.group("path") or "")
+    return path.startswith(("/docs/assets/bench/", "/docs/archive/performance/data/")) or path == "/docs/PERFORMANCE.md"
 
 
 def _readme_tag_references(path: Path) -> list[VersionReference]:
@@ -422,25 +463,54 @@ def _readme_tag_references(path: Path) -> list[VersionReference]:
                 ReferenceKind.README_TAG_LINK,
                 line.strip(),
             )
-            for match in _README_TAG_LINK_RE.finditer(line)
+            for match in README_TAG_LINK_RE.finditer(line)
+            if not readme_tag_link_is_performance_asset(match)
         )
     return references
 
 
-_BENCHMARK_CURRENT_TAG_RE = re.compile(
-    r"just (?:performance|perf)-(?:github-assets|release)\s+v"
-    r"(?P<version>[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)(?=\s|`)"
+_STABLE_RELEASE_TAG_RE = re.compile(r"^v(?P<major>0|[1-9][0-9]*)\.(?P<minor>0|[1-9][0-9]*)\.(?P<patch>0|[1-9][0-9]*)$")
+BENCHMARK_TAG_PAIR_RE = re.compile(
+    r"(?P<prefix>just performance-(?:github-assets|release)[ \t]+)"
+    r"(?P<current>v?[0-9][^\s`]+)"
+    r"(?P<separator>[ \t]+)"
+    r"(?P<baseline>[^\s`]+)"
+    r"(?=[ \t]|`|$)",
+    re.MULTILINE,
+)
+BENCHMARK_SINGLE_TAG_RE = re.compile(
+    r"just performance-(?:github-assets|release)[ \t]+"
+    r"(?P<current>v?[0-9][^\s`|]+)"
+    r"(?=[ \t]*(?:`|\||$))",
 )
 
 
+def _stable_tag_components(value: str, *, path: Path, line: int, label: str) -> tuple[int, int, int]:
+    """Parse one stable documentation tag into comparable numeric components."""
+    match = _STABLE_RELEASE_TAG_RE.fullmatch(value)
+    if match is None:
+        msg = f"{path}:{line}: benchmark {label} must be a stable tag in vX.Y.Z form, got {value!r}"
+        raise TypeError(msg)
+    return int(match.group("major")), int(match.group("minor")), int(match.group("patch"))
+
+
 def _benchmark_current_tag_references(path: Path) -> list[VersionReference]:
-    """Return current-release tag arguments in benchmark workflow examples."""
+    """Validate benchmark release pairs and return their current-tag references."""
     references: list[VersionReference] = []
     for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-        references.extend(
-            VersionReference(path, line_number, match.group("version"), ReferenceKind.BENCHMARK_CURRENT_TAG, line.strip())
-            for match in _BENCHMARK_CURRENT_TAG_RE.finditer(line)
-        )
+        incomplete = BENCHMARK_SINGLE_TAG_RE.search(line)
+        if incomplete is not None:
+            msg = f"{path}:{line_number}: benchmark command with current tag {incomplete.group('current')!r} is missing its baseline tag"
+            raise TypeError(msg)
+        for match in BENCHMARK_TAG_PAIR_RE.finditer(line):
+            current = match.group("current")
+            baseline = match.group("baseline")
+            current_components = _stable_tag_components(current, path=path, line=line_number, label="current tag")
+            baseline_components = _stable_tag_components(baseline, path=path, line=line_number, label="baseline tag")
+            if baseline_components >= current_components:
+                msg = f"{path}:{line_number}: benchmark baseline tag {baseline} must be older than current tag {current}"
+                raise TypeError(msg)
+            references.append(VersionReference(path, line_number, current.removeprefix("v"), ReferenceKind.BENCHMARK_CURRENT_TAG, line.strip()))
     return references
 
 
@@ -462,11 +532,11 @@ def _version_references(root: Path, package: PackageInfo) -> list[VersionReferen
     return references
 
 
-def find_version_mismatches(root: Path) -> list[VersionMismatch]:
-    """Return release-version references that differ from Cargo.toml."""
+def find_version_mismatches(root: Path, *, final_release: bool = False) -> list[VersionMismatch]:
+    """Return release-version mismatches, optionally requiring final changelog evidence."""
     package = _read_cargo_package_info(root / "Cargo.toml")
     references = _version_references(root, package)
-    _validate_release_date_sync(root, package)
+    _validate_release_date_sync(root, package, final_release=final_release)
     _validate_citation_doi(root / "CITATION.cff")
     return [VersionMismatch(reference=reference, package=package) for reference in references if reference.version != package.version]
 
@@ -480,6 +550,11 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
         color=False,
     )
     parser.add_argument("root", nargs="?", type=Path, default=Path.cwd(), help="Repository root to check (default: current directory)")
+    parser.add_argument(
+        "--final-release",
+        action="store_true",
+        help="require exactly one current-version CHANGELOG heading matching CITATION.cff",
+    )
     return parser.parse_args(argv)
 
 
@@ -488,7 +563,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(sys.argv[1:] if argv is None else argv)
     root = args.root.resolve()
     try:
-        mismatches = find_version_mismatches(root)
+        mismatches = find_version_mismatches(root, final_release=args.final_release)
     except (OSError, TypeError, tomllib.TOMLDecodeError) as error:
         print(f"Could not check release-version synchronization: {error}", file=sys.stderr)
         return 1

--- a/scripts/check_docs_version_sync.py
+++ b/scripts/check_docs_version_sync.py
@@ -475,7 +475,7 @@ BENCHMARK_TAG_PAIR_RE = re.compile(
     r"(?P<current>v?[0-9][^\s`]+)"
     r"(?P<separator>[ \t]+)"
     r"(?P<baseline>[^\s`]+)"
-    r"(?=[ \t]|`|$)",
+    r"(?=[ \t\r]|`|$)",
     re.MULTILINE,
 )
 BENCHMARK_SINGLE_TAG_RE = re.compile(

--- a/scripts/publish_readme_performance.py
+++ b/scripts/publish_readme_performance.py
@@ -217,13 +217,19 @@ def publish_readme_performance(
     )
     source_csv = source.csv.read_bytes()
     source_provenance = source.provenance.read_bytes()
+    missing_durable = [path for path in (durable.csv, durable.provenance) if not path.is_file()]
+    if missing_durable:
+        rendered = ", ".join(path.relative_to(resolved_root).as_posix() for path in missing_durable)
+        msg = f"promoted performance evidence is missing: {rendered}; run `just performance-release` before publishing the README snapshot"
+        raise ValueError(msg)
     if durable.csv.read_bytes() != source_csv or durable.provenance.read_bytes() != source_provenance:
         msg = "retained performance data does not match the exact bundle promoted by `just performance-release`"
         raise ValueError(msg)
 
     performance_report = resolved_root / "docs/PERFORMANCE.md"
     if not performance_report.is_file():
-        msg = f"{performance_report} is missing; run `just performance-release` before publishing the README snapshot"
+        report_label = performance_report.relative_to(resolved_root).as_posix()
+        msg = f"{report_label} is missing; run `just performance-release` before publishing the README snapshot"
         raise ValueError(msg)
     durable_evidence = ArtifactPaths(
         csv=durable.csv.relative_to(resolved_root),

--- a/scripts/publish_readme_performance.py
+++ b/scripts/publish_readme_performance.py
@@ -212,8 +212,21 @@ def publish_readme_performance(
     baseline = bundle.context.release.baseline
     archive_stem = f"{current}-vs-{baseline}"
     durable = ArtifactPaths(
-        csv=resolved_root / "docs/archive/performance/data" / f"{archive_stem}.csv",
-        provenance=resolved_root / "docs/archive/performance/data" / f"{archive_stem}.provenance.json",
+        csv=_contained_destination(
+            resolved_root,
+            resolved_root / "docs/archive/performance/data" / f"{archive_stem}.csv",
+            label="promoted performance CSV",
+        ),
+        provenance=_contained_destination(
+            resolved_root,
+            resolved_root / "docs/archive/performance/data" / f"{archive_stem}.provenance.json",
+            label="promoted performance provenance",
+        ),
+    )
+    performance_report = _contained_destination(
+        resolved_root,
+        resolved_root / "docs/PERFORMANCE.md",
+        label="promoted performance report",
     )
     source_csv = source.csv.read_bytes()
     source_provenance = source.provenance.read_bytes()
@@ -226,7 +239,6 @@ def publish_readme_performance(
         msg = "retained performance data does not match the exact bundle promoted by `just performance-release`"
         raise ValueError(msg)
 
-    performance_report = resolved_root / "docs/PERFORMANCE.md"
     if not performance_report.is_file():
         report_label = performance_report.relative_to(resolved_root).as_posix()
         msg = f"{report_label} is missing; run `just performance-release` before publishing the README snapshot"

--- a/scripts/publish_readme_performance.py
+++ b/scripts/publish_readme_performance.py
@@ -1,0 +1,305 @@
+"""Publish a compact README snapshot from retained release-performance data."""
+
+import argparse
+import math
+import os
+import sys
+import tempfile
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from benchmark_utils import render_performance_bundle
+from performance_artifacts import ArtifactPaths, PerformanceBundle, PerformanceRow, load_bundle
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_MARKER_BEGIN = "<!-- PERFORMANCE_RELEASE_TABLE:BEGIN -->"
+_MARKER_END = "<!-- PERFORMANCE_RELEASE_TABLE:END -->"
+_ASSET_CSV = Path("docs/assets/bench/release-performance.csv")
+_ASSET_PROVENANCE = Path("docs/assets/bench/release-performance.provenance.json")
+
+
+@dataclass(frozen=True, slots=True)
+class PublicationSummary:
+    """Destinations and release identity for one README publication."""
+
+    current_tag: str
+    baseline_tag: str
+    changed_paths: tuple[Path, ...]
+
+
+def _cargo_package_tag(cargo_toml: Path) -> str:
+    """Return the stable tag implied by Cargo package metadata."""
+    data = tomllib.loads(cargo_toml.read_text(encoding="utf-8"))
+    package = data.get("package")
+    if not isinstance(package, dict):
+        msg = f"{cargo_toml} is missing a [package] table"
+        raise TypeError(msg)
+    version = package.get("version")
+    if not isinstance(version, str):
+        msg = f"{cargo_toml} [package] is missing a string version"
+        raise TypeError(msg)
+    return f"v{version.removeprefix('v')}"
+
+
+def _comparable_groups(rows: tuple[PerformanceRow, ...]) -> dict[str, list[PerformanceRow]]:
+    """Group comparable rows without discarding their validated identities."""
+    groups: dict[str, list[PerformanceRow]] = {}
+    for row in rows:
+        if row.coverage_status == "comparable":
+            groups.setdefault(row.group, []).append(row)
+    return groups
+
+
+def _geometric_mean_speedup(rows: list[PerformanceRow]) -> float:
+    """Return the geometric mean of baseline/current median ratios."""
+    logarithms: list[float] = []
+    for row in rows:
+        if row.baseline is None or row.current is None:
+            msg = f"comparable row {row.benchmark_id} is missing one timing estimate"
+            raise ValueError(msg)
+        logarithms.append(math.log(row.baseline.median_ns) - math.log(row.current.median_ns))
+    mean_logarithm = math.fsum(logarithms) / len(logarithms)
+    try:
+        speedup = math.exp(mean_logarithm)
+    except OverflowError as error:
+        msg = "geometric mean speedup is outside the finite floating-point range"
+        raise ValueError(msg) from error
+    if not math.isfinite(speedup) or speedup <= 0.0:
+        msg = "geometric mean speedup is outside the positive finite floating-point range"
+        raise ValueError(msg)
+    return speedup
+
+
+def render_readme_block(bundle: PerformanceBundle) -> str:
+    """Render a compact, deterministic release snapshot from validated rows."""
+    context = bundle.context
+    current = context.release.current
+    baseline = context.release.baseline
+    groups = _comparable_groups(bundle.sorted_rows)
+    if not groups:
+        msg = "README publication requires at least one comparable benchmark row"
+        raise ValueError(msg)
+
+    asset_base = f"https://github.com/acgetchell/delaunay/blob/{current}"
+    lines = [
+        _MARKER_BEGIN,
+        "",
+        f"Latest retained release comparison: **{current} vs {baseline}**.",
+        "",
+        "| Benchmark group | Comparable cases | Geometric mean median speedup |",
+        "|-----------------|-----------------:|------------------------------:|",
+    ]
+    for group in sorted(groups):
+        rows = groups[group]
+        lines.append(f"| `{group}` | {len(rows)} | {_geometric_mean_speedup(rows):.3f}x |")
+    lines.extend(
+        (
+            "",
+            (
+                "Speedup is baseline median divided by current median; values above 1.000x are faster. "
+                "These descriptive aggregates are not statistical-significance claims."
+            ),
+            "",
+            (
+                f"[Full report]({asset_base}/docs/PERFORMANCE.md) · "
+                f"[CSV]({asset_base}/{_ASSET_CSV.as_posix()}) · "
+                f"[provenance]({asset_base}/{_ASSET_PROVENANCE.as_posix()})"
+            ),
+            "",
+            _MARKER_END,
+        )
+    )
+    return "\n".join(lines)
+
+
+def _replace_marked_block(readme: str, replacement: str) -> str:
+    """Replace exactly one ordered README publication block."""
+    begin_count = readme.count(_MARKER_BEGIN)
+    end_count = readme.count(_MARKER_END)
+    if begin_count != 1 or end_count != 1:
+        msg = f"README performance markers must be unique (begin={begin_count}, end={end_count})"
+        raise ValueError(msg)
+    begin = readme.index(_MARKER_BEGIN)
+    end = readme.index(_MARKER_END, begin) + len(_MARKER_END)
+    return f"{readme[:begin]}{replacement}{readme[end:]}"
+
+
+def _write_bytes_atomic(path: Path, payload: bytes) -> None:
+    """Replace one file atomically while preserving its existing mode."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(payload)
+        temporary.chmod(path.stat().st_mode if path.exists() else 0o644)
+        temporary.replace(path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def _publish_transaction(payloads: dict[Path, bytes], validate: Callable[[], None]) -> tuple[Path, ...]:
+    """Publish changed payloads together and roll back caught failures."""
+    originals = {path: path.read_bytes() if path.exists() else None for path in payloads}
+    changed = tuple(sorted((path for path, payload in payloads.items() if payload != originals[path]), key=str))
+    replaced: list[Path] = []
+    try:
+        for path in changed:
+            _write_bytes_atomic(path, payloads[path])
+            replaced.append(path)
+        validate()
+    except BaseException as primary:
+        rollback_errors: list[str] = []
+        for path in reversed(replaced):
+            try:
+                original = originals[path]
+                if original is None:
+                    path.unlink(missing_ok=True)
+                else:
+                    _write_bytes_atomic(path, original)
+            except OSError as error:
+                rollback_errors.append(f"{path}: {error}")
+        if rollback_errors:
+            msg = f"README performance publication failed ({primary}); rollback also failed: {'; '.join(rollback_errors)}"
+            raise RuntimeError(msg) from primary
+        raise
+    return changed
+
+
+def _contained_destination(root: Path, path: Path, *, label: str) -> Path:
+    """Resolve one write destination and require repository containment."""
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as error:
+        msg = f"{label} must be contained by repository root {root}, got {resolved}"
+        raise ValueError(msg) from error
+    return resolved
+
+
+def publish_readme_performance(
+    root: Path,
+    *,
+    artifacts: ArtifactPaths | None = None,
+    readme: Path | None = None,
+) -> PublicationSummary:
+    """Validate retained evidence and publish README-owned files transactionally."""
+    resolved_root = root.resolve()
+    source = artifacts or ArtifactPaths(
+        csv=resolved_root / "target/bench-reports/performance.csv",
+        provenance=resolved_root / "target/bench-reports/performance.provenance.json",
+    )
+    readme_path = _contained_destination(resolved_root, readme or resolved_root / "README.md", label="README destination")
+    bundle = load_bundle(source)
+    bundle.require_promotable()
+    expected_current = _cargo_package_tag(resolved_root / "Cargo.toml")
+    if bundle.context.release.current != expected_current:
+        msg = (
+            f"retained performance data is for {bundle.context.release.current}, but Cargo.toml is {expected_current}; "
+            "run `just performance-release` for the current release"
+        )
+        raise ValueError(msg)
+    if bundle.context.measurement_mode != "local-worktrees":
+        msg = "README publication requires locally retained release measurements"
+        raise ValueError(msg)
+
+    current = bundle.context.release.current
+    baseline = bundle.context.release.baseline
+    archive_stem = f"{current}-vs-{baseline}"
+    durable = ArtifactPaths(
+        csv=resolved_root / "docs/archive/performance/data" / f"{archive_stem}.csv",
+        provenance=resolved_root / "docs/archive/performance/data" / f"{archive_stem}.provenance.json",
+    )
+    source_csv = source.csv.read_bytes()
+    source_provenance = source.provenance.read_bytes()
+    if durable.csv.read_bytes() != source_csv or durable.provenance.read_bytes() != source_provenance:
+        msg = "retained performance data does not match the exact bundle promoted by `just performance-release`"
+        raise ValueError(msg)
+
+    performance_report = resolved_root / "docs/PERFORMANCE.md"
+    if not performance_report.is_file():
+        msg = f"{performance_report} is missing; run `just performance-release` before publishing the README snapshot"
+        raise ValueError(msg)
+    durable_evidence = ArtifactPaths(
+        csv=durable.csv.relative_to(resolved_root),
+        provenance=durable.provenance.relative_to(resolved_root),
+    )
+    expected_report = render_performance_bundle(bundle, evidence_paths=durable_evidence, evidence_state="promoted")
+    if performance_report.read_text(encoding="utf-8") != expected_report:
+        msg = "docs/PERFORMANCE.md is not the canonical rendering of the retained and promoted performance bundle"
+        raise ValueError(msg)
+
+    updated_readme = _replace_marked_block(readme_path.read_text(encoding="utf-8"), render_readme_block(bundle))
+    asset_paths = ArtifactPaths(
+        csv=_contained_destination(resolved_root, resolved_root / _ASSET_CSV, label="README CSV asset destination"),
+        provenance=_contained_destination(
+            resolved_root,
+            resolved_root / _ASSET_PROVENANCE,
+            label="README provenance asset destination",
+        ),
+    )
+    payloads = {
+        asset_paths.csv: source_csv,
+        asset_paths.provenance: source_provenance,
+        readme_path: updated_readme.encode("utf-8"),
+    }
+
+    def validate() -> None:
+        if load_bundle(asset_paths) != bundle:
+            msg = "published README performance assets do not round-trip to the retained bundle"
+            raise ValueError(msg)
+        if readme_path.read_text(encoding="utf-8") != updated_readme:
+            msg = "published README performance block does not match the validated plan"
+            raise ValueError(msg)
+
+    changed = _publish_transaction(payloads, validate)
+    return PublicationSummary(current_tag=current, baseline_tag=baseline, changed_paths=changed)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd(), help="repository root (default: current directory)")
+    parser.add_argument("--artifact-csv", type=Path, default=Path("target/bench-reports/performance.csv"))
+    parser.add_argument("--artifact-provenance", type=Path, default=Path("target/bench-reports/performance.provenance.json"))
+    parser.add_argument("--readme", type=Path, default=Path("README.md"))
+    return parser.parse_args(argv)
+
+
+def _under_root(root: Path, path: Path) -> Path:
+    return path if path.is_absolute() else root / path
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Publish README performance evidence without running measurements."""
+    args = parse_args(argv)
+    root = args.root.resolve()
+    try:
+        summary = publish_readme_performance(
+            root,
+            artifacts=ArtifactPaths(
+                csv=_under_root(root, args.artifact_csv),
+                provenance=_under_root(root, args.artifact_provenance),
+            ),
+            readme=_under_root(root, args.readme),
+        )
+    except (OSError, RuntimeError, TypeError, ValueError, tomllib.TOMLDecodeError) as error:
+        print(f"performance-readme: {error}", file=sys.stderr)
+        return 1
+
+    if summary.changed_paths:
+        for path in summary.changed_paths:
+            print(f"Updated {path.relative_to(root)}")
+    else:
+        print("README performance publication is already current.")
+    print(f"README performance report: {summary.current_tag} vs {summary.baseline_tag}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tag_release.py
+++ b/scripts/tag_release.py
@@ -18,9 +18,11 @@ import re
 import subprocess
 import sys
 import tomllib
+from datetime import UTC, date, datetime
 from pathlib import Path
 from urllib.parse import urlsplit
 
+import check_docs_version_sync as version_sync
 from subprocess_utils import (
     ExecutableNotFoundError,
     run_git_command,
@@ -143,6 +145,35 @@ def _package_version(changelog: Path) -> str:
     return version
 
 
+def _citation_release_date(changelog: Path) -> date:
+    """Return the one calendar-valid top-level publication date beside the changelog."""
+    citation = changelog.parent / "CITATION.cff"
+    try:
+        _line, value = version_sync.citation_release_date(citation)
+    except (OSError, TypeError) as exc:
+        msg = f"Could not validate {citation}: {exc}"
+        raise PackageMetadataError(msg) from exc
+    return date.fromisoformat(value)
+
+
+def _current_utc_date() -> date:
+    """Return the current UTC calendar day through a patchable clock boundary."""
+    return datetime.now(UTC).date()
+
+
+def _validate_publication_date(changelog: Path) -> None:
+    """Require the intended citation publication date to equal today's UTC date."""
+    intended = _citation_release_date(changelog)
+    current = _current_utc_date()
+    if intended != current:
+        msg = (
+            f"CITATION.cff intended publication date {intended.isoformat()} does not match "
+            f"the current UTC date {current.isoformat()}; rerun release metadata and changelog "
+            "generation with the actual publication date before tagging"
+        )
+        raise ValueError(msg)
+
+
 def _validated_release_target(tag_version: str) -> tuple[str, Path]:
     """Validate the requested tag against Cargo before any Git tag query."""
     validate_semver(tag_version)
@@ -152,6 +183,7 @@ def _validated_release_target(tag_version: str) -> tuple[str, Path]:
     if version != package_version:
         msg = f"Tag version {version!r} does not match Cargo package version {package_version!r}"
         raise ValueError(msg)
+    _validate_publication_date(changelog)
     return version, changelog
 
 

--- a/scripts/tests/test_benchmark_utils.py
+++ b/scripts/tests/test_benchmark_utils.py
@@ -867,14 +867,21 @@ def test_promote_performance_report_archives_previous_and_updates_index(tmp_path
         csv=archive_dir / "data" / "v0.8.0-vs-v0.7.8.csv",
         provenance=archive_dir / "data" / "v0.8.0-vs-v0.7.8.provenance.json",
     )
-    promoted_report = benchmark_utils.render_performance_bundle(performance_artifacts.load_bundle(artifacts), evidence_paths=durable, evidence_state="promoted")
+    promoted_report = benchmark_utils.render_performance_bundle(
+        performance_artifacts.load_bundle(artifacts),
+        evidence_paths=benchmark_utils._promoted_evidence_paths(durable, project_root=tmp_path),
+        evidence_state="promoted",
+    )
     source.write_text(promoted_report, encoding=UTF8)
 
     promoted = promote_performance_report(
         source=source,
         artifacts=artifacts,
-        current=current,
-        archive_dir=archive_dir,
+        destinations=benchmark_utils.PerformancePromotionDestinations(
+            project_root=tmp_path,
+            current=current,
+            archive_dir=archive_dir,
+        ),
         expected=benchmark_utils.PerformanceReportId(current_tag="v0.8.0", baseline_tag="v0.7.8"),
     )
 
@@ -914,7 +921,11 @@ def test_promote_performance_report_rolls_back_every_destination_on_failure(
         provenance=archive_dir / "data" / "v0.8.0-vs-v0.7.8.provenance.json",
     )
     source.write_text(
-        benchmark_utils.render_performance_bundle(performance_artifacts.load_bundle(artifacts), evidence_paths=durable, evidence_state="promoted"),
+        benchmark_utils.render_performance_bundle(
+            performance_artifacts.load_bundle(artifacts),
+            evidence_paths=benchmark_utils._promoted_evidence_paths(durable, project_root=tmp_path),
+            evidence_state="promoted",
+        ),
         encoding=UTF8,
     )
 
@@ -928,14 +939,19 @@ def test_promote_performance_report_rolls_back_every_destination_on_failure(
         promote_performance_report(
             source=source,
             artifacts=artifacts,
-            current=current,
-            archive_dir=archive_dir,
+            destinations=benchmark_utils.PerformancePromotionDestinations(
+                project_root=tmp_path,
+                current=current,
+                archive_dir=archive_dir,
+            ),
             expected=benchmark_utils.PerformanceReportId(current_tag="v0.8.0", baseline_tag="v0.7.8"),
         )
 
     assert current.read_text(encoding=UTF8) == delaunay_report("0.7.8", "v0.7.7")
     assert index.read_text(encoding=UTF8) == "old index\n"
     assert not archived.exists()
+    assert not durable.csv.exists()
+    assert not durable.provenance.exists()
 
 
 def test_promote_performance_report_rejects_conflicting_existing_archive_before_mutation(tmp_path: Path) -> None:
@@ -954,7 +970,11 @@ def test_promote_performance_report_rejects_conflicting_existing_archive_before_
         provenance=archive_dir / "data" / "v0.8.0-vs-v0.7.8.provenance.json",
     )
     source.write_text(
-        benchmark_utils.render_performance_bundle(performance_artifacts.load_bundle(artifacts), evidence_paths=durable, evidence_state="promoted"),
+        benchmark_utils.render_performance_bundle(
+            performance_artifacts.load_bundle(artifacts),
+            evidence_paths=benchmark_utils._promoted_evidence_paths(durable, project_root=tmp_path),
+            evidence_state="promoted",
+        ),
         encoding=UTF8,
     )
     prior_current = current.read_bytes()
@@ -963,8 +983,11 @@ def test_promote_performance_report_rejects_conflicting_existing_archive_before_
         promote_performance_report(
             source=source,
             artifacts=artifacts,
-            current=current,
-            archive_dir=archive_dir,
+            destinations=benchmark_utils.PerformancePromotionDestinations(
+                project_root=tmp_path,
+                current=current,
+                archive_dir=archive_dir,
+            ),
             expected=benchmark_utils.PerformanceReportId(current_tag="v0.8.0", baseline_tag="v0.7.8"),
         )
 
@@ -996,6 +1019,47 @@ def test_release_generation_preflights_output_aliases_before_measurement(tmp_pat
         )
 
 
+@pytest.mark.parametrize("escape", ["traversal", "symlink"])
+def test_release_generation_rejects_archive_escape_before_measurement_or_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    escape: str,
+) -> None:
+    """Tracked performance destinations must remain below the explicit root."""
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    if escape == "traversal":
+        archive_dir = project_root / "docs" / "archive" / ".." / ".." / ".." / "outside"
+    else:
+        docs = project_root / "docs"
+        docs.mkdir()
+        (docs / "archive").symlink_to(outside, target_is_directory=True)
+        archive_dir = docs / "archive" / "performance"
+
+    measurement = Mock()
+    publication = Mock()
+    monkeypatch.setattr(benchmark_utils, "_build_performance_bundle_in_temp_worktree", measurement)
+    monkeypatch.setattr(benchmark_utils, "_publish_performance_bundle", publication)
+
+    with pytest.raises(ValueError, match="contained by repository root"):
+        benchmark_utils.generate_and_promote_performance_report(
+            output=project_root / "target" / "bench-reports" / "performance.md",
+            current=project_root / "docs" / "PERFORMANCE.md",
+            archive_dir=archive_dir,
+            config=ReleaseReportConfig(
+                repo_root=project_root,
+                current_tag="v0.8.0",
+                baseline_tag="v0.7.8",
+                worktree_ref="HEAD",
+            ),
+        )
+
+    measurement.assert_not_called()
+    publication.assert_not_called()
+
+
 def test_performance_doc_promotes_retained_bundle_without_commands(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Retained artifacts should be sufficient to rebuild and promote docs."""
     output = tmp_path / "target" / "bench-reports" / "performance.md"
@@ -1019,8 +1083,11 @@ def test_performance_doc_promotes_retained_bundle_without_commands(tmp_path: Pat
     report_id = benchmark_utils.render_and_promote_performance_artifacts(
         output=output,
         artifacts=artifacts,
-        current=current,
-        archive_dir=archive_dir,
+        destinations=benchmark_utils.PerformancePromotionDestinations(
+            project_root=tmp_path,
+            current=current,
+            archive_dir=archive_dir,
+        ),
         expected_current_tag="v0.8.0",
     )
 
@@ -1046,8 +1113,11 @@ def test_performance_doc_rejects_same_version_without_changing_outputs(tmp_path:
         benchmark_utils.render_and_promote_performance_artifacts(
             output=output,
             artifacts=artifacts,
-            current=current,
-            archive_dir=tmp_path / "docs" / "archive" / "performance",
+            destinations=benchmark_utils.PerformancePromotionDestinations(
+                project_root=tmp_path,
+                current=current,
+                archive_dir=tmp_path / "docs" / "archive" / "performance",
+            ),
             expected_current_tag="v0.8.0",
         )
 
@@ -1073,8 +1143,11 @@ def test_performance_doc_rejects_malformed_pair_without_changing_outputs(tmp_pat
         benchmark_utils.render_and_promote_performance_artifacts(
             output=output,
             artifacts=artifacts,
-            current=current,
-            archive_dir=tmp_path / "docs" / "archive" / "performance",
+            destinations=benchmark_utils.PerformancePromotionDestinations(
+                project_root=tmp_path,
+                current=current,
+                archive_dir=tmp_path / "docs" / "archive" / "performance",
+            ),
             expected_current_tag="v0.8.0",
         )
 
@@ -1094,8 +1167,11 @@ def test_performance_doc_rejects_stale_current_release_before_writing(tmp_path: 
         benchmark_utils.render_and_promote_performance_artifacts(
             output=output,
             artifacts=artifacts,
-            current=current,
-            archive_dir=tmp_path / "docs" / "archive" / "performance",
+            destinations=benchmark_utils.PerformancePromotionDestinations(
+                project_root=tmp_path,
+                current=current,
+                archive_dir=tmp_path / "docs" / "archive" / "performance",
+            ),
             expected_current_tag="v0.8.0",
         )
 
@@ -1117,8 +1193,11 @@ def test_performance_doc_rejects_zero_comparable_rows_before_writing(tmp_path: P
         benchmark_utils.render_and_promote_performance_artifacts(
             output=output,
             artifacts=artifacts,
-            current=tmp_path / "docs" / "PERFORMANCE.md",
-            archive_dir=tmp_path / "docs" / "archive" / "performance",
+            destinations=benchmark_utils.PerformancePromotionDestinations(
+                project_root=tmp_path,
+                current=tmp_path / "docs" / "PERFORMANCE.md",
+                archive_dir=tmp_path / "docs" / "archive" / "performance",
+            ),
             expected_current_tag="v0.8.0",
         )
 
@@ -1165,14 +1244,20 @@ def test_renderer_distinguishes_scratch_and_promoted_evidence_paths(tmp_path: Pa
         csv=tmp_path / "docs" / "archive" / "performance" / "data" / "v0.8.0-vs-v0.7.8.csv",
         provenance=tmp_path / "docs" / "archive" / "performance" / "data" / "v0.8.0-vs-v0.7.8.provenance.json",
     )
+    current = tmp_path / "docs" / "PERFORMANCE.md"
 
     scratch_report = benchmark_utils.render_performance_artifacts(scratch)
-    promoted_report = benchmark_utils.render_performance_bundle(performance_artifacts.load_bundle(scratch), evidence_paths=durable, evidence_state="promoted")
+    promoted_report = benchmark_utils.render_performance_bundle(
+        performance_artifacts.load_bundle(scratch),
+        evidence_paths=benchmark_utils._promoted_evidence_paths(durable, project_root=tmp_path),
+        evidence_state="promoted",
+    )
 
     assert "Retained scratch evidence" in scratch_report
     assert scratch.csv.as_posix() in scratch_report
     assert "Promoted evidence" in promoted_report
-    assert durable.csv.as_posix() in promoted_report
+    assert durable.csv.relative_to(tmp_path).as_posix() in promoted_report
+    assert durable.csv.as_posix() not in promoted_report
     assert scratch.csv.as_posix() not in promoted_report
 
 
@@ -4660,8 +4745,11 @@ class TestTimeoutHandling:
                 csv=tmp_path / "target" / "bench-reports" / "performance.csv",
                 provenance=tmp_path / "target" / "bench-reports" / "performance.provenance.json",
             ),
-            current=tmp_path / "docs" / "PERFORMANCE.md",
-            archive_dir=tmp_path / "docs" / "archive" / "performance",
+            destinations=benchmark_utils.PerformancePromotionDestinations(
+                project_root=tmp_path,
+                current=tmp_path / "docs" / "PERFORMANCE.md",
+                archive_dir=tmp_path / "docs" / "archive" / "performance",
+            ),
             expected_current_tag="v0.8.0",
         )
 

--- a/scripts/tests/test_check_docs_version_sync.py
+++ b/scripts/tests/test_check_docs_version_sync.py
@@ -53,6 +53,18 @@ def test_find_version_mismatches_accepts_matching_dependency_snippets(tmp_path: 
     assert check_docs_version_sync.find_version_mismatches(tmp_path) == []
 
 
+def test_find_version_mismatches_reports_single_quoted_dependency_snippets(tmp_path: Path) -> None:
+    """TOML literal-string dependency versions remain release-owned surfaces."""
+    _write_project(
+        tmp_path,
+        readme="delaunay = '1.2.2'\ndelaunay = { features = ['diagnostics'], version = '1.2.1' }\n",
+    )
+
+    mismatches = check_docs_version_sync.find_version_mismatches(tmp_path)
+
+    assert [mismatch.reference.version for mismatch in mismatches] == ["1.2.2", "1.2.1"]
+
+
 def test_find_version_mismatches_reports_stale_dependency_snippets(tmp_path: Path) -> None:
     """Stale active documentation snippets are reported with source context."""
     _write_project(tmp_path)
@@ -156,7 +168,7 @@ def test_readme_tag_references_reject_longer_non_semver_tags(tmp_path: Path, tag
     assert check_docs_version_sync._readme_tag_references(readme) == []
 
 
-@pytest.mark.parametrize("recipe", ["performance-github-assets", "performance-release", "perf-github-assets", "perf-release"])
+@pytest.mark.parametrize("recipe", ["performance-github-assets", "performance-release"])
 def test_find_version_mismatches_reports_stale_benchmark_current_tags(tmp_path: Path, recipe: str) -> None:
     """The first explicit benchmark release tag is the current release tag."""
     _write_project(tmp_path)
@@ -179,8 +191,8 @@ def test_find_version_mismatches_reports_stale_benchmark_current_tags(tmp_path: 
     assert mismatches[0].reference.version == "1.2.2"
 
 
-def test_benchmark_current_tag_references_ignore_baselines_and_historical_prose(tmp_path: Path) -> None:
-    """Only the current-tag argument is checked for benchmark examples."""
+def test_benchmark_current_tag_references_validate_pair_and_ignore_historical_prose(tmp_path: Path) -> None:
+    """A valid baseline relationship is checked without scanning historical prose."""
     benchmarking = tmp_path / "BENCHMARKING.md"
     benchmarking.write_text(
         "just performance-release v1.2.3 v1.2.2\nThe v1.2.2 harness compares against v1.2.1.\n",
@@ -190,6 +202,65 @@ def test_benchmark_current_tag_references_ignore_baselines_and_historical_prose(
     references = check_docs_version_sync._benchmark_current_tag_references(benchmarking)
 
     assert [(reference.line, reference.version) for reference in references] == [(1, "1.2.3")]
+
+
+@pytest.mark.parametrize("baseline", ["v1.2", "v1.2.3", "v1.2.4"])
+def test_find_version_mismatches_rejects_invalid_benchmark_baseline(tmp_path: Path, baseline: str) -> None:
+    """Malformed, equal, and newer benchmark baselines fail closed."""
+    _write_project(tmp_path)
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    workflow = docs / "workflow.md"
+    workflow.write_text(f"just performance-release v1.2.3 {baseline}\n", encoding="utf-8")
+
+    with pytest.raises(TypeError, match="benchmark baseline tag") as exc_info:
+        check_docs_version_sync.find_version_mismatches(tmp_path)
+
+    assert "workflow.md:1" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("current", ["1.2.3", "v1.2"])
+def test_find_version_mismatches_rejects_invalid_benchmark_current_tag(tmp_path: Path, current: str) -> None:
+    """Numeric current tags cannot evade stable vX.Y.Z parsing."""
+    _write_project(tmp_path)
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    workflow = docs / "workflow.md"
+    workflow.write_text(f"just performance-release {current} v1.2.2\n", encoding="utf-8")
+
+    with pytest.raises(TypeError, match="benchmark current tag") as exc_info:
+        check_docs_version_sync.find_version_mismatches(tmp_path)
+
+    assert "workflow.md:1" in str(exc_info.value)
+
+
+def test_find_version_mismatches_rejects_benchmark_command_missing_baseline(tmp_path: Path) -> None:
+    """A lone explicit current tag cannot evade the complete command contract."""
+    _write_project(tmp_path)
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    workflow = docs / "workflow.md"
+    workflow.write_text("`just performance-release v1.2.3`\n", encoding="utf-8")
+
+    with pytest.raises(TypeError, match="missing its baseline tag") as exc_info:
+        check_docs_version_sync.find_version_mismatches(tmp_path)
+
+    assert "workflow.md:1" in str(exc_info.value)
+
+
+def test_find_version_mismatches_leaves_performance_readme_links_to_their_owner(tmp_path: Path) -> None:
+    """Performance publication, not metadata updates, owns tagged evidence links."""
+    _write_project(
+        tmp_path,
+        readme=(
+            "[license](https://github.com/acgetchell/delaunay/blob/v1.2.3/LICENSE)\n"
+            "[report](https://github.com/acgetchell/delaunay/blob/v1.2.2/docs/PERFORMANCE.md)\n"
+            "[csv](https://github.com/acgetchell/delaunay/blob/v1.2.2/docs/assets/bench/release-performance.csv)\n"
+            "[provenance](https://github.com/acgetchell/delaunay/blob/v1.2.2/docs/archive/performance/data/v1.2.2-vs-v1.2.1.provenance.json)\n"
+        ),
+    )
+
+    assert check_docs_version_sync.find_version_mismatches(tmp_path) == []
 
 
 @pytest.mark.parametrize(
@@ -232,6 +303,18 @@ def test_find_version_mismatches_rejects_missing_editable_uv_package(tmp_path: P
     _write_project(tmp_path)
     (tmp_path / "uv.lock").write_text(
         'version = 1\n\n[[package]]\nname = "delaunay-scripts"\nversion = "1.2.3"\nsource = { registry = "https://pypi.org/simple" }\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(TypeError, match=r"exactly one uv\.lock editable package"):
+        check_docs_version_sync.find_version_mismatches(tmp_path)
+
+
+def test_find_version_mismatches_rejects_same_named_non_root_editable_uv_package(tmp_path: Path) -> None:
+    """A same-named package outside the repository root is not authoritative."""
+    _write_project(tmp_path)
+    (tmp_path / "uv.lock").write_text(
+        'version = 1\n\n[[package]]\nname = "delaunay-scripts"\nversion = "1.2.3"\nsource = { editable = "../other" }\n',
         encoding="utf-8",
     )
 
@@ -333,18 +416,38 @@ def test_release_date_must_match_generated_changelog_heading(tmp_path: Path) -> 
     assert "CHANGELOG.md:3" in message
 
 
-def test_release_date_rejects_missing_current_changelog_heading(tmp_path: Path) -> None:
-    """An existing changelog must contain exactly one current-version heading."""
+def test_release_date_allows_target_heading_before_changelog_generation(tmp_path: Path) -> None:
+    """Metadata can be bumped before changelog-unreleased generates its heading."""
     _write_project(tmp_path)
     (tmp_path / "CHANGELOG.md").write_text(
         "# Changelog\n\n## [1.2.2] - 2026-01-02\n",
         encoding="utf-8",
     )
 
-    with pytest.raises(TypeError, match=r"missing release heading for 1\.2\.3") as exc_info:
-        check_docs_version_sync.find_version_mismatches(tmp_path)
+    assert check_docs_version_sync.find_version_mismatches(tmp_path) == []
 
-    assert "CHANGELOG.md" in str(exc_info.value)
+
+def test_final_release_requires_current_changelog_heading(tmp_path: Path) -> None:
+    """The strict final gate rejects the tolerant pre-generation state."""
+    _write_project(tmp_path)
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [1.2.2] - 2026-01-02\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(TypeError, match="final release validation requires exactly one generated heading"):
+        check_docs_version_sync.find_version_mismatches(tmp_path, final_release=True)
+
+
+def test_final_release_accepts_exactly_one_matching_changelog_heading(tmp_path: Path) -> None:
+    """The strict final gate accepts one current heading with the citation date."""
+    _write_project(tmp_path)
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [1.2.3] - 2026-01-02\n",
+        encoding="utf-8",
+    )
+
+    assert check_docs_version_sync.find_version_mismatches(tmp_path, final_release=True) == []
 
 
 def test_release_date_rejects_malformed_current_changelog_heading(tmp_path: Path) -> None:
@@ -396,3 +499,13 @@ def test_main_prints_mismatches(tmp_path: Path, capsys: pytest.CaptureFixture[st
 
     assert exit_code == 1
     assert "Release-version references are out of sync" in capsys.readouterr().err
+
+
+def test_main_final_release_reports_missing_changelog_heading(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The CLI exposes strict final-release changelog validation."""
+    _write_project(tmp_path)
+
+    exit_code = check_docs_version_sync.main(["--final-release", str(tmp_path)])
+
+    assert exit_code == 1
+    assert "final release validation requires" in capsys.readouterr().err

--- a/scripts/tests/test_justfile_discoverability.py
+++ b/scripts/tests/test_justfile_discoverability.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+import shlex
 import shutil
 import subprocess
 from collections import defaultdict
@@ -111,7 +112,8 @@ def test_release_signal_benchmark_recipes_match_python_runner() -> None:
 def test_canonical_performance_recipes_share_the_cross_repository_contract() -> None:
     """Canonical release workflows should expose stable names and positional arguments."""
     recipes = just_recipes()
-    assert {"performance-local", "performance-release", "performance-doc", "performance-github-assets"} <= recipes.keys()
+    assert {"performance-local", "performance-release", "performance-readme", "performance-doc", "performance-github-assets"} <= recipes.keys()
+    assert {"perf-local", "perf-release", "perf-github-assets"}.isdisjoint(recipes)
 
     bench_parameters = recipes["bench-compare"]["parameters"]
     assert [parameter["name"] for parameter in bench_parameters] == ["baseline", "suite", "scope"]
@@ -129,8 +131,68 @@ def test_canonical_performance_recipes_share_the_cross_repository_contract() -> 
         command = run_just("--dry-run", name, "v0.8.0", "v0.7.8")
         rendered = command.stdout + command.stderr
         assert f'benchmark-utils {name} "$current_tag" "$baseline_tag"' in rendered
-        assert 'current_tag="v0.8.0"' in rendered
-        assert 'baseline_tag="v0.7.8"' in rendered
+        assert "current_tag='v0.8.0'" in rendered
+        assert "baseline_tag='v0.7.8'" in rendered
+
+    readme_command = run_just("--dry-run", "performance-readme")
+    assert "uv run --locked publish-readme-performance" in readme_command.stdout + readme_command.stderr
+
+
+def test_canonical_performance_recipes_shell_quote_tag_arguments() -> None:
+    """Tag arguments must remain data in public recipes and their shared helper."""
+    injected = 'v0.8.1"; printf injected; # '
+
+    for recipe in ("performance-github-assets", "performance-release", "_performance-tag-pair-state"):
+        command = run_just("--dry-run", recipe, injected, "v0.8.0")
+        rendered = command.stdout + command.stderr
+        current_assignment = next(line for line in rendered.splitlines() if line.startswith("current_tag="))
+        baseline_assignment = next(line for line in rendered.splitlines() if line.startswith("baseline_tag="))
+
+        assert shlex.split(current_assignment) == [f"current_tag={injected}"]
+        assert shlex.split(baseline_assignment) == ["baseline_tag=v0.8.0"]
+
+
+def test_release_metadata_recipe_uses_the_current_utc_date_internally() -> None:
+    """Release preparation accepts only the target tag from the caller."""
+    recipes = just_recipes()
+    parameters = recipes["update-version"]["parameters"]
+
+    assert [parameter["name"] for parameter in parameters] == ["tag"]
+    command = run_just("--dry-run", "update-version", "v0.8.1")
+    rendered = command.stdout + command.stderr
+    assert "update-release-version 'v0.8.1'" in rendered
+    assert "--release-date" not in rendered
+    assert "check-docs-version-sync" in rendered
+    assert "just update-version <tag>" in run_just().stdout
+
+
+def test_release_workflows_fail_closed_before_writes_or_tag_mutation() -> None:
+    """Release recipes should expose their non-mutating metadata gates."""
+    recipes = just_recipes()
+    strict_check = run_just("--dry-run", "release-version-check")
+    assert "check-docs-version-sync --final-release" in strict_check.stdout + strict_check.stderr
+
+    for name in ("tag", "tag-force"):
+        dependencies = {dependency["recipe"] for dependency in recipes[name]["dependencies"]}
+        assert "release-version-check" in dependencies
+
+        injected = "v0.8.0; echo INJECTED"
+        command = run_just("--dry-run", name, injected)
+        rendered = command.stdout + command.stderr
+        tag_command = next(line for line in rendered.splitlines() if line.startswith("uv run --locked tag-release "))
+        expected = ["uv", "run", "--locked", "tag-release", injected]
+        if name == "tag-force":
+            expected.append("--force")
+        assert shlex.split(tag_command) == expected
+
+    changelog = run_just("--dry-run", "changelog-unreleased", "v0.8.1")
+    rendered = changelog.stdout + changelog.stderr
+    metadata_index = rendered.index("cargo metadata --locked --format-version 1 --no-deps")
+    release_lookup_index = rendered.index('update-release-version "$version" --print-previous-release')
+    cliff_index = rendered.index('git-cliff --tag "$version" -o CHANGELOG.md')
+    assert metadata_index < release_lookup_index < cliff_index
+    assert '[[ "$version" != "v$package_version" ]]' in rendered
+    assert '--sync-changelog-date --previous-release "$previous_release"' in rendered
 
 
 def test_canonical_performance_recipes_reject_partial_tag_pairs_before_dispatch() -> None:
@@ -218,6 +280,27 @@ def test_uv_backed_recipes_reuse_pinned_guard() -> None:
         assert "_ensure-uv" in dependencies, name
 
 
+def test_setup_tools_closes_external_and_cargo_update_prerequisites() -> None:
+    """Setup should fail early on gh, then provision and verify its update helper."""
+    recipes = just_recipes()
+    dependencies = [dependency["recipe"] for dependency in recipes["setup-tools"]["dependencies"]]
+    body = json.dumps(recipes["setup-tools"]["body"])
+
+    assert dependencies == ["_ensure-cargo", "_ensure-chktex", "_ensure-gh", "_ensure-jq", "_ensure-rustup", "_ensure-uv"]
+    assert "External prerequisites that must already be on PATH: uv, gh, jq, rustup, cargo, and chktex." in body
+    assert "unpinned cargo-update bootstrap helper" in body
+    assert "cargo install --locked cargo-update" in body
+    assert "cmds=(uv gh jq" in body
+    assert "cmds+=(cargo-install-update" in body
+
+    setup_result = run_just("--dry-run", "setup-tools")
+    rendered = setup_result.stdout + setup_result.stderr
+    first_mutation = rendered.index("uv sync --locked --group dev")
+    for prerequisite in ("cargo", "chktex", "gh", "jq", "rustup"):
+        assert rendered.index(f"command -v {prerequisite}") < first_mutation
+    assert rendered.index("uv --version") < first_mutation
+
+
 def test_validation_and_benchmark_uv_runs_are_locked() -> None:
     """Validation guards and benchmark workflows must reject lockfile drift."""
     paths = (
@@ -273,21 +356,32 @@ def test_paper_workflow_tracks_validation_figure_producers() -> None:
 def test_update_workflow_composes_scoped_dependency_and_tool_updates() -> None:
     """Update recipes should cover repo state without touching unrelated global tools."""
     recipes = just_recipes()
-    update_dependencies = {dependency["recipe"] for dependency in recipes["update"]["dependencies"]}
+    update_dependencies = [dependency["recipe"] for dependency in recipes["update"]["dependencies"]]
 
-    assert update_dependencies == {"update-cargo-tools", "update-dependencies"}
+    assert update_dependencies == ["_ensure-cargo-install-update", "update-dependencies", "update-cargo-tools"]
+
+    aggregate_result = run_just("--dry-run", "update")
+    aggregate_update = aggregate_result.stdout + aggregate_result.stderr
+    assert aggregate_update.index("command -v cargo-install-update") < aggregate_update.index("cargo upgrade --incompatible allow")
 
     dependency_result = run_just("--dry-run", "update-dependencies")
     dependency_update = dependency_result.stdout + dependency_result.stderr
+    dependency_preflights = [dependency["recipe"] for dependency in recipes["update-dependencies"]["dependencies"]]
+    assert dependency_preflights[:2] == ["_ensure-cargo-edit", "_ensure-uv"]
+    assert dependency_update.index("cargo_tool_has_exact_version") < dependency_update.index("cargo upgrade --incompatible allow")
+    assert dependency_update.index("uv --version") < dependency_update.index("cargo upgrade --incompatible allow")
     assert "cargo upgrade --incompatible allow" in dependency_update
     assert "cargo update" in dependency_update
+    assert "uv run --locked update-python-dev-pins" in dependency_update
     assert "uv lock --upgrade" in dependency_update
+    assert dependency_update.index("uv run --locked update-python-dev-pins") < dependency_update.index("uv lock --upgrade")
     assert "uv sync --locked --group dev" in dependency_update
     assert "cargo install-update --all" not in dependency_update
     assert "uv tool upgrade" not in dependency_update
 
     tool_result = run_just("--dry-run", "update-cargo-tools")
     tool_update = tool_result.stdout + tool_result.stderr
+    assert "command -v cargo-install-update" in tool_update
     assert "cargo install-update --locked" in tool_update
     assert "update-cargo-tool-pins" in tool_update
     assert "cargo install-update --all" not in tool_update

--- a/scripts/tests/test_publish_readme_performance.py
+++ b/scripts/tests/test_publish_readme_performance.py
@@ -1,0 +1,379 @@
+"""Tests for README publication from retained performance evidence."""
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+import pytest
+
+import performance_artifacts
+import publish_readme_performance
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _bundle(
+    *,
+    current: str = "v0.8.1",
+    baseline: str = "v0.8.0",
+) -> performance_artifacts.PerformanceBundle:
+    host = performance_artifacts.HostIdentity(status="recorded", cpu="Test CPU", operating_system="Test OS", architecture="test")
+    toolchain = performance_artifacts.ToolchainState(
+        rustc="rustc 1.98.0",
+        criterion_version="0.7.0",
+        cargo_profile="perf",
+        cargo_lock_sha256="a" * 64,
+        harness_sha256="b" * 64,
+        configuration_sha256="c" * 64,
+        measurement_plan_sha256="d" * 64,
+    )
+    return performance_artifacts.PerformanceBundle(
+        context=performance_artifacts.ArtifactContext(
+            release=performance_artifacts.ReleasePair(current=current, baseline=baseline),
+            statistic="median",
+            suite="release-signal",
+            scope="release-signal",
+            measurement_mode="local-worktrees",
+            current_source=performance_artifacts.SourceState(
+                version=current,
+                commit="a" * 40,
+                ref="HEAD",
+                revision_timestamp="2026-08-23T12:00:00-07:00",
+                git_clean=False,
+                source_state_sha256="c" * 64,
+            ),
+            baseline_source=performance_artifacts.SourceState(
+                version=baseline,
+                commit="b" * 40,
+                ref=baseline,
+                revision_timestamp="2026-08-01T12:00:00-07:00",
+                git_clean=True,
+                source_state_sha256="d" * 64,
+            ),
+            current_commands=(("just", "bench-latest"),),
+            baseline_commands=(("cargo", "bench", "--save-baseline", baseline),),
+            current_completed_targets=performance_artifacts.RELEASE_SIGNAL_TARGETS,
+            baseline_completed_targets=performance_artifacts.RELEASE_SIGNAL_TARGETS,
+            current_acquisition_commands=(),
+            baseline_acquisition_commands=(),
+            current_toolchain=toolchain,
+            baseline_toolchain=toolchain,
+            current_measurement_host=host,
+            baseline_measurement_host=host,
+            current_artifact=performance_artifacts.MeasurementArtifact(
+                origin="local-run",
+                content_sha256="e" * 64,
+                sample_name="new",
+            ),
+            baseline_artifact=performance_artifacts.MeasurementArtifact(
+                origin="local-run",
+                content_sha256="f" * 64,
+                sample_name=baseline,
+            ),
+            publication_host=host,
+        ),
+        rows=(
+            performance_artifacts.PerformanceRow(
+                suite="release-signal",
+                scope="release-signal",
+                benchmark_id="validation/validate_3d/750",
+                group="validation",
+                benchmark="validate_3d/750",
+                coverage_status="comparable",
+                coverage_note="",
+                baseline=performance_artifacts.TimingEstimate(2_000_000.0, 1_800_000.0, 2_200_000.0, 0.95),
+                current=performance_artifacts.TimingEstimate(1_000_000.0, 900_000.0, 1_100_000.0, 0.95),
+            ),
+        ),
+    )
+
+
+def _write_project(root: Path, *, bundle: performance_artifacts.PerformanceBundle | None = None) -> performance_artifacts.ArtifactPaths:
+    retained = bundle or _bundle()
+    (root / "Cargo.toml").write_text('[package]\nname = "delaunay"\nversion = "0.8.1"\n', encoding="utf-8")
+    (root / "README.md").write_text(
+        "# Fixture\n\n<!-- PERFORMANCE_RELEASE_TABLE:BEGIN -->\n\nNo release comparison published.\n\n<!-- PERFORMANCE_RELEASE_TABLE:END -->\n",
+        encoding="utf-8",
+    )
+    source = performance_artifacts.ArtifactPaths(
+        csv=root / "target/bench-reports/performance.csv",
+        provenance=root / "target/bench-reports/performance.provenance.json",
+    )
+    performance_artifacts.write_bundle(source, retained)
+    archive_stem = f"{retained.context.release.current}-vs-{retained.context.release.baseline}"
+    durable = performance_artifacts.ArtifactPaths(
+        csv=root / "docs/archive/performance/data" / f"{archive_stem}.csv",
+        provenance=root / "docs/archive/performance/data" / f"{archive_stem}.provenance.json",
+    )
+    performance_artifacts.write_bundle(durable, retained)
+    report = publish_readme_performance.render_performance_bundle(
+        retained,
+        evidence_paths=performance_artifacts.ArtifactPaths(
+            csv=durable.csv.relative_to(root),
+            provenance=durable.provenance.relative_to(root),
+        ),
+        evidence_state="promoted",
+    )
+    (root / "docs/PERFORMANCE.md").write_text(report, encoding="utf-8")
+    return source
+
+
+def test_publish_readme_performance_uses_retained_bundle_without_measurement_commands(tmp_path: Path) -> None:
+    source = _write_project(tmp_path)
+
+    summary = publish_readme_performance.publish_readme_performance(tmp_path, artifacts=source, readme=tmp_path / "README.md")
+
+    assert summary.current_tag == "v0.8.1"
+    assert summary.baseline_tag == "v0.8.0"
+    assert summary.changed_paths
+    readme = (tmp_path / "README.md").read_text(encoding="utf-8")
+    assert "**v0.8.1 vs v0.8.0**" in readme
+    assert "| `validation` | 1 | 2.000x |" in readme
+    assert "blob/v0.8.1/docs/PERFORMANCE.md" in readme
+    assert "blob/v0.8.1/docs/assets/bench/release-performance.csv" in readme
+    published = performance_artifacts.ArtifactPaths(
+        csv=tmp_path / "docs/assets/bench/release-performance.csv",
+        provenance=tmp_path / "docs/assets/bench/release-performance.provenance.json",
+    )
+    assert published.csv.read_bytes() == source.csv.read_bytes()
+    assert published.provenance.read_bytes() == source.provenance.read_bytes()
+    assert performance_artifacts.load_bundle(published) == _bundle()
+
+
+def test_publish_readme_performance_is_content_idempotent(tmp_path: Path) -> None:
+    source = _write_project(tmp_path)
+
+    first = publish_readme_performance.publish_readme_performance(tmp_path, artifacts=source, readme=tmp_path / "README.md")
+    second = publish_readme_performance.publish_readme_performance(tmp_path, artifacts=source, readme=tmp_path / "README.md")
+
+    assert first.changed_paths
+    assert second.changed_paths == ()
+
+
+def test_promoted_report_validation_is_independent_of_checkout_path(tmp_path: Path) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+
+    _write_project(first)
+    _write_project(second)
+
+    first_report = (first / "docs/PERFORMANCE.md").read_text(encoding="utf-8")
+    second_report = (second / "docs/PERFORMANCE.md").read_text(encoding="utf-8")
+    assert first_report == second_report
+    assert str(first) not in first_report
+    assert str(second) not in second_report
+
+
+def test_publish_readme_performance_rejects_stale_current_release_before_writing(tmp_path: Path) -> None:
+    source = _write_project(tmp_path, bundle=_bundle(current="v0.8.0", baseline="v0.7.8"))
+    original = (tmp_path / "README.md").read_bytes()
+
+    with pytest.raises(ValueError, match=r"Cargo\.toml is v0\.8\.1"):
+        publish_readme_performance.publish_readme_performance(tmp_path, artifacts=source, readme=tmp_path / "README.md")
+
+    assert (tmp_path / "README.md").read_bytes() == original
+    assert not (tmp_path / "docs/assets/bench").exists()
+
+
+@pytest.mark.parametrize("artifact", ["csv", "provenance"])
+def test_publish_readme_performance_requires_exact_promoted_bundle(tmp_path: Path, artifact: str) -> None:
+    source = _write_project(tmp_path)
+    suffix = ".csv" if artifact == "csv" else ".provenance.json"
+    durable = tmp_path / "docs/archive/performance/data" / f"v0.8.1-vs-v0.8.0{suffix}"
+    durable.write_text(f"not the retained {artifact}\n", encoding="utf-8")
+    original = (tmp_path / "README.md").read_bytes()
+
+    with pytest.raises(ValueError, match="does not match the exact bundle"):
+        publish_readme_performance.publish_readme_performance(tmp_path, artifacts=source, readme=tmp_path / "README.md")
+
+    assert (tmp_path / "README.md").read_bytes() == original
+    assert not (tmp_path / "docs/assets/bench").exists()
+
+
+def test_publish_readme_performance_requires_promoted_report(tmp_path: Path) -> None:
+    source = _write_project(tmp_path)
+    report = tmp_path / "docs/PERFORMANCE.md"
+    report.unlink()
+    original = (tmp_path / "README.md").read_bytes()
+
+    with pytest.raises(ValueError, match=r"docs/PERFORMANCE\.md.*missing"):
+        publish_readme_performance.publish_readme_performance(tmp_path, artifacts=source)
+
+    assert (tmp_path / "README.md").read_bytes() == original
+    assert not (tmp_path / "docs/assets/bench").exists()
+
+
+def test_publish_readme_performance_rejects_stale_promoted_report(tmp_path: Path) -> None:
+    source = _write_project(tmp_path)
+    report = tmp_path / "docs/PERFORMANCE.md"
+    report.write_text(f"{report.read_text(encoding='utf-8')}\nstale\n", encoding="utf-8")
+    original = (tmp_path / "README.md").read_bytes()
+
+    with pytest.raises(ValueError, match="not the canonical rendering"):
+        publish_readme_performance.publish_readme_performance(tmp_path, artifacts=source)
+
+    assert (tmp_path / "README.md").read_bytes() == original
+    assert not (tmp_path / "docs/assets/bench").exists()
+
+
+@pytest.mark.parametrize("path_form", ["absolute", "traversal"])
+def test_main_rejects_external_readme_before_any_write(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    path_form: str,
+) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    source = _write_project(root)
+    outside = tmp_path / "README.md"
+    outside.write_text("outside repository\n", encoding="utf-8")
+    original = outside.read_bytes()
+
+    exit_code = publish_readme_performance.main(
+        [
+            "--root",
+            str(root),
+            "--artifact-csv",
+            str(source.csv),
+            "--artifact-provenance",
+            str(source.provenance),
+            "--readme",
+            str(outside) if path_form == "absolute" else "../README.md",
+        ]
+    )
+
+    assert exit_code == 1
+    assert "README destination must be contained" in capsys.readouterr().err
+    assert outside.read_bytes() == original
+    assert not (root / "docs/assets/bench").exists()
+
+
+def test_publish_readme_performance_rejects_symlinked_asset_destination(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    source = _write_project(root)
+    (root / "docs/assets").symlink_to(outside, target_is_directory=True)
+    original = (root / "README.md").read_bytes()
+
+    with pytest.raises(ValueError, match="asset destination must be contained"):
+        publish_readme_performance.publish_readme_performance(root, artifacts=source, readme=root / "README.md")
+
+    assert (root / "README.md").read_bytes() == original
+    assert list(outside.iterdir()) == []
+
+
+def test_geometric_mean_speedup_is_stable_for_reciprocal_extreme_ratios() -> None:
+    bundle = _bundle()
+    row = bundle.rows[0]
+    tiny = performance_artifacts.TimingEstimate(1e-308, 1e-308, 1e-308, 0.95)
+    huge = performance_artifacts.TimingEstimate(1e308, 1e308, 1e308, 0.95)
+    reciprocal = replace(
+        bundle,
+        rows=(
+            replace(row, benchmark_id="validation/extreme-fast", benchmark="extreme-fast", baseline=huge, current=tiny),
+            replace(row, benchmark_id="validation/extreme-slow", benchmark="extreme-slow", baseline=tiny, current=huge),
+        ),
+    )
+
+    block = publish_readme_performance.render_readme_block(reciprocal)
+
+    assert "| `validation` | 2 | 1.000x |" in block
+
+
+def test_publish_readme_performance_rolls_back_all_destinations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _write_project(tmp_path)
+    readme = tmp_path / "README.md"
+    original = readme.read_bytes()
+    real_write = publish_readme_performance._write_bytes_atomic
+    failed = False
+
+    def fail_once(path: Path, payload: bytes) -> None:
+        nonlocal failed
+        if path.name == "release-performance.provenance.json" and not failed:
+            failed = True
+            msg = "simulated publication failure"
+            raise OSError(msg)
+        real_write(path, payload)
+
+    monkeypatch.setattr(publish_readme_performance, "_write_bytes_atomic", fail_once)
+
+    with pytest.raises(OSError, match="simulated publication failure"):
+        publish_readme_performance.publish_readme_performance(tmp_path, artifacts=source, readme=readme)
+
+    assert readme.read_bytes() == original
+    assert not (tmp_path / "docs/assets/bench/release-performance.csv").exists()
+    assert not (tmp_path / "docs/assets/bench/release-performance.provenance.json").exists()
+
+
+def test_publish_readme_performance_rolls_back_post_write_validation_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _write_project(tmp_path)
+    readme = tmp_path / "README.md"
+    assets = tmp_path / "docs/assets/bench"
+    assets.mkdir(parents=True)
+    csv = assets / "release-performance.csv"
+    provenance = assets / "release-performance.provenance.json"
+    csv.write_bytes(b"old csv\n")
+    provenance.write_bytes(b"old provenance\n")
+    originals = {path: path.read_bytes() for path in (readme, csv, provenance)}
+    real_load = publish_readme_performance.load_bundle
+    calls = 0
+
+    def fail_published_readback(paths: performance_artifacts.ArtifactPaths) -> performance_artifacts.PerformanceBundle:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            msg = "simulated post-write validation failure"
+            raise ValueError(msg)
+        return real_load(paths)
+
+    monkeypatch.setattr(publish_readme_performance, "load_bundle", fail_published_readback)
+
+    with pytest.raises(ValueError, match="simulated post-write validation failure"):
+        publish_readme_performance.publish_readme_performance(tmp_path, artifacts=source, readme=readme)
+
+    assert {path: path.read_bytes() for path in originals} == originals
+
+
+def test_publish_readme_performance_reports_post_validation_and_rollback_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _write_project(tmp_path)
+    real_load = publish_readme_performance.load_bundle
+    real_write = publish_readme_performance._write_bytes_atomic
+    load_calls = 0
+    write_calls = 0
+
+    def fail_published_readback(paths: performance_artifacts.ArtifactPaths) -> performance_artifacts.PerformanceBundle:
+        nonlocal load_calls
+        load_calls += 1
+        if load_calls == 2:
+            msg = "simulated post-write validation failure"
+            raise ValueError(msg)
+        return real_load(paths)
+
+    def fail_first_rollback(path: Path, payload: bytes) -> None:
+        nonlocal write_calls
+        write_calls += 1
+        if write_calls == 4:
+            msg = "simulated rollback failure"
+            raise OSError(msg)
+        real_write(path, payload)
+
+    monkeypatch.setattr(publish_readme_performance, "load_bundle", fail_published_readback)
+    monkeypatch.setattr(publish_readme_performance, "_write_bytes_atomic", fail_first_rollback)
+
+    with pytest.raises(RuntimeError, match=r"post-write validation failure.*rollback also failed.*rollback failure"):
+        publish_readme_performance.publish_readme_performance(tmp_path, artifacts=source, readme=tmp_path / "README.md")

--- a/scripts/tests/test_publish_readme_performance.py
+++ b/scripts/tests/test_publish_readme_performance.py
@@ -207,6 +207,27 @@ def test_publish_readme_performance_requires_exact_promoted_bundle(tmp_path: Pat
     assert not (tmp_path / "docs/assets/bench").exists()
 
 
+@pytest.mark.parametrize("artifact", ["csv", "provenance"])
+def test_publish_readme_performance_rejects_external_durable_symlink(tmp_path: Path, artifact: str) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    source = _write_project(root)
+    suffix = ".csv" if artifact == "csv" else ".provenance.json"
+    durable = root / "docs/archive/performance/data" / f"v0.8.1-vs-v0.8.0{suffix}"
+    outside = tmp_path / f"outside{suffix}"
+    outside.write_bytes(durable.read_bytes())
+    durable.unlink()
+    durable.symlink_to(outside)
+    original = (root / "README.md").read_bytes()
+    label = "CSV" if artifact == "csv" else artifact
+
+    with pytest.raises(ValueError, match=rf"promoted performance {label}.*must be contained"):
+        publish_readme_performance.publish_readme_performance(root, artifacts=source)
+
+    assert (root / "README.md").read_bytes() == original
+    assert not (root / "docs/assets/bench").exists()
+
+
 def test_publish_readme_performance_requires_promoted_report(tmp_path: Path) -> None:
     source = _write_project(tmp_path)
     report = tmp_path / "docs/PERFORMANCE.md"
@@ -218,6 +239,24 @@ def test_publish_readme_performance_requires_promoted_report(tmp_path: Path) -> 
 
     assert (tmp_path / "README.md").read_bytes() == original
     assert not (tmp_path / "docs/assets/bench").exists()
+
+
+def test_publish_readme_performance_rejects_external_report_symlink(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    source = _write_project(root)
+    report = root / "docs/PERFORMANCE.md"
+    outside = tmp_path / "PERFORMANCE.md"
+    outside.write_bytes(report.read_bytes())
+    report.unlink()
+    report.symlink_to(outside)
+    original = (root / "README.md").read_bytes()
+
+    with pytest.raises(ValueError, match=r"promoted performance report.*must be contained"):
+        publish_readme_performance.publish_readme_performance(root, artifacts=source)
+
+    assert (root / "README.md").read_bytes() == original
+    assert not (root / "docs/assets/bench").exists()
 
 
 def test_publish_readme_performance_rejects_stale_promoted_report(tmp_path: Path) -> None:

--- a/scripts/tests/test_publish_readme_performance.py
+++ b/scripts/tests/test_publish_readme_performance.py
@@ -178,6 +178,21 @@ def test_publish_readme_performance_rejects_stale_current_release_before_writing
 
 
 @pytest.mark.parametrize("artifact", ["csv", "provenance"])
+def test_publish_readme_performance_requires_complete_promoted_bundle(tmp_path: Path, artifact: str) -> None:
+    source = _write_project(tmp_path)
+    suffix = ".csv" if artifact == "csv" else ".provenance.json"
+    durable = tmp_path / "docs/archive/performance/data" / f"v0.8.1-vs-v0.8.0{suffix}"
+    durable.unlink()
+    original = (tmp_path / "README.md").read_bytes()
+
+    with pytest.raises(ValueError, match=r"promoted performance evidence is missing: .*just performance-release"):
+        publish_readme_performance.publish_readme_performance(tmp_path, artifacts=source, readme=tmp_path / "README.md")
+
+    assert (tmp_path / "README.md").read_bytes() == original
+    assert not (tmp_path / "docs/assets/bench").exists()
+
+
+@pytest.mark.parametrize("artifact", ["csv", "provenance"])
 def test_publish_readme_performance_requires_exact_promoted_bundle(tmp_path: Path, artifact: str) -> None:
     source = _write_project(tmp_path)
     suffix = ".csv" if artifact == "csv" else ".provenance.json"

--- a/scripts/tests/test_tag_release.py
+++ b/scripts/tests/test_tag_release.py
@@ -1,12 +1,13 @@
 """Tests for tag_release.py — repo URL normalization and credential safety."""
 
 import subprocess
+from datetime import date
 from pathlib import PureWindowsPath
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tag_release import _get_repo_url, _package_version, create_tag, main, validate_semver
+from tag_release import _citation_release_date, _get_repo_url, _package_version, create_tag, main, validate_semver
 
 # ---------------------------------------------------------------------------
 # _get_repo_url
@@ -133,6 +134,8 @@ class TestCreateTag:
     def _matching_package_version(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Keep existing tag tests focused on their original contracts."""
         monkeypatch.setattr("tag_release._package_version", lambda _changelog: "1.2.3")
+        monkeypatch.setattr("tag_release._citation_release_date", lambda _changelog: date(2026, 8, 24))
+        monkeypatch.setattr("tag_release._current_utc_date", lambda: date(2026, 8, 24))
 
     def test_package_version_reads_adjacent_cargo_manifest(self, tmp_path) -> None:
         """The preflight source of truth is the package table beside the changelog."""
@@ -181,6 +184,29 @@ class TestCreateTag:
             _package_version(changelog)
 
         assert str(cargo_toml) in str(exc_info.value)
+
+    def test_citation_release_date_reads_one_valid_top_level_date(self, tmp_path) -> None:
+        """The tag preflight reads the intended publication day from citation metadata."""
+        changelog = tmp_path / "CHANGELOG.md"
+        (tmp_path / "CITATION.cff").write_text("date-released: '2026-08-24'\n", encoding="utf-8")
+
+        assert _citation_release_date(changelog) == date(2026, 8, 24)
+
+    @pytest.mark.parametrize(
+        ("citation", "message"),
+        [
+            ("title: example\n", "missing top-level date-released"),
+            ("date-released: 2026-02-30\n", "not a valid ISO date"),
+            ("date-released: 2026-08-24\ndate-released: 2026-08-25\n", "duplicate top-level date-released"),
+        ],
+    )
+    def test_citation_release_date_rejects_invalid_contracts(self, tmp_path, citation: str, message: str) -> None:
+        """Missing, impossible, or ambiguous publication dates fail closed."""
+        changelog = tmp_path / "CHANGELOG.md"
+        (tmp_path / "CITATION.cff").write_text(citation, encoding="utf-8")
+
+        with pytest.raises(ValueError, match=message):
+            _citation_release_date(changelog)
 
     def test_next_step_sets_release_title(
         self,
@@ -276,6 +302,24 @@ class TestCreateTag:
             create_tag("v1.2.3")
 
         mock_tag_exists.assert_not_called()
+
+    def test_rejects_stale_publication_date_before_git(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A release delayed across UTC midnight cannot create or replace a tag."""
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("# Changelog\n", encoding="utf-8")
+        mock_tag_exists = MagicMock()
+        mock_create_tag = MagicMock()
+        monkeypatch.setattr("tag_release.find_changelog", lambda: changelog)
+        monkeypatch.setattr("tag_release._citation_release_date", lambda _changelog: date(2026, 8, 23))
+        monkeypatch.setattr("tag_release._current_utc_date", lambda: date(2026, 8, 24))
+        monkeypatch.setattr("tag_release._tag_exists", mock_tag_exists)
+        monkeypatch.setattr("tag_release.run_git_command_with_input", mock_create_tag)
+
+        with pytest.raises(ValueError, match="does not match the current UTC date"):
+            create_tag("v1.2.3", force=True)
+
+        mock_tag_exists.assert_not_called()
+        mock_create_tag.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_update_python_dev_pins.py
+++ b/scripts/tests/test_update_python_dev_pins.py
@@ -78,6 +78,30 @@ def test_parse_resolution_rejects_missing_direct_tool() -> None:
         update_python_dev_pins.parse_resolution("mcp==1.29.0\n", pins)
 
 
+def test_resolve_latest_pins_preserves_retained_constraint_for_managed_distribution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(project_text("ruff==0.16.2", "ruff<0.17"), encoding="utf-8")
+    calls: list[tuple[str, list[str], dict[str, object]]] = []
+
+    def fake_run(command: str, args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((command, args, kwargs))
+        return subprocess.CompletedProcess([command, *args], 0, stdout="ruff==0.16.4\n", stderr="")
+
+    monkeypatch.setattr(update_python_dev_pins, "run_safe_command", fake_run)
+
+    resolved = update_python_dev_pins.resolve_latest_pins(
+        [update_python_dev_pins.DevPin("ruff", "0.16.2")],
+        "3.14",
+        tmp_path,
+    )
+
+    assert resolved == [update_python_dev_pins.DevPin("ruff", "0.16.4")]
+    assert calls[0][2]["input"] == "packaging>=26\nruff\nruff<0.17\n"
+
+
 def test_update_dev_pins_resolves_then_applies_one_exact_transaction(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -124,7 +148,7 @@ def test_update_dev_pins_resolves_then_applies_one_exact_transaction(
         ],
         {
             "cwd": tmp_path,
-            "input": "ruff\nsemgrep\n",
+            "input": "packaging>=26\npytest>=9.1\nruff\nsemgrep\nty~=0.0.66\n",
             "timeout": update_python_dev_pins.UV_PIP_COMPILE_TIMEOUT_SECONDS,
         },
     )
@@ -333,6 +357,36 @@ def test_main_rolls_back_manifest_and_lock_after_uv_add_timeout(
     assert "timed out after 300 seconds" in captured.err
     assert pyproject.read_text(encoding="utf-8") == original_manifest
     assert uv_lock.read_bytes() == original_lock
+
+
+def test_main_rejects_symlinked_lock_without_mutating_link_or_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    original_manifest = project_text("ruff==0.16.2")
+    pyproject.write_text(original_manifest, encoding="utf-8")
+    lock_target = tmp_path / "shared.lock"
+    original_lock = b"version = 1\n"
+    lock_target.write_bytes(original_lock)
+    uv_lock = tmp_path / "uv.lock"
+    uv_lock.symlink_to(lock_target.name)
+
+    def unexpected_uv(*_args: object, **_kwargs: object) -> None:
+        msg = "uv must not run with a symlinked lockfile"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(update_python_dev_pins, "run_safe_command", unexpected_uv)
+
+    assert update_python_dev_pins.main(["--pyproject", str(pyproject)]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "uv.lock must not be a symbolic link" in captured.err
+    assert uv_lock.is_symlink()
+    assert uv_lock.readlink().as_posix() == lock_target.name
+    assert lock_target.read_bytes() == original_lock
+    assert pyproject.read_text(encoding="utf-8") == original_manifest
 
 
 def test_main_reports_primary_and_rollback_failures_without_traceback(

--- a/scripts/tests/test_update_python_dev_pins.py
+++ b/scripts/tests/test_update_python_dev_pins.py
@@ -1,0 +1,363 @@
+"""Tests for resolver-backed Python development-tool pin updates."""
+
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+import update_python_dev_pins
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def project_text(*requirements: str) -> str:
+    """Return a minimal project with a mixed development requirement group."""
+    rendered = "\n".join(f'    "{requirement}",' for requirement in requirements)
+    return f"""[build-system]
+requires = ["setuptools>=83"]
+
+[project]
+name = "fixture"
+version = "0.1.0"
+requires-python = ">=3.14"
+dependencies = ["packaging>=26"]
+
+[dependency-groups]
+dev = [
+{rendered}
+]
+"""
+
+
+def test_parse_project_selects_only_exact_simple_dev_pins() -> None:
+    python_version, pins = update_python_dev_pins.parse_project(
+        project_text("pytest>=9.1", "ruff==0.16.2", "semgrep==1.172.0", "ty~=0.0.66"),
+    )
+
+    assert python_version == "3.14"
+    assert pins == [
+        update_python_dev_pins.DevPin("ruff", "0.16.2"),
+        update_python_dev_pins.DevPin("semgrep", "1.172.0"),
+    ]
+
+
+def test_parse_project_leaves_compound_and_wildcard_requirements_unmanaged() -> None:
+    python_version, pins = update_python_dev_pins.parse_project(
+        project_text("ruff==0.16.2,!=0.16.3", "semgrep==1.172.*", "ty==0.0.66; python_version >= '3.14'"),
+    )
+
+    assert python_version == "3.14"
+    assert pins == []
+
+
+def test_parse_project_accepts_group_without_exact_pins() -> None:
+    python_version, pins = update_python_dev_pins.parse_project(project_text("pytest>=9.1", "ruff~=0.16"))
+
+    assert python_version == "3.14"
+    assert pins == []
+
+
+def test_parse_resolution_preserves_direct_order_and_ignores_transitives() -> None:
+    pins = [
+        update_python_dev_pins.DevPin("ruff", "0.16.2"),
+        update_python_dev_pins.DevPin("semgrep", "1.172.0"),
+    ]
+    output = "packaging==26.3\nsemgrep==1.174.0\nruff==0.16.4\nmcp==1.29.0\n"
+
+    assert update_python_dev_pins.parse_resolution(output, pins) == [
+        update_python_dev_pins.DevPin("ruff", "0.16.4"),
+        update_python_dev_pins.DevPin("semgrep", "1.174.0"),
+    ]
+
+
+def test_parse_resolution_rejects_missing_direct_tool() -> None:
+    pins = [update_python_dev_pins.DevPin("semgrep", "1.172.0")]
+
+    with pytest.raises(ValueError, match="uv resolver output omitted direct development tool: semgrep"):
+        update_python_dev_pins.parse_resolution("mcp==1.29.0\n", pins)
+
+
+def test_update_dev_pins_resolves_then_applies_one_exact_transaction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    original = project_text("pytest>=9.1", "ruff==0.16.2", "semgrep==1.172.0", "ty~=0.0.66")
+    pyproject.write_text(original, encoding="utf-8")
+    uv_lock = tmp_path / "uv.lock"
+    uv_lock.write_text("version = 1\nruff = 0.16.2\nsemgrep = 1.172.0\n", encoding="utf-8")
+    calls: list[tuple[str, list[str], dict[str, object]]] = []
+
+    def fake_run(command: str, args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((command, args, kwargs))
+        if args[:2] == ["pip", "compile"]:
+            output = "ruff==0.16.4\nsemgrep==1.174.0\nmcp==1.29.0\n"
+        else:
+            pyproject.write_text(
+                pyproject.read_text(encoding="utf-8").replace("ruff==0.16.2", "ruff==0.16.4").replace("semgrep==1.172.0", "semgrep==1.174.0"),
+                encoding="utf-8",
+            )
+            uv_lock.write_text("version = 1\nruff = 0.16.4\nsemgrep = 1.174.0\n", encoding="utf-8")
+            output = ""
+        return subprocess.CompletedProcess([command, *args], 0, stdout=output, stderr="")
+
+    monkeypatch.setattr(update_python_dev_pins, "run_safe_command", fake_run)
+
+    changes = update_python_dev_pins.update_dev_pins(pyproject)
+
+    assert changes == {
+        "ruff": ("0.16.2", "0.16.4"),
+        "semgrep": ("1.172.0", "1.174.0"),
+    }
+    assert calls[0] == (
+        "uv",
+        [
+            "pip",
+            "compile",
+            "-",
+            "--universal",
+            "--no-header",
+            "--no-annotate",
+            "--python-version",
+            "3.14",
+        ],
+        {
+            "cwd": tmp_path,
+            "input": "ruff\nsemgrep\n",
+            "timeout": update_python_dev_pins.UV_PIP_COMPILE_TIMEOUT_SECONDS,
+        },
+    )
+    assert calls[1] == (
+        "uv",
+        ["add", "--dev", "--no-sync", "ruff==0.16.4", "semgrep==1.174.0"],
+        {"cwd": tmp_path, "timeout": update_python_dev_pins.UV_ADD_TIMEOUT_SECONDS},
+    )
+    assert uv_lock.read_text(encoding="utf-8") == "version = 1\nruff = 0.16.4\nsemgrep = 1.174.0\n"
+
+
+def test_update_dev_pins_rolls_back_collateral_manifest_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    original = project_text("pytest>=9.1", "ruff==0.16.2")
+    pyproject.write_text(original, encoding="utf-8")
+
+    def mutate_unmanaged_requirement(command: str, args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        if args[:2] == ["pip", "compile"]:
+            return subprocess.CompletedProcess([command, *args], 0, stdout="ruff==0.16.4\n", stderr="")
+        pyproject.write_text(original.replace("ruff==0.16.2", "ruff==0.16.4").replace("pytest>=9.1", "pytest>=9.2"), encoding="utf-8")
+        return subprocess.CompletedProcess([command, *args], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(update_python_dev_pins, "run_safe_command", mutate_unmanaged_requirement)
+
+    with pytest.raises(ValueError, match="changed non-target manifest content"):
+        update_python_dev_pins.update_dev_pins(pyproject)
+
+    assert pyproject.read_text(encoding="utf-8") == original
+
+
+def test_resolver_failure_leaves_manifest_unchanged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    original = project_text("pytest>=9.1", "ruff==0.16.2")
+    pyproject.write_text(original, encoding="utf-8")
+
+    def failed_uv(_command: str, args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(1, ["uv", *args], stderr="resolver conflict")
+
+    monkeypatch.setattr(update_python_dev_pins, "run_safe_command", failed_uv)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        update_python_dev_pins.update_dev_pins(pyproject)
+
+    assert pyproject.read_text(encoding="utf-8") == original
+
+
+def test_main_skips_uv_when_group_has_no_exact_pins(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(project_text("pytest>=9.1", "ruff~=0.16"), encoding="utf-8")
+
+    def unexpected_uv(*_args: object, **_kwargs: object) -> None:
+        msg = "uv must not run without exact pins"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(update_python_dev_pins, "run_safe_command", unexpected_uv)
+
+    assert update_python_dev_pins.main(["--pyproject", str(pyproject)]) == 0
+    assert capsys.readouterr().out == "No exact direct Python development-tool pins to update.\n"
+
+
+def test_main_reports_uv_diagnostics_without_traceback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(project_text("semgrep==1.172.0"), encoding="utf-8")
+
+    def failed_uv(_command: str, args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(1, ["uv", *args], stderr="resolver conflict")
+
+    monkeypatch.setattr(update_python_dev_pins, "run_safe_command", failed_uv)
+
+    assert update_python_dev_pins.main(["--pyproject", str(pyproject)]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "failed to update Python development-tool pins: resolver conflict\n"
+
+
+def test_main_uses_stdout_when_uv_stderr_is_empty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(project_text("semgrep==1.172.0"), encoding="utf-8")
+
+    def failed_uv(_command: str, args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(1, ["uv", *args], output="actionable resolver conflict", stderr="")
+
+    monkeypatch.setattr(update_python_dev_pins, "run_safe_command", failed_uv)
+
+    assert update_python_dev_pins.main(["--pyproject", str(pyproject)]) == 1
+    assert capsys.readouterr().err == "failed to update Python development-tool pins: actionable resolver conflict\n"
+
+
+def test_update_dev_pins_rejects_nonstandard_manifest_before_uv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = tmp_path / "release-tools.toml"
+    original = project_text("ruff==0.16.2")
+    manifest.write_text(original, encoding="utf-8")
+
+    def unexpected_uv(*_args: object, **_kwargs: object) -> None:
+        msg = "uv must not discover a sibling project for a nonstandard manifest"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(update_python_dev_pins, "run_safe_command", unexpected_uv)
+
+    with pytest.raises(ValueError, match=r"conventional pyproject\.toml"):
+        update_python_dev_pins.update_dev_pins(manifest)
+
+    assert manifest.read_text(encoding="utf-8") == original
+
+
+def test_update_dev_pins_rejects_uv_workspace_member_before_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root_manifest = tmp_path / "pyproject.toml"
+    root_manifest.write_text('[tool.uv.workspace]\nmembers = ["member"]\n', encoding="utf-8")
+    root_lock = tmp_path / "uv.lock"
+    root_lock.write_bytes(b"workspace lock\n")
+    member = tmp_path / "member"
+    member.mkdir()
+    member_manifest = member / "pyproject.toml"
+    member_manifest.write_text(project_text("ruff==0.16.2"), encoding="utf-8")
+
+    def unexpected_uv(*_args: object, **_kwargs: object) -> None:
+        msg = "uv must not run for a workspace member"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(update_python_dev_pins, "run_safe_command", unexpected_uv)
+
+    with pytest.raises(TypeError, match="must not select a uv workspace member"):
+        update_python_dev_pins.update_dev_pins(member_manifest)
+
+    assert root_lock.read_bytes() == b"workspace lock\n"
+    assert member_manifest.read_text(encoding="utf-8") == project_text("ruff==0.16.2")
+
+
+def test_main_reports_resolver_timeout_and_leaves_project_unchanged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    original = project_text("ruff==0.16.2")
+    pyproject.write_text(original, encoding="utf-8")
+
+    def timed_out(_command: str, args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        timeout = kwargs.get("timeout")
+        if not isinstance(timeout, int | float):
+            msg = "expected a finite subprocess timeout"
+            raise TypeError(msg)
+        raise subprocess.TimeoutExpired(["uv", *args], timeout)
+
+    monkeypatch.setattr(update_python_dev_pins, "run_safe_command", timed_out)
+
+    assert update_python_dev_pins.main(["--pyproject", str(pyproject)]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "timed out after 300 seconds" in captured.err
+    assert pyproject.read_text(encoding="utf-8") == original
+
+
+def test_main_rolls_back_manifest_and_lock_after_uv_add_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    original_manifest = project_text("ruff==0.16.2")
+    pyproject.write_text(original_manifest, encoding="utf-8")
+    uv_lock = tmp_path / "uv.lock"
+    original_lock = b"version = 1\n"
+    uv_lock.write_bytes(original_lock)
+
+    def time_out_after_mutation(command: str, args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if args[:2] == ["pip", "compile"]:
+            return subprocess.CompletedProcess([command, *args], 0, stdout="ruff==0.16.4\n", stderr="")
+        pyproject.write_text(original_manifest.replace("ruff==0.16.2", "ruff==0.16.4"), encoding="utf-8")
+        uv_lock.write_text("partially updated\n", encoding="utf-8")
+        timeout = kwargs.get("timeout")
+        if not isinstance(timeout, int | float):
+            msg = "expected a finite subprocess timeout"
+            raise TypeError(msg)
+        raise subprocess.TimeoutExpired(["uv", *args], timeout)
+
+    monkeypatch.setattr(update_python_dev_pins, "run_safe_command", time_out_after_mutation)
+
+    assert update_python_dev_pins.main(["--pyproject", str(pyproject)]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "timed out after 300 seconds" in captured.err
+    assert pyproject.read_text(encoding="utf-8") == original_manifest
+    assert uv_lock.read_bytes() == original_lock
+
+
+def test_main_reports_primary_and_rollback_failures_without_traceback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(project_text("ruff==0.16.2"), encoding="utf-8")
+
+    def fail_update(command: str, args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        if args[:2] == ["pip", "compile"]:
+            return subprocess.CompletedProcess([command, *args], 0, stdout="ruff==0.16.4\n", stderr="")
+        msg = "primary update failure"
+        raise OSError(msg)
+
+    def fail_restore(_snapshots: object) -> None:
+        msg = "rollback failure"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(update_python_dev_pins, "run_safe_command", fail_update)
+    monkeypatch.setattr(update_python_dev_pins, "_restore_snapshots", fail_restore)
+
+    assert update_python_dev_pins.main(["--pyproject", str(pyproject)]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "primary update failure" in captured.err
+    assert "rollback failure" in captured.err

--- a/scripts/tests/test_update_release_version.py
+++ b/scripts/tests/test_update_release_version.py
@@ -118,7 +118,7 @@ def test_update_release_version_is_content_idempotent_on_the_same_utc_day(tmp_pa
 def test_successful_update_preserves_crlf_line_endings(tmp_path: Path) -> None:
     _write_project(tmp_path)
     cargo_lock = tmp_path / "Cargo.lock"
-    cargo_lock.write_bytes(cargo_lock.read_bytes().replace(b"\n", b"\r\n"))
+    cargo_lock.write_bytes(cargo_lock.read_bytes().replace(b"\r\n", b"\n").replace(b"\n", b"\r\n"))
 
     summary = update_release_version.update_release_version(
         tmp_path,
@@ -135,7 +135,7 @@ def test_successful_update_preserves_crlf_line_endings(tmp_path: Path) -> None:
 def test_successful_update_preserves_crlf_benchmark_commands(tmp_path: Path) -> None:
     _write_project(tmp_path)
     benchmarking = tmp_path / "docs" / "BENCHMARKING.md"
-    benchmarking.write_bytes(benchmarking.read_bytes().replace(b"\n", b"\r\n"))
+    benchmarking.write_bytes(benchmarking.read_bytes().replace(b"\r\n", b"\n").replace(b"\n", b"\r\n"))
 
     summary = update_release_version.update_release_version(
         tmp_path,

--- a/scripts/tests/test_update_release_version.py
+++ b/scripts/tests/test_update_release_version.py
@@ -1,0 +1,558 @@
+"""Tests for transactional release-version updates."""
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+import check_docs_version_sync
+import update_release_version
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_CONCEPT_DOI = "10.5281/zenodo.16931097"
+
+
+@pytest.fixture(autouse=True)
+def _fixed_utc_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep release-date expectations deterministic unless a test advances UTC."""
+    monkeypatch.setattr(update_release_version, "_current_utc_date", lambda: "2026-08-20")
+
+
+def _write_project(root: Path, *, metadata_version: str = "1.2.2", dependency_version: str = "1.2.2") -> None:
+    files = {
+        "Cargo.toml": f'[package]\nname = "delaunay"\nversion = "{metadata_version}"\n',
+        "Cargo.lock": (f'version = 4\n\n[[package]]\nname = "either"\nversion = "1.17.0"\n\n[[package]]\nname = "delaunay"\nversion = "{metadata_version}"\n'),
+        "pyproject.toml": (
+            f'[project]\nname = "delaunay-scripts"\nversion = "{metadata_version}"\nrequires-python = ">=3.14"\n\n[dependency-groups]\ndev = ["pytest>=9"]\n'
+        ),
+        "uv.lock": (f'version = 1\n\n[[package]]\nname = "delaunay-scripts"\nversion = "{metadata_version}"\nsource = {{ editable = "." }}\n'),
+        "CITATION.cff": (f'cff-version: 1.2.0\nversion: {metadata_version}\ndate-released: 2026-07-13\ndoi: "{_CONCEPT_DOI}"\n'),
+        "README.md": (
+            f"cargo add delaunay@{dependency_version}\n"
+            f'delaunay = "{dependency_version}"\n'
+            f'delaunay = {{ version = "{dependency_version}", features = ["diagnostics"] }}\n'
+            f"[license](https://github.com/acgetchell/delaunay/blob/v{metadata_version}/LICENSE)\n"
+            f"[performance](https://github.com/acgetchell/delaunay/blob/v{metadata_version}/docs/PERFORMANCE.md)\n"
+            f"[csv](https://github.com/acgetchell/delaunay/blob/v{metadata_version}/docs/assets/bench/release-performance.csv)\n"
+        ),
+        "CHANGELOG.md": "# Changelog\n\n## [1.2.2] - 2026-07-13\n",
+    }
+    for filename, content in files.items():
+        (root / filename).write_text(content, encoding="utf-8")
+    docs = root / "docs"
+    docs.mkdir()
+    (docs / "BENCHMARKING.md").write_text(
+        "just performance-release v1.2.2 v1.2.1\nHistorical v1.2.1 behavior remains documented.\n",
+        encoding="utf-8",
+    )
+
+
+def _previous() -> update_release_version.ReleaseTag:
+    return update_release_version.parse_release_tag("v1.2.2")
+
+
+def _file_snapshots(root: Path) -> dict[Path, bytes]:
+    return {path: path.read_bytes() for path in root.rglob("*") if path.is_file()}
+
+
+def test_update_release_version_updates_current_surfaces_without_dependency_upgrades(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+
+    summary = update_release_version.update_release_version(
+        tmp_path,
+        "v1.2.3",
+        previous=_previous(),
+    )
+
+    assert summary.target.tag == "v1.2.3"
+    assert summary.previous.tag == "v1.2.2"
+    assert summary.release_date == "2026-08-20"
+    assert summary.changed_paths
+    assert 'name = "either"\nversion = "1.17.0"' in (tmp_path / "Cargo.lock").read_text(encoding="utf-8")
+    assert 'name = "delaunay"\nversion = "1.2.3"' in (tmp_path / "Cargo.lock").read_text(encoding="utf-8")
+    assert 'name = "delaunay-scripts"\nversion = "1.2.3"' in (tmp_path / "uv.lock").read_text(encoding="utf-8")
+    citation = (tmp_path / "CITATION.cff").read_text(encoding="utf-8")
+    assert "version: 1.2.3" in citation
+    assert "date-released: 2026-08-20" in citation
+    assert f'doi: "{_CONCEPT_DOI}"' in citation
+    readme = (tmp_path / "README.md").read_text(encoding="utf-8")
+    assert "cargo add delaunay@1.2.3" in readme
+    assert 'delaunay = "1.2.3"' in readme
+    assert 'version = "1.2.3"' in readme
+    assert "blob/v1.2.3/LICENSE" in readme
+    assert "blob/v1.2.2/docs/PERFORMANCE.md" in readme
+    assert "blob/v1.2.2/docs/assets/bench/release-performance.csv" in readme
+    benchmarking = (tmp_path / "docs" / "BENCHMARKING.md").read_text(encoding="utf-8")
+    assert "just performance-release v1.2.3 v1.2.2" in benchmarking
+    assert "Historical v1.2.1 behavior remains documented." in benchmarking
+    assert "## [1.2.2] - 2026-07-13" in (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert check_docs_version_sync.find_version_mismatches(tmp_path) == []
+
+
+def test_update_release_version_updates_single_quoted_dependency_snippets(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    readme = tmp_path / "README.md"
+    readme.write_text("delaunay = '1.2.2'\ndelaunay = { version = '1.2.2', features = ['diagnostics'] }\n", encoding="utf-8")
+
+    update_release_version.update_release_version(
+        tmp_path,
+        "v1.2.3",
+        previous=_previous(),
+    )
+
+    assert readme.read_text(encoding="utf-8") == "delaunay = '1.2.3'\ndelaunay = { version = '1.2.3', features = ['diagnostics'] }\n"
+
+
+def test_update_release_version_is_content_idempotent_on_the_same_utc_day(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    kwargs = {"previous": _previous()}
+
+    first = update_release_version.update_release_version(tmp_path, "v1.2.3", **kwargs)
+    second = update_release_version.update_release_version(tmp_path, "v1.2.3", **kwargs)
+
+    assert first.changed_paths
+    assert second.changed_paths == ()
+
+
+def test_successful_update_preserves_crlf_line_endings(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    cargo_lock = tmp_path / "Cargo.lock"
+    cargo_lock.write_bytes(cargo_lock.read_bytes().replace(b"\n", b"\r\n"))
+
+    summary = update_release_version.update_release_version(
+        tmp_path,
+        "v1.2.3",
+        previous=_previous(),
+    )
+
+    content = cargo_lock.read_bytes()
+    assert cargo_lock in summary.changed_paths
+    assert b'\r\nname = "delaunay"\r\nversion = "1.2.3"\r\n' in content
+    assert b"\n" not in content.replace(b"\r\n", b"")
+
+
+def test_update_release_version_advances_existing_release_dates_together(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_project(tmp_path, metadata_version="1.2.3", dependency_version="1.2.3")
+    citation = tmp_path / "CITATION.cff"
+    citation.write_text(citation.read_text(encoding="utf-8").replace("2026-07-13", "2026-08-20"), encoding="utf-8")
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n\n## [1.2.3] - 2026-08-20\n", encoding="utf-8")
+    benchmarking = tmp_path / "docs" / "BENCHMARKING.md"
+    benchmarking.write_text("just performance-release v1.2.3 v1.2.2\n", encoding="utf-8")
+    monkeypatch.setattr(update_release_version, "_current_utc_date", lambda: "2026-08-21")
+
+    summary = update_release_version.update_release_version(
+        tmp_path,
+        "v1.2.3",
+        previous=_previous(),
+    )
+
+    assert summary.changed_paths == (changelog, citation)
+    assert "date-released: 2026-08-21" in citation.read_text(encoding="utf-8")
+    assert "## [1.2.3] - 2026-08-21" in changelog.read_text(encoding="utf-8")
+
+
+def test_select_previous_release_tag_uses_latest_stable_published_tag() -> None:
+    target = update_release_version.parse_release_tag("v1.3.0")
+
+    previous = update_release_version.select_previous_release_tag(
+        ["v1.1.9", "v1.2.0-rc.1", "not-a-release", "v1.2.0"],
+        target,
+    )
+
+    assert previous.tag == "v1.2.0"
+
+
+def test_select_previous_release_tag_ignores_already_published_target() -> None:
+    target = update_release_version.parse_release_tag("v1.3.0")
+
+    previous = update_release_version.select_previous_release_tag(["v1.2.0", "v1.3.0"], target)
+
+    assert previous.tag == "v1.2.0"
+
+
+@pytest.mark.parametrize("target", ["1.2.3", "v1.2", "v01.2.3", "v1.2.3-rc.1"])
+def test_parse_release_tag_rejects_non_stable_tag_forms(target: str) -> None:
+    with pytest.raises(ValueError, match=r"stable tag in vX\.Y\.Z form"):
+        update_release_version.parse_release_tag(target)
+
+
+def test_release_tag_direct_construction_rejects_contradictory_components() -> None:
+    with pytest.raises(ValueError, match="contradict emitted tag"):
+        update_release_version.ReleaseTag(major=1, minor=2, patch=2, tag="v1.2.3")
+
+
+def test_select_previous_release_tag_rejects_missing_history() -> None:
+    target = update_release_version.parse_release_tag("v1.2.3")
+
+    with pytest.raises(ValueError, match="no published stable"):
+        update_release_version.select_previous_release_tag([], target)
+
+
+def test_select_previous_release_tag_rejects_target_older_than_published_release() -> None:
+    target = update_release_version.parse_release_tag("v1.2.3")
+
+    with pytest.raises(ValueError, match="older than published"):
+        update_release_version.select_previous_release_tag(["v1.2.3", "v1.3.0"], target)
+
+
+def test_infer_previous_release_tag_uses_published_github_releases(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_release_version, "published_stable_release_tags", lambda root: ["v1.2.1", "v1.2.2"] if root == tmp_path else [])
+
+    previous = update_release_version.infer_previous_release_tag(tmp_path, update_release_version.parse_release_tag("v1.2.3"))
+
+    assert previous.tag == "v1.2.2"
+
+
+def test_unexpected_version_fails_before_writing(tmp_path: Path) -> None:
+    _write_project(tmp_path, dependency_version="1.0.0")
+    originals = {path: path.read_text(encoding="utf-8") for path in tmp_path.rglob("*") if path.is_file()}
+
+    with pytest.raises(ValueError, match="unexpected delaunay dependency version"):
+        update_release_version.update_release_version(
+            tmp_path,
+            "v1.2.3",
+            previous=_previous(),
+        )
+
+    assert {path: path.read_text(encoding="utf-8") for path in originals} == originals
+
+
+@pytest.mark.parametrize("baseline", ["v1.2", "v1.2.2", "v1.2.4"])
+def test_invalid_benchmark_baseline_fails_before_writing(tmp_path: Path, baseline: str) -> None:
+    _write_project(tmp_path)
+    workflow = tmp_path / "docs/BENCHMARKING.md"
+    workflow.write_text(f"just performance-release v1.2.2 {baseline}\n", encoding="utf-8")
+    originals = _file_snapshots(tmp_path)
+
+    with pytest.raises(ValueError, match="benchmark baseline"):
+        update_release_version.update_release_version(
+            tmp_path,
+            "v1.2.3",
+            previous=_previous(),
+        )
+
+    assert _file_snapshots(tmp_path) == originals
+
+
+def test_nonadjacent_target_benchmark_baseline_fails_before_writing(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    workflow = tmp_path / "docs/BENCHMARKING.md"
+    workflow.write_text("just performance-release v1.2.3 v1.2.1\n", encoding="utf-8")
+    originals = _file_snapshots(tmp_path)
+
+    with pytest.raises(ValueError, match=r"non-adjacent benchmark pair.*expected baseline v1\.2\.2"):
+        update_release_version.update_release_version(
+            tmp_path,
+            "v1.2.3",
+            previous=_previous(),
+        )
+
+    assert _file_snapshots(tmp_path) == originals
+
+
+@pytest.mark.parametrize("current", ["1.2.2", "v1.2"])
+def test_malformed_benchmark_current_tag_fails_before_writing(tmp_path: Path, current: str) -> None:
+    _write_project(tmp_path)
+    workflow = tmp_path / "docs/BENCHMARKING.md"
+    workflow.write_text(f"just performance-release {current} v1.2.1\n", encoding="utf-8")
+    originals = _file_snapshots(tmp_path)
+
+    with pytest.raises(ValueError, match="benchmark current tag"):
+        update_release_version.update_release_version(
+            tmp_path,
+            "v1.2.3",
+            previous=_previous(),
+        )
+
+    assert _file_snapshots(tmp_path) == originals
+
+
+def test_benchmark_command_missing_baseline_fails_before_writing(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    workflow = tmp_path / "docs/BENCHMARKING.md"
+    workflow.write_text("`just performance-release v1.2.2`\n", encoding="utf-8")
+    originals = _file_snapshots(tmp_path)
+
+    with pytest.raises(ValueError, match="missing the baseline tag"):
+        update_release_version.update_release_version(
+            tmp_path,
+            "v1.2.3",
+            previous=_previous(),
+        )
+
+    assert _file_snapshots(tmp_path) == originals
+
+
+def test_non_root_editable_uv_package_fails_before_writing(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    uv_lock = tmp_path / "uv.lock"
+    uv_lock.write_text(
+        'version = 1\n\n[[package]]\nname = "delaunay-scripts"\nversion = "1.2.2"\nsource = { editable = "../other" }\n',
+        encoding="utf-8",
+    )
+    originals = _file_snapshots(tmp_path)
+
+    with pytest.raises(TypeError, match=r"exactly one uv\.lock editable package"):
+        update_release_version.update_release_version(
+            tmp_path,
+            "v1.2.3",
+            previous=_previous(),
+        )
+
+    assert _file_snapshots(tmp_path) == originals
+
+
+def test_validation_failure_precedes_every_repository_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_project(tmp_path)
+    originals = {path: path.read_text(encoding="utf-8") for path in tmp_path.rglob("*") if path.is_file()}
+    writes: list[Path] = []
+
+    def fail_validation(*_args: object) -> None:
+        msg = "simulated validation failure"
+        raise ValueError(msg)
+
+    def record_write(path: Path, text: str) -> None:
+        writes.append(path)
+        path.write_text(text, encoding="utf-8")
+
+    monkeypatch.setattr(update_release_version, "_validate_updated_root", fail_validation)
+    monkeypatch.setattr(update_release_version, "_write_text_atomic", record_write)
+
+    with pytest.raises(ValueError, match="simulated validation failure"):
+        update_release_version.update_release_version(
+            tmp_path,
+            "v1.2.3",
+            previous=_previous(),
+        )
+
+    assert writes == []
+    assert {path: path.read_text(encoding="utf-8") for path in originals} == originals
+
+
+def test_mid_write_failure_rolls_back_every_release_surface(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_project(tmp_path)
+    originals = _file_snapshots(tmp_path)
+    real_write = update_release_version._write_text_atomic
+    calls = 0
+
+    def fail_second_write(path: Path, text: str) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            msg = "simulated mid-write failure"
+            raise OSError(msg)
+        real_write(path, text)
+
+    monkeypatch.setattr(update_release_version, "_write_text_atomic", fail_second_write)
+
+    with pytest.raises(OSError, match="simulated mid-write failure"):
+        update_release_version.update_release_version(
+            tmp_path,
+            "v1.2.3",
+            previous=_previous(),
+        )
+
+    assert _file_snapshots(tmp_path) == originals
+
+
+def test_mid_write_failure_restores_original_crlf_bytes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_project(tmp_path)
+    cargo_lock = tmp_path / "Cargo.lock"
+    cargo_lock.write_bytes(cargo_lock.read_bytes().replace(b"\n", b"\r\n"))
+    originals = _file_snapshots(tmp_path)
+    real_write = update_release_version._write_text_atomic
+    calls = 0
+
+    def fail_second_write(path: Path, text: str) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            msg = "simulated mid-write failure"
+            raise OSError(msg)
+        real_write(path, text)
+
+    monkeypatch.setattr(update_release_version, "_write_text_atomic", fail_second_write)
+
+    with pytest.raises(OSError, match="simulated mid-write failure"):
+        update_release_version.update_release_version(
+            tmp_path,
+            "v1.2.3",
+            previous=_previous(),
+        )
+
+    assert _file_snapshots(tmp_path) == originals
+
+
+def test_post_write_validation_failure_rolls_back_every_release_surface(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_project(tmp_path)
+    originals = _file_snapshots(tmp_path)
+    real_validate = update_release_version._validate_updated_root
+    calls = 0
+
+    def fail_final_validation(root: Path, target: update_release_version.ReleaseTag, previous: update_release_version.ReleaseTag) -> None:
+        nonlocal calls
+        calls += 1
+        real_validate(root, target, previous)
+        if calls == 2:
+            msg = "simulated post-write validation failure"
+            raise ValueError(msg)
+
+    monkeypatch.setattr(update_release_version, "_validate_updated_root", fail_final_validation)
+
+    with pytest.raises(ValueError, match="simulated post-write validation failure"):
+        update_release_version.update_release_version(
+            tmp_path,
+            "v1.2.3",
+            previous=_previous(),
+        )
+
+    assert _file_snapshots(tmp_path) == originals
+
+
+def test_rollback_failure_reports_primary_and_restore_errors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_project(tmp_path)
+    real_write = update_release_version._write_text_atomic
+    calls = 0
+
+    def fail_rollback(_path: Path, _content: bytes) -> None:
+        msg = "simulated rollback failure"
+        raise OSError(msg)
+
+    def fail_second_write(path: Path, text: str) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            monkeypatch.setattr(update_release_version, "_write_bytes_atomic", fail_rollback)
+            msg = "simulated primary write failure"
+            raise OSError(msg)
+        real_write(path, text)
+
+    monkeypatch.setattr(update_release_version, "_write_text_atomic", fail_second_write)
+
+    with pytest.raises(RuntimeError, match=r"simulated primary write failure.*rollback also failed.*simulated rollback failure"):
+        update_release_version.update_release_version(
+            tmp_path,
+            "v1.2.3",
+            previous=_previous(),
+        )
+
+
+def test_sync_changelog_release_date_uses_citation_date(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    update_release_version.update_release_version(
+        tmp_path,
+        "v1.2.3",
+        previous=_previous(),
+    )
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n\n## [1.2.3] - 2026-08-21\n", encoding="utf-8")
+
+    changed, release_date = update_release_version.sync_changelog_release_date(
+        tmp_path,
+        "v1.2.3",
+        previous=_previous(),
+    )
+
+    assert changed == (changelog,)
+    assert release_date == "2026-08-20"
+    assert "## [1.2.3] - 2026-08-20" in changelog.read_text(encoding="utf-8")
+    assert check_docs_version_sync.find_version_mismatches(tmp_path) == []
+
+
+def test_main_supports_help(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit, match="0"):
+        update_release_version.main(["--help"])
+
+    assert "Target stable release tag" in capsys.readouterr().out
+
+
+def test_main_prints_previous_release_without_mutating_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_project(tmp_path)
+    originals = _file_snapshots(tmp_path)
+    monkeypatch.setattr(update_release_version, "published_stable_release_tags", lambda root: ["v1.2.1", "v1.2.2"] if root == tmp_path else [])
+
+    assert update_release_version.main(["v1.2.3", "--root", str(tmp_path), "--print-previous-release"]) == 0
+    assert capsys.readouterr().out == "v1.2.2\n"
+    assert _file_snapshots(tmp_path) == originals
+
+
+def test_previous_release_preflight_failure_leaves_files_unchanged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_project(tmp_path)
+    originals = _file_snapshots(tmp_path)
+
+    def fail_lookup(*_args: object) -> update_release_version.ReleaseTag:
+        msg = "GitHub release lookup failed"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(update_release_version, "infer_previous_release_tag", fail_lookup)
+
+    assert update_release_version.main(["v1.2.3", "--root", str(tmp_path), "--print-previous-release"]) == 1
+    assert "GitHub release lookup failed" in capsys.readouterr().err
+    assert _file_snapshots(tmp_path) == originals
+
+
+def test_main_uses_preflighted_previous_release_without_remote_lookup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_project(tmp_path)
+
+    def unexpected_lookup(*_args: object) -> None:
+        msg = "published release lookup must not repeat after preflight"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(update_release_version, "infer_previous_release_tag", unexpected_lookup)
+
+    assert (
+        update_release_version.main(
+            [
+                "v1.2.3",
+                "--root",
+                str(tmp_path),
+                "--previous-release",
+                "v1.2.2",
+            ]
+        )
+        == 0
+    )
+
+
+def test_main_retries_are_idempotent_on_the_same_utc_day(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_project(tmp_path)
+
+    def fixed_previous(root: Path, target: update_release_version.ReleaseTag) -> update_release_version.ReleaseTag:
+        assert root == tmp_path
+        assert target.tag == "v1.2.3"
+        return _previous()
+
+    monkeypatch.setattr(update_release_version, "infer_previous_release_tag", fixed_previous)
+    argv = ["v1.2.3", "--root", str(tmp_path)]
+
+    assert update_release_version.main(argv) == 0
+    after_first = _file_snapshots(tmp_path)
+    assert update_release_version.main(argv) == 0
+
+    assert _file_snapshots(tmp_path) == after_first
+    output = capsys.readouterr().out
+    assert "CITATION.cff UTC release date: 2026-08-20" in output
+    assert "Release-version references already match v1.2.3." in output

--- a/scripts/tests/test_update_release_version.py
+++ b/scripts/tests/test_update_release_version.py
@@ -132,6 +132,23 @@ def test_successful_update_preserves_crlf_line_endings(tmp_path: Path) -> None:
     assert b"\n" not in content.replace(b"\r\n", b"")
 
 
+def test_successful_update_preserves_crlf_benchmark_commands(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    benchmarking = tmp_path / "docs" / "BENCHMARKING.md"
+    benchmarking.write_bytes(benchmarking.read_bytes().replace(b"\n", b"\r\n"))
+
+    summary = update_release_version.update_release_version(
+        tmp_path,
+        "v1.2.3",
+        previous=_previous(),
+    )
+
+    content = benchmarking.read_bytes()
+    assert benchmarking in summary.changed_paths
+    assert b"just performance-release v1.2.3 v1.2.2\r\n" in content
+    assert b"\n" not in content.replace(b"\r\n", b"")
+
+
 def test_update_release_version_advances_existing_release_dates_together(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/scripts/update_python_dev_pins.py
+++ b/scripts/update_python_dev_pins.py
@@ -128,9 +128,59 @@ def parse_resolution(output: str, pins: list[DevPin]) -> list[DevPin]:
     return latest
 
 
+def _resolution_requirements(text: str, pins: list[DevPin]) -> str:
+    """Return project and retained dev constraints with managed pins unpinned."""
+    data = tomllib.loads(text)
+    project = _required_table(data, "project")
+    dependencies = project.get("dependencies", [])
+    if not isinstance(dependencies, list):
+        msg = "project.dependencies must be an array"
+        raise TypeError(msg)
+
+    requirements: list[str] = []
+    for dependency in dependencies:
+        if not isinstance(dependency, str):
+            msg = "project.dependencies entries must be strings"
+            raise TypeError(msg)
+        requirements.append(dependency)
+
+    groups = _required_table(data, "dependency-groups")
+    dev = groups.get("dev")
+    if not isinstance(dev, list):
+        msg = "dependency-groups.dev must be an array"
+        raise TypeError(msg)
+    managed = {canonicalize_name(pin.name): pin for pin in pins}
+    for raw_requirement in dev:
+        if not isinstance(raw_requirement, str):
+            msg = "dependency-groups.dev entries must be strings"
+            raise TypeError(msg)
+        try:
+            requirement = Requirement(raw_requirement)
+        except InvalidRequirement as error:
+            msg = f"dependency-groups.dev contains an invalid requirement: {raw_requirement!r}"
+            raise ValueError(msg) from error
+        specifiers = list(requirement.specifier)
+        pin = managed.get(canonicalize_name(requirement.name))
+        if (
+            pin is not None
+            and not requirement.extras
+            and requirement.marker is None
+            and requirement.url is None
+            and len(specifiers) == 1
+            and specifiers[0].operator == "=="
+            and "*" not in specifiers[0].version
+            and specifiers[0].version == pin.version
+        ):
+            requirements.append(pin.name)
+        else:
+            requirements.append(raw_requirement)
+    return "".join(f"{requirement}\n" for requirement in requirements)
+
+
 def resolve_latest_pins(pins: list[DevPin], python_version: str, project_root: Path) -> list[DevPin]:
     """Resolve the latest mutually compatible cross-platform set without writes."""
-    requirements = "".join(f"{pin.name}\n" for pin in pins)
+    manifest = project_root / "pyproject.toml"
+    requirements = _resolution_requirements(manifest.read_text(encoding="utf-8"), pins)
     result = run_safe_command(
         "uv",
         [
@@ -261,6 +311,10 @@ def _require_applied_pins(pyproject: Path, expected: list[DevPin], original: byt
 def update_dev_pins(pyproject: Path) -> dict[str, tuple[str, str]]:
     """Resolve and apply all changed exact direct pins in one uv transaction."""
     manifest = _conventional_manifest(pyproject)
+    uv_lock = manifest.parent / "uv.lock"
+    if uv_lock.is_symlink():
+        msg = f"uv.lock must not be a symbolic link: {uv_lock}"
+        raise ValueError(msg)
     python_version, current = parse_project(manifest.read_text(encoding="utf-8"))
     if not current:
         return {}
@@ -269,7 +323,6 @@ def update_dev_pins(pyproject: Path) -> dict[str, tuple[str, str]]:
     if not changes:
         return changes
 
-    uv_lock = manifest.parent / "uv.lock"
     snapshots = {
         manifest: manifest.read_bytes(),
         uv_lock: uv_lock.read_bytes() if uv_lock.exists() else None,

--- a/scripts/update_python_dev_pins.py
+++ b/scripts/update_python_dev_pins.py
@@ -1,0 +1,339 @@
+"""Advance exact Python development-tool pins with uv's resolver."""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+from packaging.requirements import InvalidRequirement, Requirement
+
+from subprocess_utils import ExecutableNotFoundError, run_safe_command
+
+RESOLVED_REQUIREMENT = re.compile(
+    r"^(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)==(?P<version>[^;\s]+)(?:\s*;\s*.+)?$",
+)
+PYTHON_FLOOR = re.compile(r"^>=(?P<version>[0-9]+\.[0-9]+)$")
+
+# Dependency resolution may involve network access, but neither phase may block
+# the release/update workflow indefinitely.
+UV_PIP_COMPILE_TIMEOUT_SECONDS = 300
+UV_ADD_TIMEOUT_SECONDS = 300
+
+
+@dataclass(frozen=True, slots=True)
+class DevPin:
+    """One exact direct development-tool requirement."""
+
+    name: str
+    version: str
+
+
+def canonicalize_name(name: str) -> str:
+    """Return the normalized distribution name used for comparisons."""
+    return re.sub(r"[-_.]+", "-", name).casefold()
+
+
+def _required_table(data: dict[str, object], name: str) -> dict[str, object]:
+    """Return a required TOML table with a typed failure."""
+    table = data.get(name)
+    if not isinstance(table, dict):
+        msg = f"pyproject.toml must contain a [{name}] table"
+        raise TypeError(msg)
+    return cast("dict[str, object]", table)
+
+
+def _python_floor(project: dict[str, object]) -> str:
+    """Return the repository's single supported Python lower bound."""
+    requires_python = project.get("requires-python")
+    if not isinstance(requires_python, str):
+        msg = "project.requires-python must be a string"
+        raise TypeError(msg)
+    python_match = PYTHON_FLOOR.fullmatch(requires_python)
+    if python_match is None:
+        msg = f"expected project.requires-python to be a single lower bound, found: {requires_python}"
+        raise ValueError(msg)
+    return cast("str", python_match.group("version"))
+
+
+def _dev_pins(groups: dict[str, object]) -> list[DevPin]:
+    """Return exact simple pins while leaving every other dev requirement alone."""
+    dev = groups.get("dev")
+    if not isinstance(dev, list):
+        msg = "dependency-groups.dev must be an array"
+        raise TypeError(msg)
+
+    pins: list[DevPin] = []
+    normalized_names: set[str] = set()
+    for raw_requirement in dev:
+        if not isinstance(raw_requirement, str):
+            msg = "dependency-groups.dev entries must be strings"
+            raise TypeError(msg)
+        try:
+            requirement = Requirement(raw_requirement)
+        except InvalidRequirement as error:
+            msg = f"dependency-groups.dev contains an invalid requirement: {raw_requirement!r}"
+            raise ValueError(msg) from error
+        specifiers = list(requirement.specifier)
+        if requirement.extras or requirement.marker is not None or requirement.url is not None or len(specifiers) != 1:
+            continue
+        specifier = specifiers[0]
+        if specifier.operator != "==" or "*" in specifier.version:
+            continue
+        pin = DevPin(requirement.name, specifier.version)
+        normalized = canonicalize_name(pin.name)
+        if normalized in normalized_names:
+            msg = f"duplicate exact development-tool requirement: {pin.name}"
+            raise ValueError(msg)
+        normalized_names.add(normalized)
+        pins.append(pin)
+    return pins
+
+
+def parse_project(text: str) -> tuple[str, list[DevPin]]:
+    """Parse the Python floor and exact direct development-tool pins."""
+    data = tomllib.loads(text)
+    return _python_floor(_required_table(data, "project")), _dev_pins(_required_table(data, "dependency-groups"))
+
+
+def parse_resolution(output: str, pins: list[DevPin]) -> list[DevPin]:
+    """Extract one resolver-selected version for every direct development tool."""
+    requested = {canonicalize_name(pin.name): pin.name for pin in pins}
+    resolved: dict[str, set[str]] = {name: set() for name in requested}
+
+    for raw_line in output.splitlines():
+        match = RESOLVED_REQUIREMENT.fullmatch(raw_line.strip())
+        if match is None:
+            continue
+        normalized = canonicalize_name(match.group("name"))
+        if normalized in resolved:
+            resolved[normalized].add(match.group("version"))
+
+    latest: list[DevPin] = []
+    for pin in pins:
+        versions = resolved[canonicalize_name(pin.name)]
+        if not versions:
+            msg = f"uv resolver output omitted direct development tool: {pin.name}"
+            raise ValueError(msg)
+        if len(versions) != 1:
+            rendered = ", ".join(sorted(versions))
+            msg = f"uv resolver selected multiple versions for {pin.name}: {rendered}"
+            raise ValueError(msg)
+        latest.append(DevPin(pin.name, next(iter(versions))))
+    return latest
+
+
+def resolve_latest_pins(pins: list[DevPin], python_version: str, project_root: Path) -> list[DevPin]:
+    """Resolve the latest mutually compatible cross-platform set without writes."""
+    requirements = "".join(f"{pin.name}\n" for pin in pins)
+    result = run_safe_command(
+        "uv",
+        [
+            "pip",
+            "compile",
+            "-",
+            "--universal",
+            "--no-header",
+            "--no-annotate",
+            "--python-version",
+            python_version,
+        ],
+        cwd=project_root,
+        input=requirements,
+        timeout=UV_PIP_COMPILE_TIMEOUT_SECONDS,
+    )
+    return parse_resolution(result.stdout, pins)
+
+
+def _conventional_manifest(pyproject: Path) -> Path:
+    """Resolve a conventional project manifest that uv will target exactly."""
+    if pyproject.name != "pyproject.toml":
+        msg = f"--pyproject must name a conventional pyproject.toml manifest, got {pyproject}"
+        raise ValueError(msg)
+    if pyproject.is_symlink():
+        msg = f"--pyproject must not be a symbolic link: {pyproject}"
+        raise ValueError(msg)
+    resolved = pyproject.resolve()
+    if not resolved.is_file():
+        msg = f"--pyproject must be an existing file: {resolved}"
+        raise ValueError(msg)
+    for ancestor in resolved.parent.parents:
+        candidate = ancestor / "pyproject.toml"
+        if not candidate.is_file():
+            continue
+        data = tomllib.loads(candidate.read_text(encoding="utf-8"))
+        tool = data.get("tool")
+        uv = tool.get("uv") if isinstance(tool, dict) else None
+        if isinstance(uv, dict) and isinstance(uv.get("workspace"), dict):
+            msg = f"--pyproject must not select a uv workspace member; use the workspace-root manifest instead: {resolved}"
+            raise TypeError(msg)
+    return resolved
+
+
+def _write_bytes_atomic(path: Path, payload: bytes) -> None:
+    """Atomically restore one project file from an in-memory snapshot."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(payload)
+        temporary.chmod(path.stat().st_mode if path.exists() else 0o644)
+        temporary.replace(path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def _restore_snapshots(snapshots: dict[Path, bytes | None]) -> None:
+    """Restore every manifest/lock snapshot after a failed uv mutation."""
+    errors: list[str] = []
+    for path, original in snapshots.items():
+        try:
+            if original is None:
+                path.unlink(missing_ok=True)
+            else:
+                _write_bytes_atomic(path, original)
+        except OSError as error:
+            errors.append(f"{path}: {error}")
+    if errors:
+        msg = f"could not restore Python project files after failed pin update: {'; '.join(errors)}"
+        raise RuntimeError(msg)
+
+
+def _masked_manifest(text: str, managed_names: frozenset[str]) -> dict[str, object]:
+    """Return parsed manifest data with only managed pin versions masked."""
+    data = tomllib.loads(text)
+    groups = _required_table(data, "dependency-groups")
+    dev = groups.get("dev")
+    if not isinstance(dev, list):
+        msg = "dependency-groups.dev must be an array"
+        raise TypeError(msg)
+    masked: list[object] = []
+    for entry in dev:
+        if not isinstance(entry, str):
+            masked.append(entry)
+            continue
+        try:
+            requirement = Requirement(entry)
+        except InvalidRequirement:
+            masked.append(entry)
+            continue
+        specifiers = list(requirement.specifier)
+        normalized = canonicalize_name(requirement.name)
+        if (
+            normalized in managed_names
+            and not requirement.extras
+            and requirement.marker is None
+            and requirement.url is None
+            and len(specifiers) == 1
+            and specifiers[0].operator == "=="
+            and "*" not in specifiers[0].version
+        ):
+            masked.append(f"{normalized}==<managed-version>")
+        else:
+            masked.append(entry)
+    groups["dev"] = masked
+    return cast("dict[str, object]", data)
+
+
+def _require_applied_pins(pyproject: Path, expected: list[DevPin], original: bytes) -> None:
+    """Require uv to have changed only the exact requested manifest pins."""
+    updated_text = pyproject.read_text(encoding="utf-8")
+    _python_version, actual = parse_project(updated_text)
+    expected_versions = {canonicalize_name(pin.name): pin.version for pin in expected}
+    actual_versions = {canonicalize_name(pin.name): pin.version for pin in actual}
+    if actual_versions != expected_versions:
+        msg = f"uv did not apply the resolved development-tool pins to {pyproject}"
+        raise ValueError(msg)
+    managed_names = frozenset(expected_versions)
+    original_text = original.decode("utf-8")
+    if _masked_manifest(updated_text, managed_names) != _masked_manifest(original_text, managed_names):
+        msg = f"uv changed non-target manifest content in {pyproject}"
+        raise ValueError(msg)
+
+
+def update_dev_pins(pyproject: Path) -> dict[str, tuple[str, str]]:
+    """Resolve and apply all changed exact direct pins in one uv transaction."""
+    manifest = _conventional_manifest(pyproject)
+    python_version, current = parse_project(manifest.read_text(encoding="utf-8"))
+    if not current:
+        return {}
+    latest = resolve_latest_pins(current, python_version, manifest.parent)
+    changes = {old.name: (old.version, new.version) for old, new in zip(current, latest, strict=True) if old.version != new.version}
+    if not changes:
+        return changes
+
+    uv_lock = manifest.parent / "uv.lock"
+    snapshots = {
+        manifest: manifest.read_bytes(),
+        uv_lock: uv_lock.read_bytes() if uv_lock.exists() else None,
+    }
+    try:
+        run_safe_command(
+            "uv",
+            ["add", "--dev", "--no-sync", *(f"{pin.name}=={pin.version}" for pin in latest)],
+            cwd=manifest.parent,
+            timeout=UV_ADD_TIMEOUT_SECONDS,
+        )
+        _require_applied_pins(manifest, latest, snapshots[manifest] or b"")
+    except BaseException as primary:
+        try:
+            _restore_snapshots(snapshots)
+        except RuntimeError as rollback_error:
+            msg = f"Python development-tool pin update failed ({primary}); rollback also failed: {rollback_error}"
+            raise RuntimeError(msg) from primary
+        raise
+    return changes
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--pyproject",
+        type=Path,
+        default=Path("pyproject.toml"),
+        help="project manifest containing dependency-groups.dev",
+    )
+    return parser.parse_args(argv)
+
+
+def _subprocess_detail(error: subprocess.CalledProcessError) -> str:
+    """Return captured tool diagnostics when available."""
+    stderr = error.stderr.strip() if isinstance(error.stderr, str) else ""
+    stdout = error.stdout.strip() if isinstance(error.stdout, str) else ""
+    return cast("str", stderr or stdout or str(error))
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Advance exact development-tool pins without touching other requirements."""
+    args = parse_args(argv)
+    try:
+        _python_version, pins = parse_project(args.pyproject.read_text(encoding="utf-8"))
+        if not pins:
+            print("No exact direct Python development-tool pins to update.")
+            return 0
+        changes = update_dev_pins(args.pyproject)
+    except subprocess.CalledProcessError as error:
+        print(f"failed to update Python development-tool pins: {_subprocess_detail(error)}", file=sys.stderr)
+        return 1
+    except (ExecutableNotFoundError, OSError, RuntimeError, subprocess.TimeoutExpired, TypeError, ValueError, tomllib.TOMLDecodeError) as error:
+        print(f"failed to update Python development-tool pins: {error}", file=sys.stderr)
+        return 1
+
+    if not changes:
+        print("Python development-tool pins are already current.")
+        return 0
+    for name, (old_version, new_version) in changes.items():
+        print(f"Updated {name}: {old_version} -> {new_version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_release_version.py
+++ b/scripts/update_release_version.py
@@ -1,0 +1,547 @@
+"""Update deterministic release-version references from one target Git tag."""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import tomllib
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import check_docs_version_sync as version_sync
+from benchmark_utils import published_stable_release_tags
+from subprocess_utils import ExecutableNotFoundError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_STABLE_TAG_RE = re.compile(r"^v(?P<major>0|[1-9][0-9]*)\.(?P<minor>0|[1-9][0-9]*)\.(?P<patch>0|[1-9][0-9]*)$")
+_TOML_VERSION_RE = re.compile(r'^(?P<prefix>\s*version\s*=\s*")(?P<version>[^"]+)(?P<suffix>"\s*(?:#.*)?)$')
+_CITATION_VERSION_RE = re.compile(
+    r"^(?P<prefix>version:\s*(?P<quote>['\"]?))"
+    r"(?P<version>[0-9A-Za-z][0-9A-Za-z.+-]*)"
+    r"(?P<suffix>(?P=quote)\s*(?:#.*)?)$",
+)
+_CITATION_DATE_RE = re.compile(
+    r"^(?P<prefix>date-released:\s*(?P<quote>['\"]?))"
+    r"(?P<date>\d{4}-\d{2}-\d{2})"
+    r"(?P<suffix>(?P=quote)\s*(?:#.*)?)$",
+)
+
+
+@dataclass(frozen=True, order=True, slots=True)
+class ReleaseTag:
+    """A stable release tag with SemVer ordering."""
+
+    major: int
+    minor: int
+    patch: int
+    tag: str = field(compare=False)
+
+    def __post_init__(self) -> None:
+        """Reject directly constructed values whose identity is contradictory."""
+        match = _STABLE_TAG_RE.fullmatch(self.tag)
+        if match is None:
+            msg = f"release tag must be a stable tag in vX.Y.Z form, got {self.tag!r}"
+            raise ValueError(msg)
+        parsed = (int(match.group("major")), int(match.group("minor")), int(match.group("patch")))
+        supplied = (self.major, self.minor, self.patch)
+        if supplied != parsed:
+            msg = f"release tag components {supplied} contradict emitted tag {self.tag!r} with components {parsed}"
+            raise ValueError(msg)
+
+    @property
+    def version(self) -> str:
+        """Return the package version without the leading ``v``."""
+        return self.tag.removeprefix("v")
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateSummary:
+    """Files and release identities produced by an update."""
+
+    target: ReleaseTag
+    previous: ReleaseTag
+    changed_paths: tuple[Path, ...]
+    release_date: str
+
+
+@dataclass(frozen=True, slots=True)
+class LineReplacement:
+    """One fail-closed scalar replacement on a known source line."""
+
+    line_number: int
+    pattern: re.Pattern[str]
+    group: str
+    replacement: str
+    allowed: frozenset[str]
+    context: str
+
+
+def parse_release_tag(value: str, *, label: str = "release tag") -> ReleaseTag:
+    """Parse one stable ``vX.Y.Z`` release tag."""
+    match = _STABLE_TAG_RE.fullmatch(value)
+    if match is None:
+        msg = f"{label} must be a stable tag in vX.Y.Z form, got {value!r}"
+        raise ValueError(msg)
+    return ReleaseTag(
+        major=int(match.group("major")),
+        minor=int(match.group("minor")),
+        patch=int(match.group("patch")),
+        tag=value,
+    )
+
+
+def select_previous_release_tag(tag_names: list[str], target: ReleaseTag) -> ReleaseTag:
+    """Select the newest published stable release before *target*."""
+    stable_tags = [parse_release_tag(tag) for tag in tag_names if _STABLE_TAG_RE.fullmatch(tag) is not None]
+    if not stable_tags:
+        msg = "repository has no published stable vX.Y.Z GitHub releases"
+        raise ValueError(msg)
+    newer = [tag for tag in stable_tags if tag > target]
+    if newer:
+        latest = max(newer)
+        msg = f"target {target.tag} is older than published stable GitHub release {latest.tag}"
+        raise ValueError(msg)
+    previous = [tag for tag in stable_tags if tag < target]
+    if not previous:
+        msg = f"could not find a published stable GitHub release before {target.tag}"
+        raise ValueError(msg)
+    return max(previous)
+
+
+def infer_previous_release_tag(root: Path, target: ReleaseTag) -> ReleaseTag:
+    """Infer the previous release from published stable GitHub releases."""
+    return select_previous_release_tag(published_stable_release_tags(root), target)
+
+
+def _validated_date(value: str) -> str:
+    """Require one real ISO calendar date and return it unchanged."""
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as error:
+        msg = f"release date must use YYYY-MM-DD, got {value!r}"
+        raise ValueError(msg) from error
+    if parsed.isoformat() != value:
+        msg = f"release date must use canonical YYYY-MM-DD form, got {value!r}"
+        raise ValueError(msg)
+    return value
+
+
+def _current_utc_date() -> str:
+    """Return today's canonical UTC calendar date."""
+    return datetime.now(UTC).date().isoformat()
+
+
+def _replace_line_group(text: str, edit: LineReplacement) -> str:
+    lines = text.splitlines(keepends=True)
+    if not 1 <= edit.line_number <= len(lines):
+        msg = f"{edit.context} has no line {edit.line_number}"
+        raise ValueError(msg)
+    original_line = lines[edit.line_number - 1]
+    body = original_line.rstrip("\r\n")
+    ending = original_line[len(body) :]
+    match = edit.pattern.fullmatch(body)
+    if match is None:
+        msg = f"{edit.context}:{edit.line_number} has an unsupported version assignment: {body!r}"
+        raise ValueError(msg)
+    current = match.group(edit.group)
+    if current not in edit.allowed:
+        msg = f"{edit.context}:{edit.line_number} has unexpected version {current!r}; expected one of {sorted(edit.allowed)}"
+        raise ValueError(msg)
+    start, end = match.span(edit.group)
+    lines[edit.line_number - 1] = f"{body[:start]}{edit.replacement}{body[end:]}{ending}"
+    return "".join(lines)
+
+
+def _replace_match_groups(match: re.Match[str], replacements: dict[str, str]) -> str:
+    updated = match.group(0)
+    spans = sorted(
+        ((match.start(group) - match.start(), match.end(group) - match.start(), value) for group, value in replacements.items()),
+        reverse=True,
+    )
+    for start, end, value in spans:
+        updated = f"{updated[:start]}{value}{updated[end:]}"
+    return updated
+
+
+def _replace_dependency_versions(text: str, package_name: str, target: ReleaseTag, previous: ReleaseTag, path: Path) -> str:
+    allowed = frozenset({target.version, previous.version})
+    pattern = version_sync.dependency_regex(package_name)
+
+    def replace(match: re.Match[str]) -> str:
+        group = next(name for name in ("plain", "plain_literal", "table", "table_literal") if match.group(name) is not None)
+        current = match.group(group)
+        if current not in allowed:
+            msg = f"{path} has unexpected {package_name} dependency version {current!r}; expected one of {sorted(allowed)}"
+            raise ValueError(msg)
+        return _replace_match_groups(match, {group: target.version})
+
+    return pattern.sub(replace, text)
+
+
+def _replace_cargo_add_versions(text: str, package_name: str, target: ReleaseTag, previous: ReleaseTag, path: Path) -> str:
+    allowed = frozenset({target.version, previous.version})
+    pattern = version_sync.cargo_add_regex(package_name)
+
+    def replace(match: re.Match[str]) -> str:
+        current = match.group("version")
+        if current not in allowed:
+            msg = f"{path} has unexpected cargo add version {current!r}; expected one of {sorted(allowed)}"
+            raise ValueError(msg)
+        return _replace_match_groups(match, {"version": target.version})
+
+    return pattern.sub(replace, text)
+
+
+def _replace_readme_links(text: str, target: ReleaseTag, previous: ReleaseTag, path: Path) -> str:
+    allowed = frozenset({target.version, previous.version})
+
+    def replace(match: re.Match[str]) -> str:
+        if version_sync.readme_tag_link_is_performance_asset(match):
+            return match.group(0)
+        version = match.group("version")
+        if version is not None and version not in allowed:
+            msg = f"{path} has unexpected release-pinned link version {version!r}; expected one of {sorted(allowed)}"
+            raise ValueError(msg)
+        group = "version" if version is not None else "revision"
+        replacement = target.version if version is not None else target.tag
+        return _replace_match_groups(match, {group: replacement})
+
+    return version_sync.README_TAG_LINK_RE.sub(replace, text)
+
+
+def _replace_benchmark_tag_pairs(text: str, target: ReleaseTag, previous: ReleaseTag, path: Path) -> str:
+    allowed_current = frozenset({target.tag, previous.tag})
+
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        incomplete = version_sync.BENCHMARK_SINGLE_TAG_RE.search(line)
+        if incomplete is not None:
+            msg = f"{path}:{line_number} has a benchmark command missing the baseline tag after {incomplete.group('current')!r}"
+            raise ValueError(msg)
+
+    def replace(match: re.Match[str]) -> str:
+        current = parse_release_tag(match.group("current"), label=f"{path} benchmark current tag")
+        baseline = parse_release_tag(match.group("baseline"), label=f"{path} benchmark baseline tag")
+        if baseline >= current:
+            msg = f"{path} has benchmark baseline {baseline.tag} that is not older than current tag {current.tag}"
+            raise ValueError(msg)
+        if current.tag not in allowed_current:
+            msg = f"{path} has unexpected benchmark current tag {current.tag}; expected {target.tag} or {previous.tag}"
+            raise ValueError(msg)
+        if current == target and baseline != previous:
+            msg = f"{path} has non-adjacent benchmark pair {current.tag} against {baseline.tag}; expected baseline {previous.tag}"
+            raise ValueError(msg)
+        return _replace_match_groups(match, {"current": target.tag, "baseline": previous.tag})
+
+    return version_sync.BENCHMARK_TAG_PAIR_RE.sub(replace, text)
+
+
+def _read_text(path: Path) -> str:
+    with path.open(encoding="utf-8", newline="") as stream:
+        return stream.read()
+
+
+def _metadata_updates(root: Path, target: ReleaseTag, previous: ReleaseTag, release_date: str) -> dict[Path, str]:
+    allowed = frozenset({target.version, previous.version})
+    cargo_toml = root / "Cargo.toml"
+    cargo_lock = root / "Cargo.lock"
+    pyproject = root / "pyproject.toml"
+    uv_lock = root / "uv.lock"
+    citation = root / "CITATION.cff"
+
+    package = version_sync.read_cargo_package_info(cargo_toml)
+    project = version_sync.read_python_project_info(pyproject)
+    cargo_toml_line = version_sync.toml_table_key_line(cargo_toml, "package", "version")
+    cargo_lock_reference = version_sync.cargo_lock_reference(cargo_lock, package)
+    pyproject_reference = version_sync.pyproject_reference(pyproject, project)
+    uv_lock_reference = version_sync.uv_lock_reference(uv_lock, project)
+    citation_reference = version_sync.citation_reference(citation)
+
+    updates = {
+        cargo_toml: _replace_line_group(
+            _read_text(cargo_toml),
+            LineReplacement(cargo_toml_line, _TOML_VERSION_RE, "version", target.version, allowed, str(cargo_toml)),
+        ),
+        cargo_lock: _replace_line_group(
+            _read_text(cargo_lock),
+            LineReplacement(cargo_lock_reference.line, _TOML_VERSION_RE, "version", target.version, allowed, str(cargo_lock)),
+        ),
+        pyproject: _replace_line_group(
+            _read_text(pyproject),
+            LineReplacement(pyproject_reference.line, _TOML_VERSION_RE, "version", target.version, allowed, str(pyproject)),
+        ),
+        uv_lock: _replace_line_group(
+            _read_text(uv_lock),
+            LineReplacement(uv_lock_reference.line, _TOML_VERSION_RE, "version", target.version, allowed, str(uv_lock)),
+        ),
+        citation: _replace_line_group(
+            _read_text(citation),
+            LineReplacement(citation_reference.line, _CITATION_VERSION_RE, "version", target.version, allowed, str(citation)),
+        ),
+    }
+    citation_line, current_date = version_sync.citation_release_date(citation)
+    updates[citation] = _replace_line_group(
+        updates[citation],
+        LineReplacement(
+            citation_line,
+            _CITATION_DATE_RE,
+            "date",
+            release_date,
+            frozenset({current_date, release_date}),
+            str(citation),
+        ),
+    )
+    return updates
+
+
+def _prepare_updates(root: Path, target: ReleaseTag, previous: ReleaseTag, release_date: str) -> dict[Path, str]:
+    updates = _metadata_updates(root, target, previous, release_date)
+    changelog = root / "CHANGELOG.md"
+    changelog_match = version_sync.changelog_release_date(changelog, target.version)
+    if changelog_match is not None:
+        changelog_line, changelog_date = changelog_match
+        updates[changelog] = _replace_changelog_release_date(
+            changelog,
+            target,
+            line=changelog_line,
+            current_date=changelog_date,
+            release_date=release_date,
+        )
+    package = version_sync.read_cargo_package_info(root / "Cargo.toml")
+    for path in version_sync.iter_active_markdown_files(root):
+        original = _read_text(path)
+        updated = _replace_dependency_versions(original, package.name, target, previous, path)
+        updated = _replace_cargo_add_versions(updated, package.name, target, previous, path)
+        updated = _replace_benchmark_tag_pairs(updated, target, previous, path)
+        if path == root / "README.md":
+            updated = _replace_readme_links(updated, target, previous, path)
+        updates[path] = updated
+    return updates
+
+
+def _replace_changelog_release_date(
+    changelog: Path,
+    target: ReleaseTag,
+    *,
+    line: int,
+    current_date: str,
+    release_date: str,
+) -> str:
+    """Return a changelog with one target release heading date synchronized."""
+    heading_re = re.compile(rf"^(?P<prefix>## \[v?{re.escape(target.version)}\] - )(?P<date>\d{{4}}-\d{{2}}-\d{{2}})$")
+    return _replace_line_group(
+        _read_text(changelog),
+        LineReplacement(
+            line,
+            heading_re,
+            "date",
+            release_date,
+            frozenset({current_date, release_date}),
+            str(changelog),
+        ),
+    )
+
+
+def _write_bytes_atomic(path: Path, content: bytes) -> None:
+    """Replace ``path`` atomically with exact bytes while preserving its mode."""
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(content)
+        temporary.chmod(path.stat().st_mode)
+        temporary.replace(path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def _write_text_atomic(path: Path, text: str) -> None:
+    _write_bytes_atomic(path, text.encode("utf-8"))
+
+
+def _validate_updated_root(root: Path, target: ReleaseTag, previous: ReleaseTag) -> None:
+    mismatches = version_sync.find_version_mismatches(root)
+    if mismatches:
+        details = "; ".join(
+            f"{mismatch.reference.path.relative_to(root)}:{mismatch.reference.line} has {mismatch.reference.version}" for mismatch in mismatches
+        )
+        msg = f"release-version validation failed after updating to {target.tag}: {details}"
+        raise ValueError(msg)
+    for path in version_sync.iter_active_markdown_files(root):
+        for match in version_sync.BENCHMARK_TAG_PAIR_RE.finditer(_read_text(path)):
+            if match.group("current") != target.tag or match.group("baseline") != previous.tag:
+                msg = f"{path} contains a benchmark tag pair that does not match {target.tag} against {previous.tag}"
+                raise ValueError(msg)
+
+
+def _validate_planned_updates(
+    root: Path,
+    updates: dict[Path, str],
+    target: ReleaseTag,
+    previous: ReleaseTag,
+) -> None:
+    """Validate the complete candidate tree before replacing repository files."""
+    sources = {
+        root / "Cargo.toml",
+        root / "Cargo.lock",
+        root / "pyproject.toml",
+        root / "uv.lock",
+        root / "CITATION.cff",
+        *version_sync.iter_active_markdown_files(root),
+    }
+    changelog = root / "CHANGELOG.md"
+    if changelog.is_file():
+        sources.add(changelog)
+
+    with tempfile.TemporaryDirectory(prefix="delaunay-release-plan-") as temporary_directory:
+        candidate_root = Path(temporary_directory)
+        for source in sources:
+            destination = candidate_root / source.relative_to(root)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_text(updates.get(source, _read_text(source)), encoding="utf-8", newline="")
+        _validate_updated_root(candidate_root, target, previous)
+
+
+def _publish_transaction(updates: dict[Path, str], validate: Callable[[], None]) -> tuple[Path, ...]:
+    original_bytes = {path: path.read_bytes() for path in updates}
+    original_text = {path: _read_text(path) for path in updates}
+    changed = tuple(sorted((path for path, text in updates.items() if text != original_text[path]), key=str))
+    replaced: list[Path] = []
+    try:
+        for path in changed:
+            _write_text_atomic(path, updates[path])
+            replaced.append(path)
+        validate()
+    except BaseException as primary:
+        rollback_errors: list[str] = []
+        for path in reversed(replaced):
+            try:
+                _write_bytes_atomic(path, original_bytes[path])
+            except OSError as error:
+                rollback_errors.append(f"{path}: {error}")
+        if rollback_errors:
+            msg = f"release-version update failed ({primary}); rollback also failed: {'; '.join(rollback_errors)}"
+            raise RuntimeError(msg) from primary
+        raise
+    return changed
+
+
+def update_release_version(
+    root: Path,
+    tag: str,
+    *,
+    previous: ReleaseTag | None = None,
+) -> UpdateSummary:
+    """Update release references transactionally and return a summary."""
+    resolved_root = root.resolve()
+    target = parse_release_tag(tag, label="target tag")
+    previous_release = previous or infer_previous_release_tag(resolved_root, target)
+    if previous_release >= target:
+        msg = f"previous release {previous_release.tag} must be older than target {target.tag}"
+        raise ValueError(msg)
+    prepared_date = _validated_date(_current_utc_date())
+    updates = _prepare_updates(resolved_root, target, previous_release, prepared_date)
+    _validate_planned_updates(resolved_root, updates, target, previous_release)
+    changed = _publish_transaction(updates, lambda: _validate_updated_root(resolved_root, target, previous_release))
+    return UpdateSummary(target=target, previous=previous_release, changed_paths=changed, release_date=prepared_date)
+
+
+def sync_changelog_release_date(
+    root: Path,
+    tag: str,
+    *,
+    previous: ReleaseTag | None = None,
+) -> tuple[tuple[Path, ...], str]:
+    """Synchronize a generated changelog heading from ``CITATION.cff``."""
+    resolved_root = root.resolve()
+    target = parse_release_tag(tag, label="target tag")
+    previous_release = previous or infer_previous_release_tag(resolved_root, target)
+    package = version_sync.read_cargo_package_info(resolved_root / "Cargo.toml")
+    if package.version != target.version:
+        msg = f"Cargo.toml version {package.version} does not match target {target.tag}"
+        raise ValueError(msg)
+    citation = resolved_root / "CITATION.cff"
+    _, citation_date = version_sync.citation_release_date(citation)
+    changelog = resolved_root / "CHANGELOG.md"
+    changelog_match = version_sync.changelog_release_date(changelog, target.version)
+    if changelog_match is None:
+        msg = f"{changelog} has no generated release heading for {target.tag}"
+        raise ValueError(msg)
+    changelog_line, changelog_date = changelog_match
+    updated = _replace_changelog_release_date(
+        changelog,
+        target,
+        line=changelog_line,
+        current_date=changelog_date,
+        release_date=citation_date,
+    )
+    updates = {changelog: updated}
+    _validate_planned_updates(resolved_root, updates, target, previous_release)
+    changed = _publish_transaction(
+        updates,
+        lambda: _validate_updated_root(resolved_root, target, previous_release),
+    )
+    return changed, citation_date
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tag", help="Target stable release tag in vX.Y.Z form")
+    parser.add_argument("--root", type=Path, default=Path.cwd(), help="Repository root to update (default: current directory)")
+    parser.add_argument("--previous-release", help="previous stable published tag already resolved by a non-mutating preflight")
+    parser.add_argument(
+        "--print-previous-release",
+        action="store_true",
+        help="print the inferred previous stable published tag without changing files",
+    )
+    parser.add_argument(
+        "--sync-changelog-date",
+        action="store_true",
+        help="Synchronize the generated changelog heading from CITATION.cff instead of updating release metadata",
+    )
+    args = parser.parse_args(argv)
+    if args.print_previous_release and (args.sync_changelog_date or args.previous_release is not None):
+        parser.error("--print-previous-release cannot be combined with update or synchronization options")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Update deterministic release metadata with fail-closed diagnostics."""
+    args = parse_args(argv)
+    try:
+        target = parse_release_tag(args.tag, label="target tag")
+        if args.print_previous_release:
+            print(infer_previous_release_tag(args.root.resolve(), target).tag)
+            return 0
+        previous = parse_release_tag(args.previous_release, label="previous release") if args.previous_release is not None else None
+        if args.sync_changelog_date:
+            changed_paths, release_date = sync_changelog_release_date(args.root, args.tag, previous=previous)
+            if changed_paths:
+                print(f"Synchronized CHANGELOG.md release date to {release_date}.")
+            else:
+                print(f"CHANGELOG.md release date already matches {release_date}.")
+            return 0
+        summary = update_release_version(args.root, args.tag, previous=previous)
+    except (ExecutableNotFoundError, OSError, RuntimeError, subprocess.SubprocessError, TypeError, ValueError, tomllib.TOMLDecodeError) as error:
+        print(f"failed to update release version: {error}", file=sys.stderr)
+        return 1
+
+    if summary.changed_paths:
+        for path in summary.changed_paths:
+            print(f"Updated {path.relative_to(args.root.resolve())}")
+    else:
+        print(f"Release-version references already match {summary.target.tag}.")
+    print(f"Previous release: {summary.previous.tag}")
+    print(f"CITATION.cff UTC release date: {summary.release_date}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
- Synchronize package, lockfile, citation, changelog, and documentation versions through rollback-safe release commands.
- Update exact Python development pins before lock regeneration and verify release identity against published stable history.
- Promote validated performance evidence into curated reports and an atomic README snapshot with durable provenance.
- Fail closed on stale dates, mismatched metadata, unsafe tag input, and partial artifact publication.

BREAKING CHANGE: remove the perf-local, perf-release, and perf-github-assets compatibility recipes; use performance-local, performance-release, and performance-github-assets instead.

Closes #573