### PR TITLE
feat: expose Level 4 adapter workflows on Triangulation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,11 @@ workflow references do not need to be loaded preemptively.
   example-only changes use the matching focused validators from
   `docs/dev/commands.md`; compose those validators once each when multiple
   focused surfaces changed.
+- **Review substantive changes before a PR.** After fast checks, run
+  `just review` against the intended PR base, assess CodeRabbit findings, and
+  fix valid issues before final validation. Small editorial changes may skip
+  review. Report unavailable or skipped reviews explicitly; command scope and
+  follow-up guidance live in `docs/dev/commands.md#local-coderabbit-review`.
 - **Find local MacTeX tools before declaring them missing.** On macOS, prepend
   `/Library/TeX/texbin` to `PATH` when commands such as `chktex` are not visible
   to a non-interactive shell; see `docs/dev/commands.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,13 @@ just check
 ```
 
 During iterative review and fixes, use `just check` alongside targeted tests
-for changed behavior. Reserve `just ci` for final validation once those
+for changed behavior. Once substantive changes settle, run `just review`
+against the intended PR base and address valid CodeRabbit findings before
+final validation. Small editorial changes may skip this review. See
+[local CodeRabbit review](docs/dev/commands.md#local-coderabbit-review) for
+scope selection and prerequisites.
+
+Reserve `just ci` for final validation once those
 iterations are complete. Core Rust/Cargo or public-behavior changes must pass
 that comprehensive check before a pull request is ready or the changes are
 pushed. Documentation, configuration, Python, notebook, test-only,

--- a/docs/architecture/module_map.md
+++ b/docs/architecture/module_map.md
@@ -91,6 +91,8 @@ receiving raw access to canonical TDS storage:
   complete connectivity and the generic layer exposes no further staged
   mutation.
 - `construction.rs` - generic construction helpers and initial-simplex setup.
+- `editing.rs` - public Euclidean insertion/deletion adapters and typed edit
+  failures, preserving Levels 1–4 without requiring Level 5.
 - `insertion.rs` - generic transactional insertion, duplicate detection, and
   insertion telemetry.
 - `orientation.rs` - simplex orientation validation, lifted-coordinate
@@ -100,6 +102,8 @@ receiving raw access to canonical TDS storage:
 - `repair.rs` - generic local topology repair, stale incident-simplex repair,
   and vertex-deletion cavity retriangulation.
 - `rollback.rs` - rollback guards for generic mutation windows.
+- `serialization.rs` - exact UUID snapshot envelope, borrowed payload encoding,
+  and strict Levels 1–4 restoration with caller-selected or default kernels.
 - `validation.rs` - Level 3 topology validation vocabulary and orchestration.
 - `realization.rs` - Level 4 realization validation and the shared Levels 3–4
   certification used by both strict TDS-to-`Triangulation` refinement and
@@ -206,8 +210,8 @@ operations require only the Levels 1–4 owner.
   visualization tools, analysis pipelines, and downstream crates.
 
 This layer is distinct from the TDS snapshot/hydration boundary. TDS serde
-persists the Levels 1–2 owner; Delaunay serde wraps that snapshot with the
-higher-layer proof context needed for validated restoration.
+persists the Levels 1–2 owner; triangulation and Delaunay serde each wrap that
+snapshot with their context for validated restoration at the owning layer.
 `io::visualization` exposes stable UUID-based records for consumers that should
 not depend on runtime slotmap handles.
 

--- a/docs/construction_and_validation.md
+++ b/docs/construction_and_validation.md
@@ -244,6 +244,60 @@ as a full audit and as input to future repair workflows.
 
 ---
 
+## Level 4 adapter workflows
+
+Mutable geometry adapters can retain `Triangulation` after edits that preserve
+realization but invalidate the Delaunay predicate. The public workflows are:
+
+| Workflow | `Triangulation` contract | `DelaunayTriangulation` contract |
+|---|---|---|
+| `to_visualization_data()` | Export the current geometry and UUID connectivity. | Delegate to the Level 4 export. |
+| Serde persistence | Preserve exact storage; restore through Levels 1–4. | Restore through Levels 1–5 with the Delaunay checkpoint format. |
+| `insert_vertex()` | Euclidean simplex subdivision or hull extension. | Preserve Levels 1–5, with Delaunay repair as needed. |
+| `delete_vertex()` | Euclidean cavity fan retriangulation; no Level 5 check or repair. | Preserve Levels 1–5 after deletion and repair. |
+| Pachner proposals | Transactional moves in Euclidean or supported toroidal charts. | Requires explicit demotion to `Triangulation`. |
+
+General Level 4 insertion and deletion validate the complete candidate through
+Level 4 before committing, regardless of `ValidationPolicy`. Failed edits
+restore the owner, generational keys, payloads, and construction evidence.
+`TriangulationEditError` retains the typed insertion, cavity-operation, or
+invariant diagnostic. Insertion preserves the supplied vertex UUID, payload,
+and coordinate bits. New simplices have no payload; surviving entities retain
+theirs. A missing deletion key returns zero. Empty owners require a builder to
+bootstrap, and unsupported degenerate insertion locations return an error.
+
+General cavity editing currently accepts Euclidean geometry. Toroidal callers
+use `PachnerMove::K1Insert { simplex_key, vertex }` to choose a simplex in its
+lifted chart and `PachnerMove::K1Remove { vertex_key }` for the inverse stellar
+deletion. Obtain a canonical interior point with `simplex_barycenter`, construct
+the proposal with `propose_pachner`, then consume it with `attempt_on`. Other
+Pachner moves can reshape the vertex star before an inverse stellar deletion.
+Each proposal execution is failure-atomic; a sequence of separately committed
+proposals is not one transaction. Use a detached trial owner and publish it only
+after the complete sequence succeeds when the adapter needs sequence-wide
+atomicity. Arbitrary periodic cavity deletion is not currently supported by the
+general Euclidean fan routine.
+
+Serialize `&triangulation` directly, without cloning payloads or assembling a
+TDS snapshot. The versioned envelope embeds CBOR storage to preserve coordinate
+bits independently of the outer JSON/CBOR codec. It includes vertex/simplex
+UUIDs, simplex vertex order, neighbor slots, periodic lift offsets, topology
+guarantee, global topology, validation policy, and payloads. Runtime slotmap keys
+and incidence are rebuilt from UUIDs. Kernel configuration is chosen on load:
+deserialize `TriangulationSnapshot<U, V, D>` and call
+`try_into_triangulation(kernel)` for a typed, recoverable certification failure,
+or deserialize `Triangulation<K, U, V, D>` to use `K::default()`.
+
+Restoration performs no orientation normalization, connectivity repair, or
+Level 5 work. Stored construction provenance is not accepted as proof: a
+nontrivial high-dimensional PL-manifold snapshot can fail strict restoration
+when its link proof cannot be re-established. General high-dimensional fan
+deletion has the same proof limitation. Serialization also rejects present
+payloads containing CBOR null/unit values, whose nested `Option` states cannot
+all be distinguished by that codec; use explicitly tagged payload enums.
+Absent entity payloads are supported. `DelaunayRefinementBuilder` remains the
+consuming, explicit boundary for subsequent Level 5 certification or repair.
+
 ## Automatic validation during incremental insertion (`ValidationPolicy`)
 
 The library always provides **explicit** validation APIs (Levels 1–5) that you can call when you need them.

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -11,7 +11,7 @@ remains the architecture hub.
 
 | File | Owns |
 |-----|-----|
-| [`commands.md`](commands.md) | Validation command selection, `just` recipes, benchmark profiles, and CI expectations |
+| [`commands.md`](commands.md) | Validation command selection, local CodeRabbit review, `just` recipes, benchmark profiles, and CI expectations |
 | [`git.md`](git.md) | Git safety, GitHub CLI usage, issue dependencies, branch names, and commit-message rules |
 | [`rust.md`](rust.md) | Rust guidance index; read its focused links before touching Rust code |
 | [`testing.md`](testing.md) | Unit, integration, property, doctest, slow-test, and dimension-coverage expectations |

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -10,6 +10,7 @@ Agents must run appropriate checks after modifying code.
 
 - [Core Workflow](#core-workflow)
 - [Validation Command Selection](#validation-command-selection)
+- [Local CodeRabbit Review](#local-coderabbit-review)
 - [Justfile Usage](#justfile-usage)
 - [Formatting](#formatting)
 - [Linting](#linting)
@@ -117,6 +118,48 @@ For benchmark-only changes, run the changed benchmark with
 `cargo bench --profile perf --bench <name>` when the change affects measured
 behavior. Use `just bench-smoke` for harness-only edits, and `just bench` for
 broad benchmark-suite changes.
+
+## Local CodeRabbit Review
+
+Run one local CodeRabbit review after substantive code, API, numerical, or
+tooling changes settle and fast checks pass, before submitting a PR. Assess
+each finding against the repository's contracts, fix valid issues, and run the
+affected checks. Small editorial or formatting-only changes may skip review.
+
+```bash
+just review                  # Complete branch diff against local main
+just review origin/main      # Use a different locally available PR base
+just review-uncommitted      # Only staged, unstaged, and new files
+```
+
+`just review [base]` includes committed branch changes and local edits;
+`just review-uncommitted` excludes already committed changes. Both include
+non-ignored untracked files and pass `AGENTS.md` and `.coderabbit.yml` as
+additional review instructions. Inspect the intended diff before invoking
+either recipe. The base defaults to local `main`; choose the actual PR base
+and ensure it is current. These commands do not fetch or change Git state.
+
+The recipes use CodeRabbit's `--agent` output so agents can read structured
+findings. Install the [CodeRabbit CLI](https://docs.coderabbit.ai/cli) separately
+and authenticate with `coderabbit auth login` before the first review. The
+required scope flags are supported by CLI 0.7.6; consult
+`coderabbit review --help` when using another version. CodeRabbit is an
+external prerequisite, separate from the tools managed by `just setup-tools`.
+
+Review is a separate step from `just check` and `just ci`: it uses a remote
+service, authentication, and review allowances. CLI failures propagate through
+the recipes. A skipped review, authentication failure, service error, or
+exhausted allowance is an unavailable review, never a clean result. Report
+the scope, completion status, actionable findings, fixes, and any remaining
+issues or access limitation in the handoff; continue the applicable local
+validators even when review is unavailable.
+
+Reuse a completed review of the same diff. Rerun only when substantial fixes
+or new changes warrant another pass, rather than after every edit or to chase
+style preferences. After fixes, run `just ci` for core Rust/Cargo or public
+behavior changes, or the focused final validators in the matrix above for
+other changes. Keep the GitHub PR review: its broader context can produce
+different findings from the local CLI review.
 
 ## Justfile Usage
 
@@ -930,6 +973,8 @@ just action-lint
 |-----|-----|
 | Run lints | `just check` |
 | Fast compile check | `just check-fast` |
+| Review a branch and local edits before a PR | `just review [base]` |
+| Review only uncommitted edits and new files | `just review-uncommitted` |
 | Check formatting | `just fmt-check` |
 | Check justfile formatting | `just justfile-fmt-check` |
 | Apply formatters/auto-fixes | `just fix` |

--- a/just/helpers.just
+++ b/just/helpers.just
@@ -58,6 +58,14 @@ _ensure-chktex:
         exit 1
     }
 
+_ensure-coderabbit:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v coderabbit >/dev/null || {
+        echo "CodeRabbit CLI is required for local review. Install it from https://docs.coderabbit.ai/cli and ensure coderabbit is on PATH." >&2
+        exit 1
+    }
+
 _ensure-dprint: (_ensure-pinned-cargo-tool "dprint" "dprint" dprint_version)
 
 _ensure-gh:
@@ -204,6 +212,18 @@ _performance-tag-pair-state current_tag baseline_tag:
     else
         echo "inferred"
     fi
+
+[private]
+_review scope base: _ensure-coderabbit
+    #!/usr/bin/env bash
+    set -euo pipefail
+    args=(review --agent --include-untracked -c AGENTS.md .coderabbit.yml)
+    case {{ quote(scope) }} in
+        branch) args+=(--base {{ quote(base) }}) ;;
+        uncommitted) args+=(--uncommitted) ;;
+        *) echo "Unsupported review scope: "{{ quote(scope) }} >&2; exit 2 ;;
+    esac
+    exec coderabbit "${args[@]}"
 
 _validation-doc-figures-check-if-canonical:
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -329,6 +329,10 @@ help-workflows:
     @echo "  just test               # Default Rust and Python test buckets"
     @echo "  just ci                 # GitHub-equivalent default validation suite"
     @echo ""
+    @echo "Local CodeRabbit review:"
+    @echo "  just review [base]      # Review the branch and local edits; base defaults to main"
+    @echo "  just review-uncommitted # Review only local edits, including new files"
+    @echo ""
     @echo "Setup and maintenance:"
     @echo "  just setup              # Install pinned tools and build the development profile"
     @echo "  just setup-tools        # Install and verify pinned repository tools"
@@ -1125,6 +1129,14 @@ python-typecheck: _ensure-uv
 [group('release')]
 release-version-check: _ensure-uv
     uv run --locked check-docs-version-sync --final-release
+
+# Review committed and local changes against the PR base with CodeRabbit.
+[group('review')]
+review base="main": (_review "branch" base)
+
+# Review staged, unstaged, and new files without committed branch changes.
+[group('review')]
+review-uncommitted: (_review "uncommitted" "")
 
 # Run the opt-in companion binary with the CLI feature and perf profile.
 [group('build and setup')]

--- a/src/core/tds/snapshot.rs
+++ b/src/core/tds/snapshot.rs
@@ -1045,6 +1045,38 @@ impl<U, V, const D: usize> RawTdsSnapshot<U, V, D> {
 }
 
 impl<U, V, const D: usize> TdsSnapshot<U, V, D> {
+    /// Moves codec payload wrappers without cloning payloads or UUID relationships.
+    pub(crate) fn map_payloads<NewU, NewV>(
+        self,
+        mut map_vertex: impl FnMut(U) -> NewU,
+        mut map_simplex: impl FnMut(V) -> NewV,
+    ) -> TdsSnapshot<NewU, NewV, D> {
+        TdsSnapshot {
+            vertices: self
+                .vertices
+                .into_iter()
+                .map(|vertex| {
+                    Vertex::from_validated_point_with_uuid(
+                        *vertex.point(),
+                        vertex.uuid(),
+                        vertex.data.map(&mut map_vertex),
+                    )
+                })
+                .collect(),
+            simplices: self
+                .simplices
+                .into_iter()
+                .map(|simplex| TdsSnapshotSimplex {
+                    uuid: simplex.uuid,
+                    data: simplex.data.map(&mut map_simplex),
+                    vertex_uuids: simplex.vertex_uuids,
+                    neighbor_uuids: simplex.neighbor_uuids,
+                    periodic_vertex_offsets: simplex.periodic_vertex_offsets,
+                })
+                .collect(),
+        }
+    }
+
     /// Returns the validated vertex records in their interchange order.
     pub(crate) fn vertices(&self) -> impl Iterator<Item = &Vertex<U, D>> {
         self.vertices.iter()

--- a/src/io/visualization.rs
+++ b/src/io/visualization.rs
@@ -13,6 +13,7 @@ use crate::core::vertex::Vertex;
 use crate::delaunay_model::DelaunayTriangulation;
 use crate::geometry::traits::coordinate::InvalidCoordinateValue;
 use crate::topology::traits::topological_space::TopologyKind;
+use crate::triangulation::Triangulation;
 use crate::triangulation::validation::TopologyGuarantee;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -859,7 +860,7 @@ pub enum VisualizationDataValidationError {
     },
 }
 
-impl<K, U, V, const D: usize> DelaunayTriangulation<K, U, V, D> {
+impl<K, U, V, const D: usize> Triangulation<K, U, V, D> {
     /// Exports this triangulation as generic visualization/interchange data.
     ///
     /// The returned value implements [`Serialize`] and [`Deserialize`] so callers
@@ -893,7 +894,7 @@ impl<K, U, V, const D: usize> DelaunayTriangulation<K, U, V, D> {
     ///     vertex![0.0, 1.0, 0.0]?,
     ///     vertex![0.0, 0.0, 1.0]?,
     /// ];
-    /// let triangulation = DelaunayTriangulationBuilder::new(&vertices).build()?;
+    /// let triangulation = DelaunayTriangulationBuilder::new(&vertices).build_triangulation()?;
     ///
     /// let export = triangulation.to_visualization_data()?;
     ///
@@ -965,6 +966,31 @@ impl<K, U, V, const D: usize> DelaunayTriangulation<K, U, V, D> {
             simplices,
             adjacency,
         })
+    }
+}
+
+impl<K, U, V, const D: usize> DelaunayTriangulation<K, U, V, D> {
+    /// Exports the same UUID-based records as [`Triangulation::to_visualization_data`].
+    ///
+    /// Export reads Levels 1–4 only and performs no Delaunay certification or repair.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VisualizationExportError`] for unresolved topology relationships.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulationBuilder, vertex};
+    /// # fn main() -> DelaunayResult<()> {
+    /// let vertices = [vertex![0.0, 0.0]?, vertex![1.0, 0.0]?, vertex![0.0, 1.0]?];
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build()?;
+    /// assert_eq!(dt.to_visualization_data()?.vertices.len(), 3);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn to_visualization_data(&self) -> Result<VisualizationData<D>, VisualizationExportError> {
+        self.as_triangulation().to_visualization_data()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -898,6 +898,7 @@ pub(crate) mod triangulation {
     pub mod builder;
     pub mod construction;
     pub mod draft;
+    pub mod editing;
     pub mod flips;
     pub mod insertion;
     pub mod jaccard;
@@ -909,6 +910,7 @@ pub(crate) mod triangulation {
     pub mod realization;
     pub mod repair;
     pub mod rollback;
+    pub mod serialization;
     pub mod validation;
 
     pub use model::Triangulation;
@@ -1116,6 +1118,7 @@ pub use crate::triangulation::builder::{
 pub use crate::triangulation::construction::{
     FinalDelaunayValidationContext, FinalTopologyValidationContext, TriangulationConstructionError,
 };
+pub use crate::triangulation::editing::TriangulationEditError;
 pub use crate::triangulation::insertion::DuplicateDetectionMetrics;
 pub use crate::triangulation::query::SimplexBarycenterError;
 pub use crate::triangulation::realization::{
@@ -1125,6 +1128,9 @@ pub use crate::triangulation::realization::{
     TriangulationRealizationValidationReport,
 };
 pub use crate::triangulation::repair::{LocalFacetRepairGuard, TriangulationRepairOperation};
+pub use crate::triangulation::serialization::{
+    TRIANGULATION_SNAPSHOT_SCHEMA_VERSION, TriangulationSnapshot,
+};
 pub use crate::triangulation::validation::{
     OrientationWitness, TopologyGuarantee, TriangulationValidationError,
     ValidationConfigurationError, ValidationPolicy,
@@ -1718,6 +1724,10 @@ pub mod prelude {
             TriangulationValidationErrorKind, Vertex, VertexKey,
         };
         pub use crate::topology::manifold::ManifoldError;
+        pub use crate::triangulation::editing::{TriangulationEditError, VertexRemovalError};
+        pub use crate::triangulation::serialization::{
+            TRIANGULATION_SNAPSHOT_SCHEMA_VERSION, TriangulationSnapshot,
+        };
         pub use crate::vertex;
         pub use crate::{
             InsertionError, LocalFacetRepairGuard, PeriodicDomainPeriodError, RefinementError,

--- a/src/triangulation/editing.rs
+++ b/src/triangulation/editing.rs
@@ -1,0 +1,330 @@
+//! General Euclidean edits on a proof-bearing Levels 1–4 owner.
+//!
+//! These operations accept non-Delaunay input and never certify Level 5.
+//! For toroidal edits in a selected lifted chart, compose the transactional
+//! [`PachnerMoves`](crate::pachner::PachnerMoves) proposal API instead.
+
+use crate::core::algorithms::insertion::InsertionError;
+use crate::core::tds::VertexKey;
+use crate::core::traits::data_type::DataType;
+use crate::core::vertex::Vertex;
+use crate::geometry::kernel::Kernel;
+use crate::topology::traits::topological_space::TopologyKind;
+use crate::triangulation::Triangulation;
+pub use crate::triangulation::repair::VertexRemovalError;
+
+use thiserror::Error;
+
+/// Structured rejection of a general Levels 1–4 vertex edit.
+#[derive(Clone, Debug, Error, PartialEq)]
+#[non_exhaustive]
+pub enum TriangulationEditError {
+    /// General cavity editing requires Euclidean coordinates.
+    #[error(
+        "general vertex editing is unsupported for {topology:?}; use a chart-bound Pachner proposal"
+    )]
+    UnsupportedTopology {
+        /// The owner's selected geometry.
+        topology: TopologyKind,
+    },
+    /// Insertion or its cumulative postcondition failed.
+    #[error("Level 4 insertion failed: {source}")]
+    Insertion {
+        /// The original insertion diagnostic.
+        #[source]
+        source: Box<InsertionError>,
+    },
+    /// Cavity deletion or its cumulative postcondition failed.
+    #[error("Level 4 deletion failed: {source}")]
+    Deletion {
+        /// The original removal diagnostic.
+        #[source]
+        source: VertexRemovalError,
+    },
+}
+
+impl<K, U, V, const D: usize> Triangulation<K, U, V, D>
+where
+    K: Kernel<D, Scalar = f64>,
+    U: DataType,
+    V: DataType,
+{
+    /// Inserts an exact-coordinate vertex while preserving Levels 1–4.
+    ///
+    /// Interior insertion subdivides the containing simplex; exterior insertion
+    /// extends the hull. Existing non-Delaunay state is accepted. The operation
+    /// never perturbs the input coordinates or performs Level 5 repair. New
+    /// simplices have no payload; surviving vertices and simplices retain theirs.
+    /// A successful edit passes cumulative realization validation regardless of
+    /// the configured validation cadence. Failure restores the complete owner,
+    /// including generational keys and construction evidence.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TriangulationEditError`] for duplicates, unsupported degenerate
+    /// locations, an empty owner requiring bootstrap construction, a non-Euclidean
+    /// topology, or a failed geometric/topological postcondition. Toroidal callers
+    /// can select a lifted simplex using [`PachnerMove::K1Insert`](crate::pachner::PachnerMove::K1Insert)
+    /// and execute its checked proposal through [`PachnerMoves`](crate::pachner::PachnerMoves).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #   #[error(transparent)] Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
+    /// #   #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #   #[error(transparent)] Edit(#[from] delaunay::TriangulationEditError),
+    /// #   #[error(transparent)] Realization(#[from] delaunay::TriangulationRealizationValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
+    /// let vertices = [vertex![0.0, 0.0]?, vertex![1.0, 0.0]?, vertex![0.0, 1.0]?];
+    /// let mut tri = DelaunayTriangulationBuilder::new(&vertices).build_triangulation()?;
+    /// let key = tri.insert_vertex(vertex![0.2, 0.3]?)?;
+    /// assert!(tri.vertex(key).is_some());
+    /// tri.validate_realization()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn insert_vertex(
+        &mut self,
+        vertex: Vertex<U, D>,
+    ) -> Result<VertexKey, TriangulationEditError> {
+        self.require_euclidean_edit()?;
+        self.insert_vertex_preserving_realization(vertex)
+            .map_err(|source| TriangulationEditError::Insertion {
+                source: Box::new(source),
+            })
+    }
+
+    /// Deletes a vertex by retriangulating its cavity, preserving Levels 1–4.
+    ///
+    /// Returns the number of removed simplices, or zero for a missing key.
+    /// Fan filling need not produce a Delaunay triangulation. New simplices have
+    /// no payload, and surviving entities retain UUIDs and payloads. Failure
+    /// restores the complete owner and retains the typed operation or invariant
+    /// diagnostic. In high dimensions an arbitrary fan may lack a PL-link proof
+    /// and is rejected; inverse stellar deletion is available through
+    /// [`PachnerMoves`](crate::pachner::PachnerMoves).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TriangulationEditError`] when the topology is non-Euclidean,
+    /// the cavity cannot be filled, or Levels 1–4 reject the candidate.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #   #[error(transparent)] Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
+    /// #   #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #   #[error(transparent)] Edit(#[from] delaunay::TriangulationEditError),
+    /// #   #[error(transparent)] Realization(#[from] delaunay::TriangulationRealizationValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
+    /// let vertices = [vertex![0.0, 0.0]?, vertex![1.0, 0.0]?, vertex![0.0, 1.0]?];
+    /// let mut tri = DelaunayTriangulationBuilder::new(&vertices).build_triangulation()?;
+    /// let key = tri.insert_vertex(vertex![0.2, 0.3]?)?;
+    /// assert_eq!(tri.delete_vertex(key)?, 3);
+    /// assert!(tri.vertex(key).is_none());
+    /// tri.validate_realization()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn delete_vertex(
+        &mut self,
+        vertex_key: VertexKey,
+    ) -> Result<usize, TriangulationEditError> {
+        self.require_euclidean_edit()?;
+        self.remove_vertex_preserving_realization(vertex_key)
+            .map_err(|source| TriangulationEditError::Deletion { source })
+    }
+
+    /// Prevents Euclidean cavity routines from interpreting periodic quotient coordinates.
+    const fn require_euclidean_edit(&self) -> Result<(), TriangulationEditError> {
+        match self.topology_kind() {
+            TopologyKind::Euclidean => Ok(()),
+            topology => Err(TriangulationEditError::UnsupportedTopology { topology }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DelaunayRefinementBuilder;
+    use crate::core::tds::{Tds, TdsBuilder, TopologyOwner};
+    use crate::geometry::kernel::RobustKernel;
+    use crate::triangulation::builder::TriangulationBuilder;
+    use crate::triangulation::validation::ValidationPolicy;
+    use crate::{DelaunayTriangulationBuilder, vertex};
+
+    /// Supplies a convex quadrilateral with the strictly non-Delaunay diagonal.
+    fn non_delaunay_quad() -> Triangulation<RobustKernel<f64>, u32, u32, 2> {
+        let vertices = [
+            vertex!([0.0, 0.0]; data = 10).unwrap(),
+            vertex!([2.0, 0.0]; data = 20).unwrap(),
+            vertex!([2.0, 1.0]; data = 30).unwrap(),
+            vertex!([0.0, 2.0]; data = 40).unwrap(),
+        ];
+        let tds = TdsBuilder::new(&vertices, &[vec![0, 1, 3], vec![1, 2, 3]])
+            .simplex_data_type::<u32>()
+            .build()
+            .unwrap();
+        TriangulationBuilder::new(tds, RobustKernel::new())
+            .build()
+            .unwrap()
+    }
+
+    /// Exercises exact-coordinate insertion and inverse cavity deletion in each dimension.
+    fn round_trip<const D: usize>() {
+        let mut vertices = vec![vertex!([0.0; D]; data = 7_u32).unwrap()];
+        for axis in 0..D {
+            let mut coordinates = [0.0; D];
+            coordinates[axis] = 1.0;
+            vertices.push(vertex!(coordinates; data = 9).unwrap());
+        }
+        let simplices = [(0..=D).collect::<Vec<_>>()];
+        let tds = TdsBuilder::new(&vertices, &simplices)
+            .simplex_data_type::<u32>()
+            .build()
+            .unwrap();
+        let mut tri = TriangulationBuilder::new(tds, RobustKernel::new())
+            .canonicalizing()
+            .build()
+            .unwrap();
+        let original_vertices = tri
+            .vertices()
+            .map(|(key, vertex)| (key, vertex.uuid(), *vertex.data().unwrap()))
+            .collect::<Vec<_>>();
+        let inserted = vertex!([0.1; D]; data = 99).unwrap();
+        let inserted_uuid = inserted.uuid();
+        let key = tri.insert_vertex(inserted).unwrap();
+        let actual = tri.vertex(key).unwrap();
+        assert_eq!(actual.uuid(), inserted_uuid);
+        assert_eq!(
+            actual.point().coords().map(f64::to_bits),
+            [0.1_f64.to_bits(); D]
+        );
+        assert_eq!(actual.data(), Some(&99));
+        assert_eq!(tri.number_of_simplices(), D + 1);
+        tri.validate_realization().unwrap();
+        assert_eq!(tri.delete_vertex(key).unwrap(), D + 1);
+        assert_eq!(tri.number_of_simplices(), 1);
+        assert_eq!(tri.delete_vertex(key).unwrap(), 0);
+        assert_eq!(
+            tri.vertices()
+                .map(|(key, vertex)| (key, vertex.uuid(), *vertex.data().unwrap()))
+                .collect::<Vec<_>>(),
+            original_vertices
+        );
+        tri.validate_realization().unwrap();
+    }
+
+    macro_rules! dimension_tests {
+        ($($dimension:literal),+) => { $(pastey::paste! {
+            #[test]
+            fn [<insertion_deletion_round_trip_ $dimension d>]() {
+                round_trip::<$dimension>();
+            }
+        })+ };
+    }
+    dimension_tests!(2, 3, 4, 5);
+
+    #[test]
+    fn non_delaunay_input_supports_interior_and_exterior_insertion() {
+        let mut tri = non_delaunay_quad();
+        assert!(DelaunayRefinementBuilder::new(tri.clone()).build().is_err());
+        let key = tri
+            .insert_vertex(vertex!([0.2, 0.3]; data = 50).unwrap())
+            .unwrap();
+        tri.validate_realization().unwrap();
+        tri.delete_vertex(key).unwrap();
+        tri.insert_vertex(vertex!([3.0, 3.0]; data = 60).unwrap())
+            .unwrap();
+        tri.validate_realization().unwrap();
+    }
+
+    #[test]
+    fn failed_insertion_restores_owner_keys_generation_payloads_and_evidence() {
+        let mut tri = non_delaunay_quad();
+        tri.try_set_validation_policy(ValidationPolicy::ExplicitOnly)
+            .unwrap();
+        let original = tri.tds.clone_for_rollback();
+        let serialized = serde_json::to_value(&tri.tds).unwrap();
+        let handles = tri
+            .vertices()
+            .map(|(key, vertex)| (key, vertex.incident_simplex()))
+            .collect::<Vec<_>>();
+        let identity = tri.topology_owner_id();
+        let generation = tri.topology_generation();
+        let evidence = tri.topology_construction_provenance;
+        // This point lies exactly on the existing interior diagonal. A stellar
+        // subdivision cannot realize it without a degenerate simplex.
+        assert!(matches!(
+            tri.insert_vertex(vertex!([1.0, 1.0]; data = 99).unwrap()),
+            Err(TriangulationEditError::Insertion { .. })
+        ));
+        assert_eq!(tri.tds, original);
+        assert_eq!(serde_json::to_value(&tri.tds).unwrap(), serialized);
+        assert_eq!(
+            tri.vertices()
+                .map(|(key, vertex)| (key, vertex.incident_simplex()))
+                .collect::<Vec<_>>(),
+            handles
+        );
+        assert_eq!(tri.topology_owner_id(), identity);
+        assert_eq!(tri.topology_generation(), generation);
+        assert_eq!(tri.topology_construction_provenance, evidence);
+        assert_eq!(tri.validation_policy(), ValidationPolicy::ExplicitOnly);
+        tri.validate_realization().unwrap();
+    }
+
+    #[test]
+    fn failed_deletion_restores_complete_owner_and_typed_error() {
+        let vertices = [
+            vertex![0.0, 0.0].unwrap(),
+            vertex![1.0, 0.0].unwrap(),
+            vertex![0.0, 1.0].unwrap(),
+        ];
+        let mut tri = DelaunayTriangulationBuilder::new(&vertices)
+            .build_triangulation()
+            .unwrap();
+        let key = tri.vertices().next().unwrap().0;
+        let original = tri.tds.clone_for_rollback();
+        let serialized = serde_json::to_value(&tri.tds).unwrap();
+        let identity = tri.topology_owner_id();
+        let generation = tri.topology_generation();
+        assert!(matches!(
+            tri.delete_vertex(key),
+            Err(TriangulationEditError::Deletion { .. })
+        ));
+        assert_eq!(tri.tds, original);
+        assert_eq!(serde_json::to_value(&tri.tds).unwrap(), serialized);
+        assert_eq!(tri.topology_owner_id(), identity);
+        assert_eq!(tri.topology_generation(), generation);
+        tri.validate_realization().unwrap();
+    }
+
+    #[test]
+    fn empty_owner_and_duplicate_insertion_fail_without_mutation() {
+        let mut empty = TriangulationBuilder::new(Tds::<(), (), 2>::empty(), RobustKernel::new())
+            .build()
+            .unwrap();
+        assert!(matches!(empty.insert_vertex(vertex![0.0, 0.0].unwrap()),
+            Err(TriangulationEditError::Insertion { source })
+                if matches!(*source, InsertionError::PublishedOwnerBootstrapRequiresBuilder { dimension: 2 })));
+        assert_eq!(empty.number_of_vertices(), 0);
+        let mut tri = non_delaunay_quad();
+        let before = serde_json::to_value(&tri.tds).unwrap();
+        assert!(
+            matches!(tri.insert_vertex(vertex!([0.0, 0.0]; data = 99).unwrap()),
+            Err(TriangulationEditError::Insertion { source })
+                if matches!(*source, InsertionError::DuplicateCoordinates { .. }))
+        );
+        assert_eq!(serde_json::to_value(&tri.tds).unwrap(), before);
+    }
+}

--- a/src/triangulation/insertion.rs
+++ b/src/triangulation/insertion.rs
@@ -539,6 +539,55 @@ where
     U: DataType,
     V: DataType,
 {
+    /// Runs Level 4 insertion without assuming a Delaunay conflict cavity.
+    ///
+    /// An empty explicit conflict set selects the containing simplex's stellar
+    /// subdivision for interior points, or hull extension for exterior points.
+    /// The caller must select Euclidean geometry before entering this path.
+    pub(crate) fn insert_vertex_preserving_realization(
+        &mut self,
+        vertex: Vertex<U, D>,
+    ) -> Result<VertexKey, InsertionError> {
+        if D > 0 && self.tds.number_of_simplices() == 0 {
+            return Err(InsertionError::PublishedOwnerBootstrapRequiresBuilder { dimension: D });
+        }
+        let mut prepared = self.prepare_insertion(vertex, None, None);
+        if let Some(DetailedInsertionResult {
+            outcome: InsertionOutcome::Skipped { error },
+            ..
+        }) = self.duplicate_skip(&mut prepared, None)
+        {
+            return Err(error);
+        }
+
+        let mut transaction = TriangulationRollbackTransaction::begin(self);
+        let conflict = SimplexKeyBuffer::new();
+        let result = Self::insert_prepared_in_rollback_window(
+            &mut transaction,
+            prepared,
+            Some(&conflict),
+            0,
+            0,
+            None,
+            None,
+            InsertionTelemetryMode::CountsOnly,
+            false,
+            true,
+        )?;
+        let vertex_key = match result.outcome {
+            InsertionOutcome::Inserted { vertex_key, .. } => vertex_key,
+            InsertionOutcome::Skipped { error } => return Err(error),
+        };
+        // The generic adapter accepts non-Delaunay input and does not rely on
+        // Level 5 cavity arguments or a caller's optional validation cadence.
+        transaction
+            .triangulation_mut()
+            .validate_realization()
+            .map_err(|source| InsertionError::RealizationValidationFailed { source })?;
+        transaction.commit();
+        Ok(vertex_key)
+    }
+
     /// Returns duplicate-detection telemetry if enabled via `DELAUNAY_DUPLICATE_METRICS`.
     ///
     /// This is a process-wide counter (across all triangulation instances). It reports how often

--- a/src/triangulation/model.rs
+++ b/src/triangulation/model.rs
@@ -38,6 +38,12 @@ use crate::triangulation::validation::{
 /// triangulation with [`DelaunayRefinementBuilder`](crate::DelaunayRefinementBuilder)
 /// to certify Level 5 strictly or repair and certify the Delaunay property.
 ///
+/// Mutable adapters can use [`Self::insert_vertex`], [`Self::delete_vertex`],
+/// and [`Self::to_visualization_data`] without Level 5 certification. Serde
+/// persists exact UUID connectivity and topology context; load through
+/// [`TriangulationSnapshot`](crate::TriangulationSnapshot) to select a kernel
+/// and retain typed strict-restoration errors.
+///
 /// # Type Parameters
 /// - `K`: Geometric kernel implementing predicates
 /// - `U`: User data type for vertices

--- a/src/triangulation/repair.rs
+++ b/src/triangulation/repair.rs
@@ -304,6 +304,8 @@ impl VertexRemovalOutcome {
 /// the exact post-repair, pre-publication boundary without global test state.
 #[derive(Clone, Copy, Debug, Default)]
 struct VertexRemovalProofOptions {
+    /// General Level 4 editing checks the complete candidate before publication.
+    full_realization_validation: bool,
     corrupt_realization_before_final_check: bool,
 }
 
@@ -570,6 +572,21 @@ where
             vertex_key,
             VertexRemovalProofOptions::default(),
         )
+    }
+
+    /// Publishes a general cavity deletion only after cumulative Levels 1–4 validation.
+    pub(crate) fn remove_vertex_preserving_realization(
+        &mut self,
+        vertex_key: VertexKey,
+    ) -> Result<usize, VertexRemovalError> {
+        self.remove_vertex_with_repair_seeds_with_options(
+            vertex_key,
+            VertexRemovalProofOptions {
+                full_realization_validation: true,
+                ..VertexRemovalProofOptions::default()
+            },
+        )
+        .map(|outcome| outcome.simplices_removed)
     }
 
     /// Runs vertex removal with private proof controls used by the owning rollback regression.
@@ -924,6 +941,8 @@ where
                     .is_valid()
                     .map_err(|source| InvariantError::Tds { source })?;
                 tri.is_valid_topology()?;
+                tri.is_valid_realization()
+                    .map_err(|source| InvariantError::Realization { source })?;
                 Ok(simplices_removed)
             })()
         };
@@ -1065,6 +1084,11 @@ where
         }
         self.validate_realization_for_simplices(validation_scope)
             .map_err(|source| InvariantError::Realization { source })?;
+
+        if proof_options.full_realization_validation {
+            self.validate_realization()
+                .map_err(|source| InvariantError::Realization { source })?;
+        }
 
         #[cfg(debug_assertions)]
         {
@@ -2236,6 +2260,7 @@ mod tests {
             vertex_key,
             VertexRemovalProofOptions {
                 corrupt_realization_before_final_check: true,
+                ..VertexRemovalProofOptions::default()
             },
         );
 

--- a/src/triangulation/serialization.rs
+++ b/src/triangulation/serialization.rs
@@ -1,0 +1,506 @@
+//! Exact UUID persistence for Levels 1–4 triangulations.
+//!
+//! The outer serde envelope embeds a CBOR TDS image so floating-point bits do
+//! not depend on the outer codec. Loading validates Levels 1–4 strictly, with
+//! no orientation normalization, connectivity changes, or Level 5 work.
+//! Runtime keys, caches, kernel configuration, and construction provenance are
+//! not portable; keys and incidence are rebuilt from UUIDs. Untrusted metadata
+//! never supplies a high-dimensional PL-link proof.
+
+use crate::core::tds::{RawTdsSnapshot, Tds, ValidatedTdsSerialization};
+use crate::core::traits::data_type::{DataDeserialize, DataSerialize, DataType};
+use crate::geometry::kernel::Kernel;
+use crate::topology::traits::topological_space::{GlobalTopology, ToroidalConstructionMode};
+use crate::triangulation::Triangulation;
+use crate::triangulation::builder::{TriangulationBuildFailure, TriangulationBuilder};
+use crate::triangulation::validation::{TopologyGuarantee, ValidationPolicy};
+
+use ciborium::Value as CborValue;
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de, ser};
+
+/// Version of the exact Levels 1–4 persistence envelope.
+pub const TRIANGULATION_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+/// Separates the payload codec representation from the entity's optional data slot.
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StoredPayload<T> {
+    value: T,
+}
+
+/// Rejects CBOR's ambiguous null representation before it can change a payload on reload.
+fn contains_null(value: &CborValue) -> bool {
+    match value {
+        CborValue::Null => true,
+        CborValue::Array(values) => values.iter().any(contains_null),
+        CborValue::Map(entries) => entries
+            .iter()
+            .any(|(key, value)| contains_null(key) || contains_null(value)),
+        CborValue::Tag(_, value) => contains_null(value),
+        _ => false,
+    }
+}
+
+/// Captures each borrowed payload once, so validation and encoding observe the same value.
+fn capture_payload<T: Serialize, E: ser::Error>(
+    payload: &T,
+) -> Result<StoredPayload<CborValue>, E> {
+    let value = CborValue::serialized(payload).map_err(E::custom)?;
+    if contains_null(&value) {
+        return Err(E::custom(
+            "triangulation payload contains ambiguous CBOR null/unit data; use an explicitly tagged payload enum",
+        ));
+    }
+    Ok(StoredPayload { value })
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum StoredGuarantee {
+    Pseudomanifold,
+    PlManifold,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum StoredPolicy {
+    Never,
+    ExplicitOnly,
+    OnSuspicion,
+    Always,
+    DebugOnly,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum StoredToroidalMode {
+    PeriodicImagePoint,
+    Explicit,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+enum StoredTopology {
+    Euclidean,
+    Toroidal {
+        period_bits: Vec<u64>,
+        mode: StoredToroidalMode,
+    },
+    Spherical,
+    Hyperbolic,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SnapshotWire {
+    schema_version: u32,
+    dimension: usize,
+    tds: Vec<u8>,
+    topology_guarantee: StoredGuarantee,
+    global_topology: StoredTopology,
+    validation_policy: StoredPolicy,
+}
+
+/// Decoded Levels 1–2 storage and context for strict Level 4 restoration.
+///
+/// Deserialize this type to separate codec errors from the typed, recoverable
+/// [`TriangulationBuildFailure`] returned by [`Self::try_into_triangulation`].
+/// Decoding validates UUID relationships and TDS invariants; it does not yet
+/// certify topology or realization. The kernel is chosen explicitly at restoration.
+/// Serialization through [`Triangulation`] borrows payloads and requires only
+/// `Serialize`, with no `Clone` bound. Restoring the owner retains the usual
+/// [`DataType`] bounds of [`TriangulationBuilder`].
+/// Present payloads containing null/unit values are rejected during serialization
+/// because CBOR cannot distinguish all nested `Option` states. Use explicit
+/// tagged enums for those values; an absent entity payload remains supported.
+#[derive(Debug)]
+pub struct TriangulationSnapshot<U, V, const D: usize> {
+    tds: Tds<U, V, D>,
+    topology_guarantee: TopologyGuarantee,
+    global_topology: GlobalTopology<D>,
+    validation_policy: ValidationPolicy,
+}
+
+impl<U, V, const D: usize> TriangulationSnapshot<U, V, D>
+where
+    U: DataType,
+    V: DataType,
+{
+    /// Restores exact connectivity with the supplied kernel and proves Levels 1–4.
+    ///
+    /// UUIDs, simplex vertex order, neighbor slots, periodic lift offsets,
+    /// topology context, policy, and payloads are retained. Runtime keys are
+    /// newly allocated and should be resolved by UUID. No Level 5 work occurs.
+    ///
+    /// # Errors
+    ///
+    /// Returns the unchanged decoded TDS with a typed [`TriangulationBuildFailure`]
+    /// when strict certification fails. Nontrivial high-dimensional PL manifolds
+    /// whose link proof depends on construction history may be rejected: serialized
+    /// metadata is not accepted as proof of that history.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
+    /// use delaunay::prelude::triangulation::{RobustKernel, TriangulationSnapshot};
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #   #[error(transparent)] Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
+    /// #   #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #   #[error(transparent)] Codec(#[from] serde_json::Error),
+    /// #   #[error(transparent)] Restore(#[from] delaunay::TriangulationBuildFailure<(), (), 2>),
+    /// #   #[error(transparent)] Realization(#[from] delaunay::TriangulationRealizationValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
+    /// let vertices = [vertex![0.0, 0.0]?, vertex![1.0, 0.0]?, vertex![0.0, 1.0]?];
+    /// let tri = DelaunayTriangulationBuilder::new(&vertices).build_triangulation()?;
+    /// let json = serde_json::to_string(&tri)?;
+    /// let snapshot: TriangulationSnapshot<(), (), 2> = serde_json::from_str(&json)?;
+    /// let restored = snapshot.try_into_triangulation(RobustKernel::new())?;
+    /// restored.validate_realization()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn try_into_triangulation<K>(
+        self,
+        kernel: K,
+    ) -> Result<Triangulation<K, U, V, D>, TriangulationBuildFailure<U, V, D>>
+    where
+        K: Kernel<D, Scalar = f64>,
+    {
+        TriangulationBuilder::new(self.tds, kernel)
+            .topology_guarantee(self.topology_guarantee)
+            .global_topology(self.global_topology)
+            .validation_policy(self.validation_policy)
+            .build()
+    }
+}
+
+impl<K, U, V, const D: usize> Serialize for Triangulation<K, U, V, D>
+where
+    U: DataSerialize,
+    V: DataSerialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let validated =
+            ValidatedTdsSerialization::try_new(&self.tds).map_err(ser::Error::custom)?;
+        let snapshot = validated.snapshot().map_err(ser::Error::custom)?;
+        let wrapped = snapshot.try_map_payloads(
+            capture_payload::<_, S::Error>,
+            capture_payload::<_, S::Error>,
+        )?;
+        let mut tds = Vec::new();
+        ciborium::ser::into_writer(&wrapped.into_raw(), &mut tds).map_err(ser::Error::custom)?;
+        SnapshotWire {
+            schema_version: TRIANGULATION_SNAPSHOT_SCHEMA_VERSION,
+            dimension: D,
+            tds,
+            topology_guarantee: match self.topology_guarantee {
+                TopologyGuarantee::Pseudomanifold => StoredGuarantee::Pseudomanifold,
+                TopologyGuarantee::PLManifold => StoredGuarantee::PlManifold,
+            },
+            global_topology: match self.global_topology {
+                GlobalTopology::Euclidean => StoredTopology::Euclidean,
+                GlobalTopology::Toroidal { domain, mode } => StoredTopology::Toroidal {
+                    period_bits: domain
+                        .periods()
+                        .iter()
+                        .map(|period| period.to_bits())
+                        .collect(),
+                    mode: match mode {
+                        ToroidalConstructionMode::PeriodicImagePoint => {
+                            StoredToroidalMode::PeriodicImagePoint
+                        }
+                        ToroidalConstructionMode::Explicit => StoredToroidalMode::Explicit,
+                    },
+                },
+                GlobalTopology::Spherical => StoredTopology::Spherical,
+                GlobalTopology::Hyperbolic => StoredTopology::Hyperbolic,
+            },
+            validation_policy: match self.validation_policy {
+                ValidationPolicy::Never => StoredPolicy::Never,
+                ValidationPolicy::ExplicitOnly => StoredPolicy::ExplicitOnly,
+                ValidationPolicy::OnSuspicion => StoredPolicy::OnSuspicion,
+                ValidationPolicy::Always => StoredPolicy::Always,
+                ValidationPolicy::DebugOnly => StoredPolicy::DebugOnly,
+            },
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de, U, V, const D: usize> Deserialize<'de> for TriangulationSnapshot<U, V, D>
+where
+    U: DataDeserialize,
+    V: DataDeserialize,
+{
+    fn deserialize<De>(deserializer: De) -> Result<Self, De::Error>
+    where
+        De: Deserializer<'de>,
+    {
+        let wire = SnapshotWire::deserialize(deserializer)?;
+        if wire.schema_version != TRIANGULATION_SNAPSHOT_SCHEMA_VERSION {
+            return Err(de::Error::custom(format_args!(
+                "unsupported triangulation snapshot version {}",
+                wire.schema_version
+            )));
+        }
+        if wire.dimension != D {
+            return Err(de::Error::custom(format_args!(
+                "snapshot dimension {} does not match {D}",
+                wire.dimension
+            )));
+        }
+        let global_topology = match wire.global_topology {
+            StoredTopology::Euclidean => GlobalTopology::Euclidean,
+            StoredTopology::Toroidal { period_bits, mode } => {
+                let periods: [u64; D] = period_bits.try_into().map_err(|bits: Vec<u64>| {
+                    de::Error::custom(format_args!("expected {D} periods, got {}", bits.len()))
+                })?;
+                GlobalTopology::try_toroidal(
+                    periods.map(f64::from_bits),
+                    match mode {
+                        StoredToroidalMode::PeriodicImagePoint => {
+                            ToroidalConstructionMode::PeriodicImagePoint
+                        }
+                        StoredToroidalMode::Explicit => ToroidalConstructionMode::Explicit,
+                    },
+                )
+                .map_err(de::Error::custom)?
+            }
+            StoredTopology::Spherical => GlobalTopology::Spherical,
+            StoredTopology::Hyperbolic => GlobalTopology::Hyperbolic,
+        };
+        let mut remaining = wire.tds.as_slice();
+        let raw: RawTdsSnapshot<StoredPayload<U>, StoredPayload<V>, D> =
+            ciborium::de::from_reader(&mut remaining).map_err(de::Error::custom)?;
+        if !remaining.is_empty() {
+            return Err(de::Error::custom(
+                "trailing bytes in triangulation TDS image",
+            ));
+        }
+        let tds = raw
+            .parse()
+            .map_err(de::Error::custom)?
+            .map_payloads(|payload| payload.value, |payload| payload.value)
+            .into_tds()
+            .map_err(de::Error::custom)?;
+        Ok(Self {
+            tds,
+            topology_guarantee: match wire.topology_guarantee {
+                StoredGuarantee::Pseudomanifold => TopologyGuarantee::Pseudomanifold,
+                StoredGuarantee::PlManifold => TopologyGuarantee::PLManifold,
+            },
+            global_topology,
+            validation_policy: match wire.validation_policy {
+                StoredPolicy::Never => ValidationPolicy::Never,
+                StoredPolicy::ExplicitOnly => ValidationPolicy::ExplicitOnly,
+                StoredPolicy::OnSuspicion => ValidationPolicy::OnSuspicion,
+                StoredPolicy::Always => ValidationPolicy::Always,
+                StoredPolicy::DebugOnly => ValidationPolicy::DebugOnly,
+            },
+        })
+    }
+}
+
+impl<'de, K, U, V, const D: usize> Deserialize<'de> for Triangulation<K, U, V, D>
+where
+    K: Kernel<D, Scalar = f64> + Default,
+    U: DataType,
+    V: DataType,
+{
+    fn deserialize<De>(deserializer: De) -> Result<Self, De::Error>
+    where
+        De: Deserializer<'de>,
+    {
+        TriangulationSnapshot::deserialize(deserializer)?
+            .try_into_triangulation(K::default())
+            .map_err(de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::tds::TdsBuilder;
+    use crate::geometry::kernel::RobustKernel;
+    use crate::triangulation::builder::TriangulationBuilderError;
+    use crate::triangulation::validation::TopologyConstructionProvenance;
+    use crate::vertex;
+    use serde_json::Value;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(transparent)]
+    struct NonClonePayload(u32);
+
+    /// Builds one recognizable PL ball with payloads and nontrivial coordinate bits.
+    fn sample<const D: usize>() -> Triangulation<RobustKernel<f64>, u32, u32, D> {
+        let mut vertices = vec![vertex!([0.0; D]; data = 7_u32).unwrap()];
+        for axis in 0..D {
+            let mut coordinates = [0.0; D];
+            coordinates[axis] = f64::from_bits(1.0_f64.to_bits() + 1);
+            vertices.push(vertex!(coordinates; data = 9_u32).unwrap());
+        }
+        let simplices = [(0..=D).collect::<Vec<_>>()];
+        let tds = TdsBuilder::new(&vertices, &simplices)
+            .simplex_data_type::<u32>()
+            .build()
+            .unwrap();
+        let mut tri = TriangulationBuilder::new(tds, RobustKernel::new())
+            .validation_policy(ValidationPolicy::Always)
+            .canonicalizing()
+            .build()
+            .unwrap();
+        let key = tri.simplices().next().unwrap().0;
+        tri.set_simplex_data(key, Some(42)).unwrap();
+        tri
+    }
+
+    /// Checks bitwise coordinates, UUID relations, policy, and optional payload presence.
+    fn round_trip<const D: usize>() {
+        let tri = sample::<D>();
+        let json = serde_json::to_string(&tri).unwrap();
+        let snapshot: TriangulationSnapshot<u32, u32, D> = serde_json::from_str(&json).unwrap();
+        let restored = snapshot
+            .try_into_triangulation(RobustKernel::new())
+            .unwrap();
+        assert_eq!(restored.validation_policy(), ValidationPolicy::Always);
+        assert_eq!(restored.global_topology(), tri.global_topology());
+        assert_eq!(restored.topology_guarantee(), tri.topology_guarantee());
+        for (_, vertex) in tri.vertices() {
+            let key = restored.vertex_key_from_uuid(&vertex.uuid()).unwrap();
+            let actual = restored.vertex(key).unwrap();
+            assert_eq!(
+                actual.point().coords().map(f64::to_bits),
+                vertex.point().coords().map(f64::to_bits)
+            );
+            assert_eq!(actual.data(), vertex.data());
+        }
+        assert_eq!(restored.simplices().next().unwrap().1.data(), Some(&42));
+        assert_eq!(
+            serde_json::to_value(&restored.tds).unwrap(),
+            serde_json::to_value(&tri.tds).unwrap()
+        );
+        restored.validate_realization().unwrap();
+        let mut bytes = Vec::new();
+        ciborium::ser::into_writer(&tri, &mut bytes).unwrap();
+        let from_cbor: Triangulation<RobustKernel<f64>, u32, u32, D> =
+            ciborium::de::from_reader(bytes.as_slice()).unwrap();
+        assert_eq!(
+            serde_json::to_value(from_cbor.tds).unwrap(),
+            serde_json::to_value(tri.tds).unwrap()
+        );
+    }
+
+    macro_rules! dimension_tests {
+        ($($dimension:literal),+) => { $(pastey::paste! {
+            #[test]
+            fn [<exact_snapshot_round_trip_ $dimension d>]() { round_trip::<$dimension>(); }
+        })+ };
+    }
+    dimension_tests!(2, 3, 4, 5);
+
+    #[test]
+    fn serialization_and_transport_decoding_do_not_require_clone() {
+        let vertices = [
+            vertex!([0.0, 0.0]; data = 7_u32).unwrap(),
+            vertex!([1.0, 0.0]; data = 8).unwrap(),
+            vertex!([0.0, 1.0]; data = 9).unwrap(),
+        ];
+        let tds = TdsBuilder::new(&vertices, &[vec![0, 1, 2]])
+            .simplex_data_type::<u32>()
+            .build()
+            .unwrap();
+        let tri = TriangulationBuilder::new(tds, RobustKernel::new())
+            .build()
+            .unwrap();
+        let snapshot: TriangulationSnapshot<NonClonePayload, NonClonePayload, 2> =
+            serde_json::from_str(&serde_json::to_string(&tri).unwrap()).unwrap();
+        // The fixture's geometry is already certified. Only the transparent
+        // payload wrapper changes; no geometry or topology data is modified.
+        let non_clone = Triangulation {
+            kernel: RobustKernel::<f64>::new(),
+            tds: snapshot.tds,
+            topology_guarantee: snapshot.topology_guarantee,
+            global_topology: snapshot.global_topology,
+            validation_policy: snapshot.validation_policy,
+            topology_construction_provenance: TopologyConstructionProvenance::Unproven,
+        };
+        let encoded = serde_json::to_string(&non_clone).unwrap();
+        let decoded: TriangulationSnapshot<NonClonePayload, NonClonePayload, 2> =
+            serde_json::from_str(&encoded).unwrap();
+        assert_eq!(
+            decoded
+                .tds
+                .vertices()
+                .map(|(_, vertex)| vertex.data().unwrap().0)
+                .collect::<Vec<_>>(),
+            [7, 8, 9]
+        );
+        assert_eq!(non_clone.to_visualization_data().unwrap().vertices.len(), 3);
+    }
+
+    #[test]
+    fn malformed_envelopes_and_trailing_images_are_rejected() {
+        let original = serde_json::to_value(sample::<2>()).unwrap();
+        for (field, value) in [
+            ("schema_version", Value::from(2)),
+            ("dimension", Value::from(3)),
+        ] {
+            let mut invalid = original.clone();
+            invalid[field] = value;
+            assert!(serde_json::from_value::<TriangulationSnapshot<u32, u32, 2>>(invalid).is_err());
+        }
+        let mut trailing = original.clone();
+        trailing["tds"].as_array_mut().unwrap().push(Value::from(0));
+        assert!(serde_json::from_value::<TriangulationSnapshot<u32, u32, 2>>(trailing).is_err());
+        let mut forged = original;
+        forged["construction_provenance"] = Value::from("euclidean_delaunay_insertion");
+        assert!(serde_json::from_value::<TriangulationSnapshot<u32, u32, 2>>(forged).is_err());
+    }
+
+    #[test]
+    fn ambiguous_present_payloads_are_rejected_without_cloning_or_changing_state() {
+        for payload in [None, Some(())] {
+            let vertices = [
+                vertex!([0.0, 0.0]; data = payload).unwrap(),
+                vertex!([1.0, 0.0]; data = payload).unwrap(),
+                vertex!([0.0, 1.0]; data = payload).unwrap(),
+            ];
+            let tds = TdsBuilder::new(&vertices, &[vec![0, 1, 2]])
+                .build()
+                .unwrap();
+            let tri = TriangulationBuilder::new(tds, RobustKernel::new())
+                .build()
+                .unwrap();
+            let error = serde_json::to_string(&tri).unwrap_err();
+            assert!(error.to_string().contains("ambiguous CBOR null/unit data"));
+            assert!(
+                tri.vertices()
+                    .all(|(_, vertex)| vertex.data() == Some(&payload))
+            );
+        }
+    }
+
+    #[test]
+    fn restored_high_dimensional_proof_is_not_inferred_from_metadata() {
+        let mut tri = sample::<4>();
+        tri.insert_vertex(vertex!([0.1; 4]; data = 7_u32).unwrap())
+            .unwrap();
+        let snapshot: TriangulationSnapshot<u32, u32, 4> =
+            serde_json::from_str(&serde_json::to_string(&tri).unwrap()).unwrap();
+        let expected = serde_json::to_value(&snapshot.tds).unwrap();
+        let failure = snapshot
+            .try_into_triangulation(RobustKernel::new())
+            .unwrap_err();
+        assert!(matches!(
+            failure.reason(),
+            TriangulationBuilderError::TopologyValidation { .. }
+        ));
+        assert_eq!(serde_json::to_value(failure.owner()).unwrap(), expected);
+    }
+}

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -21,10 +21,11 @@ use delaunay::prelude::ordering::{
 };
 use delaunay::prelude::pachner::{PachnerMove, PachnerMoves};
 use delaunay::prelude::repair::DelaunayRepairError;
-use delaunay::prelude::tds::{InvariantError, Tds};
+use delaunay::prelude::tds::{InvariantError, Tds, TdsBuilder};
 use delaunay::prelude::topology::spaces::{GlobalTopology, TopologyKind};
 use delaunay::prelude::triangulation::{
-    Triangulation, TriangulationBuilder, TriangulationBuilderError,
+    Triangulation, TriangulationBuilder, TriangulationBuilderError, TriangulationEditError,
+    TriangulationSnapshot,
 };
 use delaunay::prelude::validation::{
     DelaunayTriangulationValidationError, TriangulationRealizationValidationError,
@@ -1125,6 +1126,119 @@ fn regression_issue_557_restores_evolved_toroidal_state_through_level_4() {
         global_topology,
     );
     assert_level_three_failure_returns_tds(evolved_tds, topology_guarantee, global_topology);
+}
+
+#[test]
+fn regression_issue_591_euclidean_non_delaunay_adapter_workflow() {
+    let vertices = [
+        vertex!([0.0, 0.0]; data = 10_u32).unwrap(),
+        vertex!([2.0, 0.0]; data = 20).unwrap(),
+        vertex!([2.0, 1.0]; data = 30).unwrap(),
+        vertex!([0.0, 2.0]; data = 40).unwrap(),
+    ];
+    let tds = TdsBuilder::new(&vertices, &[vec![0, 1, 3], vec![1, 2, 3]])
+        .simplex_data_type::<u32>()
+        .build()
+        .unwrap();
+    let mut tri = TriangulationBuilder::new(tds, RobustKernel::new())
+        .build()
+        .unwrap();
+    assert!(DelaunayRefinementBuilder::new(tri.clone()).build().is_err());
+    let before = serde_json::to_value(tri.to_visualization_data().unwrap()).unwrap();
+    let encoded = serde_json::to_string(&tri).unwrap();
+    let decoded: TriangulationSnapshot<u32, u32, 2> = serde_json::from_str(&encoded).unwrap();
+    let restored = decoded.try_into_triangulation(RobustKernel::new()).unwrap();
+    assert_eq!(
+        serde_json::to_value(restored.to_visualization_data().unwrap()).unwrap(),
+        before
+    );
+    let failure = DelaunayRefinementBuilder::new(restored)
+        .build()
+        .unwrap_err();
+    failure.owner().validate_realization().unwrap();
+    let key = tri
+        .insert_vertex(vertex!([0.2, 0.3]; data = 99).unwrap())
+        .unwrap();
+    assert_eq!(tri.vertex(key).unwrap().data(), Some(&99));
+    tri.delete_vertex(key).unwrap();
+    tri.validate_realization().unwrap();
+}
+
+#[test]
+fn regression_issue_591_evolved_torus_export_persistence_and_pachner_composition() {
+    let fresh = periodic_payload_fixture_t2();
+    assert_eq!(
+        serde_json::to_value(fresh.to_visualization_data().unwrap()).unwrap(),
+        serde_json::to_value(fresh.as_triangulation().to_visualization_data().unwrap()).unwrap(),
+    );
+    let mut tri = evolve_periodic_fixture_without_delaunay(&fresh);
+    tri.try_set_validation_policy(ValidationPolicy::Always)
+        .unwrap();
+    let expected_storage = serde_json::to_value(tri.clone().into_tds()).unwrap();
+    let expected_export = serde_json::to_value(tri.to_visualization_data().unwrap()).unwrap();
+    let restored: Triangulation<RobustKernel<f64>, u32, u32, 2> =
+        serde_json::from_str(&serde_json::to_string(&tri).unwrap()).unwrap();
+    assert_eq!(restored.global_topology(), tri.global_topology());
+    assert_eq!(restored.topology_guarantee(), tri.topology_guarantee());
+    assert_eq!(restored.validation_policy(), ValidationPolicy::Always);
+    assert_eq!(
+        serde_json::to_value(restored.to_visualization_data().unwrap()).unwrap(),
+        expected_export
+    );
+    assert_eq!(
+        serde_json::to_value(restored.clone().into_tds()).unwrap(),
+        expected_storage
+    );
+    assert!(DelaunayRefinementBuilder::new(restored).build().is_err());
+
+    // General Euclidean routines cannot reinterpret periodic quotient coordinates.
+    let key = tri.vertices().next().unwrap().0;
+    let keys_before = tri.vertices().map(|(key, _)| key).collect::<Vec<_>>();
+    assert_eq!(
+        tri.insert_vertex(vertex!([0.4, 0.4]; data = 99).unwrap())
+            .unwrap_err(),
+        TriangulationEditError::UnsupportedTopology {
+            topology: TopologyKind::Toroidal
+        }
+    );
+    assert_eq!(
+        tri.delete_vertex(key).unwrap_err(),
+        TriangulationEditError::UnsupportedTopology {
+            topology: TopologyKind::Toroidal
+        }
+    );
+    assert_eq!(
+        tri.vertices().map(|(key, _)| key).collect::<Vec<_>>(),
+        keys_before
+    );
+    assert_eq!(
+        serde_json::to_value(tri.clone().into_tds()).unwrap(),
+        expected_storage
+    );
+
+    // A chart-bound proposal composes the already public transactional primitive.
+    let proposal = tri
+        .simplices()
+        .find_map(|(simplex_key, _)| {
+            let point = tri.simplex_barycenter(simplex_key).unwrap();
+            tri.propose_pachner(PachnerMove::K1Insert {
+                simplex_key,
+                vertex: vertex!(*point.coords(); data = 123).unwrap(),
+            })
+            .ok()
+        })
+        .expect("an evolved periodic simplex must admit an interior stellar subdivision");
+    let inserted = proposal.attempt_on(&mut tri).unwrap();
+    tri.validate_realization().unwrap();
+    let vertex_key = inserted.inserted_face_vertices[0];
+    assert_eq!(tri.vertex(vertex_key).unwrap().data(), Some(&123));
+    let _removed = tri
+        .propose_pachner(PachnerMove::K1Remove { vertex_key })
+        .unwrap()
+        .attempt_on(&mut tri)
+        .unwrap();
+    assert!(tri.vertex(vertex_key).is_none());
+    tri.validate_realization().unwrap();
 }
 
 #[test]


### PR DESCRIPTION
- Share visualization export between Triangulation and Delaunay owners.
- Add exact UUID snapshots that preserve topology context and payloads without requiring Clone for serialization.
- Expose transactional Euclidean insertion and deletion with typed failures and complete rollback.
- Document toroidal Pachner composition and persistence limits while keeping Level 5 refinement explicit.
- Add CodeRabbit review recipes for branch and uncommitted changes, and require review of substantive changes before final validation.

Closes #591