### PR TITLE
ci: enforce Python typing and expand triangulation coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,6 +11,5 @@ coverage:
         target: 70%
 
 ignore:
-  - "src/lib.rs"
   - "benches/**"
   - "examples/**"

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -29,7 +29,9 @@ reviews:
   auto_assign_reviewers: false
   poem: true
   labeling_instructions: []
-  path_filters: []
+  # Deliberate violations are validated by repository-owned fixture checks.
+  path_filters:
+    - "!tests/semgrep/**"
   path_instructions:
     - path: "scripts/*.py"
       instructions: |
@@ -52,8 +54,8 @@ reviews:
       enabled: true
   pre_merge_checks:
     docstrings:
-      mode: warning
-      threshold: 100
+      # Ruff owns the Python docstring policy, including fixture exceptions.
+      mode: "off"
     title:
       mode: warning
       requirements: ""

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -79,7 +79,7 @@ changed surface.
 | Touched surface | Iteration validation | Final validation / PR readiness |
 |-----|-----|-----|
 | Markdown documentation (`*.md`) | `just markdown-check` | `just check-docs` |
-| Python under `scripts/` | Targeted pytest or `just test-python`; add `just python-check` for logic/style | `just python-check` and `just test-python` |
+| Python sources and fixtures | Targeted pytest and `just python-check` | `just python-check` and `just test-python` |
 | Jupyter notebooks (`notebooks/**/*.ipynb`) | `just notebook-check` | `just notebook-check` |
 | Paper sources and figures (`papers/**/*`, paper notebooks) | `just paper-check` | `just papers` |
 | Configuration only (JSON, TOML, YAML, CFF, workflows) | Matching config validator | `just check-config` |
@@ -91,6 +91,9 @@ changed surface.
 | Core Rust code | `just check` and targeted tests | `just ci` |
 | Mixed focused surfaces without core Rust | Run each matching focused validator once | Run each matching focused validator once |
 | Mixed core Rust plus tests/benches/examples/docs/config | `just check` and targeted tests | `just ci` |
+
+For Semgrep fixture changes, also run `just semgrep-test` to preserve the
+deliberate positive and negative cases.
 
 Do not run `just ci` merely because documentation, configuration, Python,
 notebook, or test-only Rust files changed. Do not run `just test` when a single
@@ -334,7 +337,8 @@ This runs:
 - release-version reference synchronization
 - `Cargo.toml`/`Cargo.lock` synchronization
 - JSON/TOML/YAML/CFF checks
-- Python lint/typecheck
+- Python formatting, full-policy lint, and type checks across tracked and new sources
+- direct Python Semgrep fixture lint
 - notebook hygiene and extracted-code checks
 - canonical validation-figure currentness on macOS
 - shell script formatting and lint checks
@@ -358,8 +362,8 @@ measured workflow maintains its triangulation, predicate, topology, and
 diagnostic invariants.
 
 `just ci` is the comprehensive error-catching validation path used by GitHub
-Actions. It composes `just check`, `just test`, `just bench-compile`, and
-`just examples`. The target classes remain orthogonal: `rust-core-check` covers
+Actions. It composes `just check`, `just python-fixture-lint`, `just test`,
+`just bench-compile`, and `just examples`. The target classes remain orthogonal: `rust-core-check` covers
 formatting, all-targets Clippy, rustdoc, and Semgrep; `unused-deps` checks direct
 Cargo dependency hygiene; `test-rust` composes unit, integration, CLI, and
 doctest buckets; `notebook-check` validates notebooks without executing them.

--- a/docs/dev/python.md
+++ b/docs/dev/python.md
@@ -1,6 +1,7 @@
 # Python Development Guidelines
 
-Guidance for Python automation under `scripts/`.
+Guidance for repository-owned Python, including automation under `scripts/`
+and static-analysis fixtures under `tests/semgrep/`.
 
 The Rust library is the primary product, but the Python benchmark, changelog,
 hardware, and release utilities are part of the trusted development workflow.
@@ -19,10 +20,17 @@ just test-python
 ```
 
 `just python-check` runs Ruff formatting checks, Ruff linting, and
-`just python-typecheck`. `just python-typecheck` runs
-`ty check scripts/ --error all`, which is the type-checking authority. Prefer
-reducing untyped surfaces in code and tests over adding more `ty`
-configuration.
+`just python-typecheck`. All three checks share a Git-derived list of tracked
+Python files plus new, unignored `.py` and `.pyi` files, including files outside
+`scripts/`. Deleted files are skipped. The fixer uses the same list.
+`ty check --error all` is the type-checking authority. Prefer reducing untyped
+surfaces in code and tests over adding more `ty` configuration.
+
+`just python-fixture-lint` runs the full configured Ruff policy over
+`tests/semgrep/` and is a direct dependency of `just ci`. Deliberate fixture
+violations use exact per-file rule ignores or line-specific suppressions;
+typing and annotation-import rules remain active. CodeRabbit excludes these
+fixtures from general review and leaves Python docstring policy to Ruff.
 
 `just check` also runs Python formatting checks, Ruff, and `ty` as part of the
 normal repository validation bundle.
@@ -36,7 +44,14 @@ treating `.ipynb` files as ordinary Python scripts.
 
 ## Typing
 
-- Add return annotations to functions and methods.
+- Annotate all function and method parameters (including `*args` and `**kwargs`)
+  and returns. Ruff enforces `ANN001`, `ANN002`, `ANN003`, `ANN201`, `ANN202`,
+  `ANN204`, `ANN205`, and `ANN206`.
+- Move annotation-only imports behind `if TYPE_CHECKING`; Ruff's configured
+  `TC` rules, including `TC003`, apply to fixtures as well as scripts.
+- On Python 3.14, use native deferred annotations and bare type names compatible
+  with `UP037`. Do not add `from __future__ import annotations` solely for lint
+  compliance. Document any runtime annotation consumer that requires strings.
 - Prefer concrete standard-library types over `Any`, `dict`, or bare `Mock`
   when the shape is known.
 - Keep helper signatures precise enough that `ty` can validate the call sites.

--- a/just/helpers.just
+++ b/just/helpers.just
@@ -213,6 +213,27 @@ _performance-tag-pair-state current_tag baseline_tag:
         echo "inferred"
     fi
 
+# Run a Python tool over tracked sources plus new, unignored sources.
+[private]
+_python-tool command: _ensure-uv
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source_list="$(mktemp "${TMPDIR:-/tmp}/delaunay-python-sources.XXXXXX")"
+    trap 'rm -f "$source_list"' EXIT
+    git --no-pager ls-files --cached --others --exclude-standard --deduplicate -z -- '*.py' '*.pyi' > "$source_list"
+    python_files=()
+    while IFS= read -r -d '' file; do
+        # A tracked file may have been deleted in the working tree.
+        if [[ -f "$file" ]]; then
+            python_files+=("$file")
+        fi
+    done < "$source_list"
+    if [[ ${#python_files[@]} -eq 0 ]]; then
+        echo "No Python source files found" >&2
+        exit 1
+    fi
+    uv run --locked {{ command }} -- "${python_files[@]}"
+
 [private]
 _review scope base: _ensure-coderabbit
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -216,7 +216,7 @@ check-fast:
 
 # CI simulation: comprehensive validation.
 [group('workflows')]
-ci: _validation-doc-figures-check-if-canonical check test bench-compile examples
+ci: _validation-doc-figures-check-if-canonical check python-fixture-lint test bench-compile examples
     @echo "🎯 CI checks complete!"
 
 # CI followed by an explicit persistent local baseline refresh.
@@ -1101,19 +1101,20 @@ python-check: python-format-check python-lint python-typecheck
 
 # Apply Ruff lint fixes and formatting to Python source.
 [group('validation')]
-python-fix: _ensure-uv
-    uv run --locked ruff check scripts/ --fix
-    uv run --locked ruff format scripts/
+python-fix: (_python-tool "ruff check --fix") (_python-tool "ruff format")
+
+# Lint deliberate Python fixtures with the full configured Ruff policy.
+[group('validation')]
+python-fixture-lint: _ensure-uv
+    uv run --locked ruff check tests/semgrep/
 
 # Check Python formatting with Ruff.
 [group('validation')]
-python-format-check: _ensure-uv
-    uv run --locked ruff format --check scripts/
+python-format-check: (_python-tool "ruff format --check")
 
 # Lint Python source with Ruff.
 [group('validation')]
-python-lint: _ensure-uv
-    uv run --locked ruff check scripts/
+python-lint: (_python-tool "ruff check")
 
 # Synchronize development Python dependencies from the lockfile.
 [group('build and setup')]
@@ -1122,8 +1123,7 @@ python-sync: _ensure-uv
 
 # Type-check Python support code with ty.
 [group('validation')]
-python-typecheck: _ensure-uv
-    uv run --locked --group notebooks ty check scripts/ --error all
+python-typecheck: (_python-tool "--group notebooks ty check --error all")
 
 # Require final release versions plus matching changelog and citation dates.
 [group('release')]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,15 +92,22 @@ py-modules = [
 [tool.ruff]
 line-length = 160
 src = [ "scripts" ]
+# Notebooks have a separate extracted-code validator.
+include = [ "*.py", "*.pyi" ]
 
 [tool.ruff.lint]
 select = [
     "E",
     "F",
     "W",
+    "ANN001",
+    "ANN002",
+    "ANN003",
     "ANN201",
     "ANN202",
     "ANN204",
+    "ANN205",
+    "ANN206",
     "C90",
     "I",
     "N",
@@ -195,6 +202,20 @@ ignore = [
 # Test names and class groupings already document behavior; avoid requiring
 # docstrings for each pytest case while still checking production scripts.
 "**/tests/test_*.py" = [ "S101", "SLF001", "D101", "D102", "D103" ]
+# Standalone static-analysis fixtures are not packages or public APIs. Keep
+# exception/process/write violations intact, without disabling typing or imports.
+"tests/semgrep/scripts/tests/python_exceptions.py" = [
+    "INP001",
+    "D103",
+    "BLE001",
+    "EM101",
+    "S110",
+    "S607",
+    "SIM105",
+    "TRY002",
+]
+"tests/semgrep/scripts/tests/python_parse_boundaries.py" = [ "INP001", "D103" ]
+"tests/semgrep/scripts/tests/python_style.py" = [ "INP001", "S202", "S605", "S607", "SIM115", "UP015" ]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10

--- a/scripts/benchmark_utils.py
+++ b/scripts/benchmark_utils.py
@@ -6551,7 +6551,7 @@ class PerformanceComparator:
 
         return "⚠️ Sampling configuration differs from baseline: " + "; ".join(mismatches)
 
-    def _write_comparison_header(self, f, metadata: dict[str, str], hardware_report: str, *, sampling_warning: str = "") -> None:
+    def _write_comparison_header(self, f: TextIO, metadata: dict[str, str], hardware_report: str, *, sampling_warning: str = "") -> None:
         """Write the header section of comparison file."""
         f.write("Comparison Results\n")
         f.write("==================\n")
@@ -6870,13 +6870,13 @@ class PerformanceComparator:
             return None
         return cur_mean_us, base_mean_us
 
-    def _write_benchmark_header(self, f, benchmark: BenchmarkData) -> None:
+    def _write_benchmark_header(self, f: TextIO, benchmark: BenchmarkData) -> None:
         """Write benchmark section header."""
         f.write(f"{benchmark.header_line()}\n")
         if benchmark.benchmark_id:
             f.write(f"Benchmark ID: {benchmark.benchmark_id}\n")
 
-    def _write_current_benchmark_data(self, f, benchmark: BenchmarkData) -> None:
+    def _write_current_benchmark_data(self, f: TextIO, benchmark: BenchmarkData) -> None:
         """Write current benchmark data."""
         f.write(f"Current Time: [{benchmark.time_low}, {benchmark.time_mean}, {benchmark.time_high}] {benchmark.time_unit}\n")
         if benchmark.throughput_mean is not None:
@@ -6884,7 +6884,7 @@ class PerformanceComparator:
                 f"Current Throughput: [{benchmark.throughput_low}, {benchmark.throughput_mean}, {benchmark.throughput_high}] {benchmark.throughput_unit}\n",
             )
 
-    def _write_baseline_benchmark_data(self, f, benchmark: BenchmarkData) -> None:
+    def _write_baseline_benchmark_data(self, f: TextIO, benchmark: BenchmarkData) -> None:
         """Write baseline benchmark data."""
         f.write(f"Baseline Time: [{benchmark.time_low}, {benchmark.time_mean}, {benchmark.time_high}] {benchmark.time_unit}\n")
         if benchmark.throughput_mean is not None:
@@ -6892,7 +6892,7 @@ class PerformanceComparator:
                 f"Baseline Throughput: [{benchmark.throughput_low}, {benchmark.throughput_mean}, {benchmark.throughput_high}] {benchmark.throughput_unit}\n",
             )
 
-    def _write_time_comparison(self, f, current: BenchmarkData, baseline: BenchmarkData) -> tuple[float | None, bool]:
+    def _write_time_comparison(self, f: TextIO, current: BenchmarkData, baseline: BenchmarkData) -> tuple[float | None, bool]:
         """Write time comparison and return time change percentage and whether individual regression was found."""
         if baseline.time_mean <= 0:
             f.write("Time Change: N/A (baseline mean is 0)\n")
@@ -6951,7 +6951,7 @@ class PerformanceComparator:
 
         return time_change_pct, is_individual_regression
 
-    def _write_throughput_comparison(self, f, current: BenchmarkData, baseline: BenchmarkData) -> None:
+    def _write_throughput_comparison(self, f: TextIO, current: BenchmarkData, baseline: BenchmarkData) -> None:
         """Write throughput comparison if data is available."""
         if current.throughput_mean is None or baseline.throughput_mean is None:
             return

--- a/scripts/tests/test_benchmark_utils.py
+++ b/scripts/tests/test_benchmark_utils.py
@@ -24,7 +24,7 @@ from dataclasses import replace
 from datetime import UTC, datetime
 from io import BytesIO, StringIO
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, TypedDict
 from unittest.mock import Mock, patch
 
 import pytest
@@ -86,6 +86,20 @@ from benchmark_utils import (
     resolve_performance_request,
     write_criterion_comparison_report,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from contextlib import AbstractContextManager
+    from typing import IO
+    from unittest.mock import MagicMock
+
+
+class InvalidWaitOptions(TypedDict, total=False):
+    """Named integer inputs for invalid baseline-fetch duration cases."""
+
+    wait_seconds: int
+    poll_seconds: int
+
 
 THRESHOLD_PERCENT = f"{DEFAULT_REGRESSION_THRESHOLD:.1f}%"
 CI_MANIFEST_STDOUT = (
@@ -236,7 +250,7 @@ def retained_performance_bundle(*, current: str = "v0.8.0", baseline: str = "v0.
     )
 
 
-def write_estimate(target_dir: Path, path_parts, mean_ns) -> None:
+def write_estimate(target_dir: Path, path_parts: tuple[str, ...], mean_ns: float) -> None:
     """Write a minimal Criterion estimates.json fixture."""
     estimates_dir = target_dir / "criterion" / Path(*path_parts) / "base"
     estimates_dir.mkdir(parents=True)
@@ -260,7 +274,7 @@ def write_estimate(target_dir: Path, path_parts, mean_ns) -> None:
 
 def write_named_estimate(  # noqa: PLR0913
     target_dir: Path,
-    path_parts,
+    path_parts: tuple[str, ...],
     sample: str,
     point_ns: float,
     stat: str = "median",
@@ -400,7 +414,7 @@ Throughput: [18.0, 19.0, 20.0] Kelem/s
 """
 
 
-def compute_average_time_change(current_results, baseline_results) -> float:
+def compute_average_time_change(current_results: list[BenchmarkData], baseline_results: dict[str, BenchmarkData]) -> float:
     """Replicate PerformanceComparator's geometric mean logic for tests."""
     time_changes = []
     for current in current_results:
@@ -546,7 +560,7 @@ def test_release_measurement_plan_matches_workflow_and_just_recipe() -> None:
 
 
 @patch("benchmark_utils.run_cargo_command")
-def test_release_measurement_plan_runner_executes_exact_target_order(mock_cargo, tmp_path: Path) -> None:
+def test_release_measurement_plan_runner_executes_exact_target_order(mock_cargo: MagicMock, tmp_path: Path) -> None:
     """The executable plan should be the only owner of release target order."""
     mock_cargo.return_value = completed_process(stdout=CI_MANIFEST_STDOUT)
 
@@ -560,7 +574,7 @@ def test_release_measurement_plan_runner_executes_exact_target_order(mock_cargo,
 
 
 @patch("benchmark_utils.run_cargo_command")
-def test_release_measurement_plan_runner_stops_at_first_failed_target(mock_cargo, tmp_path: Path) -> None:
+def test_release_measurement_plan_runner_stops_at_first_failed_target(mock_cargo: MagicMock, tmp_path: Path) -> None:
     """A failed planned target must prevent later measurements from running."""
     mock_cargo.return_value = completed_process(returncode=101, stderr="benchmark failed")
 
@@ -2004,7 +2018,7 @@ def test_atomic_write_failure_preserves_original_and_cleans_temporary_file(
 class TestCriterionParser:
     """Test cases for CriterionParser class."""
 
-    def test_parse_estimates_json_valid_data(self, sample_estimates_data) -> None:
+    def test_parse_estimates_json_valid_data(self, sample_estimates_data: dict[str, object]) -> None:
         """Test parsing valid estimates.json data."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump(sample_estimates_data, f)
@@ -2036,7 +2050,7 @@ class TestCriterionParser:
         assert benchmark.time_unit == "µs"
         assert benchmark.benchmark_id == ""
 
-    def test_parse_estimates_json_preserves_unsized_workload(self, sample_estimates_data) -> None:
+    def test_parse_estimates_json_preserves_unsized_workload(self, sample_estimates_data: dict[str, object]) -> None:
         """Test Criterion estimates without numeric input size do not get fake throughput."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump(sample_estimates_data, f)
@@ -2079,7 +2093,7 @@ class TestCriterionParser:
             {"mean": {"point_estimate": 110000.0, "confidence_interval": {"lower_bound": 100000.0}}},
         ],
     )
-    def test_parse_estimates_json_rejects_invalid_estimates(self, estimates_data) -> None:
+    def test_parse_estimates_json_rejects_invalid_estimates(self, estimates_data: object) -> None:
         """Test parsing rejects non-finite or unordered Criterion estimates."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump(estimates_data, f)
@@ -2118,7 +2132,7 @@ class TestCriterionParser:
             {"mean": {"point_estimate": 100000.0, "confidence_interval": []}},
         ],
     )
-    def test_summary_estimate_loader_rejects_structurally_invalid_mean_data(self, estimates_data) -> None:
+    def test_summary_estimate_loader_rejects_structurally_invalid_mean_data(self, estimates_data: object) -> None:
         """Test performance summary loader rejects structurally malformed Criterion estimates."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump(estimates_data, f)
@@ -2200,7 +2214,7 @@ class TestCriterionParser:
 
     @patch("benchmark_utils.Path.exists")
     @patch("benchmark_utils.Path.iterdir")
-    def test_find_criterion_results_no_criterion_dir(self, mock_iterdir, mock_exists) -> None:  # noqa: ARG002
+    def test_find_criterion_results_no_criterion_dir(self, mock_iterdir: MagicMock, mock_exists: MagicMock) -> None:  # noqa: ARG002
         """Test finding criterion results when criterion directory doesn't exist."""
         mock_exists.return_value = False
 
@@ -2358,7 +2372,7 @@ malformed api_benchmark_metric benchmark_id=ignored vertices=x simplices=y
             ({"vertices": 10, "simplices": True}, "simplices must be a positive integer"),
         ],
     )
-    def test_ci_performance_metric_rejects_invalid_counts(self, kwargs, message) -> None:
+    def test_ci_performance_metric_rejects_invalid_counts(self, kwargs: dict[str, int], message: str) -> None:
         """CiPerformanceMetric rejects non-positive and bool counts."""
         with pytest.raises(ValueError, match=message):
             CiPerformanceMetric(**kwargs)
@@ -2463,7 +2477,7 @@ malformed api_benchmark_metric benchmark_id=ignored vertices=x simplices=y
                 "validation/validate_3d/50",
             ]
 
-    def test_fallback_discovery_prefers_new_estimates_over_base(self, tmp_path) -> None:
+    def test_fallback_discovery_prefers_new_estimates_over_base(self, tmp_path: Path) -> None:
         """Test fallback Criterion discovery replaces stale base estimates with new estimates."""
         criterion_dir = tmp_path / "criterion"
         base_dir = criterion_dir / "legacy" / "2d" / "benchmark" / "1000" / "base"
@@ -2525,7 +2539,7 @@ Time: [200.0, 220.0, 240.0] µs
 Throughput: [4.167, 4.545, 5.0] Kelem/s
 """
 
-    def test_parse_baseline_file(self, comparator, sample_baseline_content) -> None:
+    def test_parse_baseline_file(self, comparator: PerformanceComparator, sample_baseline_content: str) -> None:
         """Test parsing baseline file content."""
         results = comparator._parse_baseline_file(sample_baseline_content)
 
@@ -2541,7 +2555,7 @@ Throughput: [4.167, 4.545, 5.0] Kelem/s
         assert bench_2d_1000.time_mean == 110.0
         assert bench_2d_1000.throughput_mean == 9.091
 
-    def test_parse_baseline_file_with_benchmark_ids(self, comparator) -> None:
+    def test_parse_baseline_file_with_benchmark_ids(self, comparator: PerformanceComparator) -> None:
         """Test parsing expanded ci_performance_suite baseline identifiers."""
         baseline_content = """Date: 2023-06-15 10:30:00 PDT
 Git commit: abc123def456
@@ -2566,7 +2580,7 @@ Throughput: [2.381, 2.5, 2.632] Kelem/s
         assert results["boundary_facets/boundary_facets_3d/50"].time_mean == 10.0
         assert results["validation/validate_3d/50"].time_mean == 20.0
 
-    def test_parse_baseline_file_with_scientific_notation(self, comparator) -> None:
+    def test_parse_baseline_file_with_scientific_notation(self, comparator: PerformanceComparator) -> None:
         """Test baseline parsing accepts the full float domain written by Python."""
         baseline_content = """Date: 2023-06-15 10:30:00 PDT
 Git commit: abc123def456
@@ -2584,7 +2598,7 @@ Throughput: [8.333e3, 9.091e3, 1.0e4] Kelem/s
         assert benchmark.time_high == pytest.approx(1.2e-6)
         assert benchmark.throughput_mean == pytest.approx(9.091e3)
 
-    def test_parse_baseline_file_rejects_sections_without_timing(self, comparator) -> None:
+    def test_parse_baseline_file_rejects_sections_without_timing(self, comparator: PerformanceComparator) -> None:
         """Test malformed baseline sections without timing data fail loudly."""
         baseline_content = """Date: 2023-06-15 10:30:00 PDT
 Git commit: abc123def456
@@ -2627,7 +2641,7 @@ Throughput: [9.524, 10.0, 10.526] Kelem/s
         with pytest.raises(BaselineParseError, match=message):
             comparator._parse_baseline_file(sections)
 
-    def test_parse_baseline_file_with_unsized_benchmark_id(self, comparator) -> None:
+    def test_parse_baseline_file_with_unsized_benchmark_id(self, comparator: PerformanceComparator) -> None:
         """Test parsing expanded CI benchmarks without numeric input sizes."""
         baseline_content = """Date: 2023-06-15 10:30:00 PDT
 Git commit: abc123def456
@@ -2646,7 +2660,7 @@ Time: [0.8, 0.95, 1.1] µs
 
     @patch("benchmark_utils.CriterionParser.find_criterion_results")
     @patch("benchmark_utils.run_cargo_command")
-    def test_compare_with_baseline_rejects_malformed_baseline(self, mock_cargo, mock_find_results, tmp_path) -> None:
+    def test_compare_with_baseline_rejects_malformed_baseline(self, mock_cargo: MagicMock, mock_find_results: MagicMock, tmp_path: Path) -> None:
         """Test compare fails instead of silently ignoring malformed baseline sections."""
         baseline_file = tmp_path / "baseline.txt"
         output_file = tmp_path / "compare_results.txt"
@@ -2676,7 +2690,7 @@ Time: [190.0, 200.0, 210.0] µs
         assert "Malformed baseline section" in content
         assert "malformed/no_timing" in content
 
-    def test_write_performance_comparison_matches_benchmark_ids(self, comparator) -> None:
+    def test_write_performance_comparison_matches_benchmark_ids(self, comparator: PerformanceComparator) -> None:
         """Test comparison uses expanded benchmark IDs instead of point/dimension collisions."""
         current_results = [
             BenchmarkData(50, "3D", benchmark_id="boundary_facets/boundary_facets_3d/50").with_timing(9.0, 10.0, 11.0, "µs"),
@@ -2704,7 +2718,7 @@ Time: [190.0, 200.0, 210.0] µs
         assert "OK: Time change +0.0%" in content
         assert "IMPROVEMENT: Time decreased by 50.0%" in content
 
-    def test_write_performance_comparison_no_legacy_fallback_for_benchmark_id(self, comparator) -> None:
+    def test_write_performance_comparison_no_legacy_fallback_for_benchmark_id(self, comparator: PerformanceComparator) -> None:
         """Test expanded IDs do not compare against unrelated collapsed legacy baselines."""
         current_results = [
             BenchmarkData(50, "3D", benchmark_id="validation/validate_3d/50").with_timing(
@@ -2725,7 +2739,7 @@ Time: [190.0, 200.0, 210.0] µs
         assert "Baseline: N/A (no matching entry)" in content
         assert "IMPROVEMENT: Time decreased by 50.0%" not in content
 
-    def test_write_time_comparison_no_regression(self, comparator) -> None:
+    def test_write_time_comparison_no_regression(self, comparator: PerformanceComparator) -> None:
         """Test time comparison writing with no regression."""
         current = BenchmarkData(1000, "2D").with_timing(100.0, 110.0, 120.0, "µs")
         baseline = BenchmarkData(1000, "2D").with_timing(95.0, 105.0, 115.0, "µs")
@@ -2741,7 +2755,7 @@ Time: [190.0, 200.0, 210.0] µs
         assert "4.8%" in result
         assert "✅ OK: Time change +4.8% within acceptable range" in result
 
-    def test_write_time_comparison_with_regression(self, comparator) -> None:
+    def test_write_time_comparison_with_regression(self, comparator: PerformanceComparator) -> None:
         """Test time comparison writing with regression."""
         current = BenchmarkData(1000, "2D").with_timing(100.0, 115.0, 130.0, "µs")
         baseline = BenchmarkData(1000, "2D").with_timing(95.0, 100.0, 105.0, "µs")
@@ -2757,7 +2771,7 @@ Time: [190.0, 200.0, 210.0] µs
         assert "15.0%" in result
         assert "REGRESSION" in result
 
-    def test_write_time_comparison_with_improvement(self, comparator) -> None:
+    def test_write_time_comparison_with_improvement(self, comparator: PerformanceComparator) -> None:
         """Test time comparison writing with significant improvement."""
         current = BenchmarkData(1000, "2D").with_timing(80.0, 90.0, 100.0, "µs")
         baseline = BenchmarkData(1000, "2D").with_timing(95.0, 100.0, 105.0, "µs")
@@ -2773,7 +2787,7 @@ Time: [190.0, 200.0, 210.0] µs
         assert "10.0%" in result
         assert "✅ IMPROVEMENT: Time decreased by 10.0% (faster performance)" in result
 
-    def test_write_time_comparison_zero_baseline(self, comparator) -> None:
+    def test_write_time_comparison_zero_baseline(self, comparator: PerformanceComparator) -> None:
         """Test time comparison with zero baseline time."""
         current = BenchmarkData(1000, "2D").with_timing(100.0, 110.0, 120.0, "µs")
         baseline = BenchmarkData(1000, "2D").with_timing(0.0, 0.0, 0.0, "µs")
@@ -2789,7 +2803,7 @@ Time: [190.0, 200.0, 210.0] µs
 
     @pytest.mark.parametrize("dev_mode", [False, True])
     @patch("benchmark_utils.run_cargo_command")
-    def test_compare_omits_quiet_flag(self, mock_cargo, dev_mode) -> None:
+    def test_compare_omits_quiet_flag(self, mock_cargo: MagicMock, dev_mode: bool) -> None:
         """Test that PerformanceComparator invokes cargo without --quiet flag (removed for better error visibility)."""
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
@@ -2820,7 +2834,7 @@ Time: [1.0, 1.0, 1.0] µs
             # And output is captured
             assert mock_cargo.call_args.kwargs.get("capture_output") is True
 
-    def test_write_performance_comparison_detects_individual_regression(self, comparator) -> None:
+    def test_write_performance_comparison_detects_individual_regression(self, comparator: PerformanceComparator) -> None:
         """Test strict performance comparison fails for individual regressions even when total time is fine."""
         # Create current results with mixed performance changes
         current_results = [
@@ -2854,7 +2868,7 @@ Time: [1.0, 1.0, 1.0] µs
         assert re.search(r"Geomean time change:\s*-?0\.0%", result)
         assert "⚠️ INDIVIDUAL REGRESSION" in result
 
-    def test_total_time_policy_warns_on_individual_regressions_when_total_is_ok(self, comparator) -> None:
+    def test_total_time_policy_warns_on_individual_regressions_when_total_is_ok(self, comparator: PerformanceComparator) -> None:
         """Test local ref comparisons gate on total matched time while preserving warnings."""
         current_results = [
             BenchmarkData(1000, "2D").with_timing(45.0, 50.0, 55.0, "µs"),
@@ -2886,7 +2900,7 @@ Time: [1.0, 1.0, 1.0] µs
         assert "Top improvements:" in result
         assert "- 1000_2D: -50.0%" in result
 
-    def test_write_performance_comparison_with_total_regression(self, comparator) -> None:
+    def test_write_performance_comparison_with_total_regression(self, comparator: PerformanceComparator) -> None:
         """Test performance comparison with total matched-time regression exceeding threshold."""
         # Create current results with overall performance degradation
         current_results = [
@@ -2919,7 +2933,7 @@ Time: [1.0, 1.0, 1.0] µs
         assert "Geomean time change: +11.0%" in result
         assert "🚨 OVERALL REGRESSION" in result
 
-    def test_write_performance_comparison_with_improvement(self, comparator) -> None:
+    def test_write_performance_comparison_with_improvement(self, comparator: PerformanceComparator) -> None:
         """Test performance comparison with mixed improvements and no strict regression."""
         # Create current results with overall performance improvement
         current_results = [
@@ -2953,7 +2967,7 @@ Time: [1.0, 1.0, 1.0] µs
         assert expected_average_line in result
         assert "✅ OVERALL OK" in result
 
-    def test_write_performance_comparison_missing_baseline(self, comparator) -> None:
+    def test_write_performance_comparison_missing_baseline(self, comparator: PerformanceComparator) -> None:
         """Missing baseline coverage is explicit and fails before aggregation."""
         current_results = [
             BenchmarkData(1000, "2D").with_timing(105.0, 110.0, 115.0, "µs"),
@@ -2976,7 +2990,7 @@ Time: [1.0, 1.0, 1.0] µs
         assert "Total benchmarks compared:" not in result
         assert "3000 Points (2D)" in result  # Should still show the benchmark without baseline
 
-    def test_write_performance_comparison_no_benchmarks(self, comparator) -> None:
+    def test_write_performance_comparison_no_benchmarks(self, comparator: PerformanceComparator) -> None:
         """Empty coverage cannot pass an enforcing performance guard."""
         output = StringIO()
         regression_found = comparator._write_performance_comparison(output, [], {})
@@ -2984,7 +2998,7 @@ Time: [1.0, 1.0, 1.0] µs
         assert regression_found
         assert "current and baseline benchmark keysets are empty" in output.getvalue()
 
-    def test_total_time_policy_fails_on_non_comparable_coverage(self, comparator) -> None:
+    def test_total_time_policy_fails_on_non_comparable_coverage(self, comparator: PerformanceComparator) -> None:
         """The lenient regression policy still enforces complete measurement coverage."""
         current = [BenchmarkData(10, "2D").with_timing(1.0, 2.0, 3.0, "µs")]
         baseline = {"20_2D": BenchmarkData(20, "2D").with_timing(1.0, 2.0, 3.0, "µs")}
@@ -3001,7 +3015,7 @@ Time: [1.0, 1.0, 1.0] µs
         assert "Missing from baseline: 10_2D" in output.getvalue()
         assert "Missing from current run: 20_2D" in output.getvalue()
 
-    def test_duplicate_current_keys_are_non_comparable(self, comparator) -> None:
+    def test_duplicate_current_keys_are_non_comparable(self, comparator: PerformanceComparator) -> None:
         """Duplicate current measurements cannot be collapsed into one aggregate row."""
         benchmark = BenchmarkData(10, "2D").with_timing(1.0, 2.0, 3.0, "µs")
         baseline = {"10_2D": BenchmarkData(10, "2D").with_timing(1.0, 2.0, 3.0, "µs")}
@@ -3018,7 +3032,9 @@ Time: [1.0, 1.0, 1.0] µs
 
     @patch("benchmark_utils.get_git_commit_hash")
     @patch("benchmark_utils.datetime")
-    def test_prepare_comparison_metadata(self, mock_datetime, mock_git, comparator, sample_baseline_content) -> None:
+    def test_prepare_comparison_metadata(
+        self, mock_datetime: MagicMock, mock_git: MagicMock, comparator: PerformanceComparator, sample_baseline_content: str
+    ) -> None:
         """Test preparation of comparison metadata."""
         # Mock current datetime
         mock_now = Mock()
@@ -3036,7 +3052,7 @@ Time: [1.0, 1.0, 1.0] µs
         assert metadata["baseline_commit"] == "abc123def456"
 
     @patch("benchmark_utils.get_git_commit_hash")
-    def test_prepare_comparison_metadata_git_failure(self, mock_git, comparator, sample_baseline_content) -> None:
+    def test_prepare_comparison_metadata_git_failure(self, mock_git: MagicMock, comparator: PerformanceComparator, sample_baseline_content: str) -> None:
         """Test metadata preparation when git command fails."""
         mock_git.side_effect = RuntimeError("Git not available")
 
@@ -3044,7 +3060,7 @@ Time: [1.0, 1.0, 1.0] µs
 
         assert metadata["current_commit"] == "unknown"
 
-    def test_regression_threshold_configuration(self, comparator) -> None:
+    def test_regression_threshold_configuration(self, comparator: PerformanceComparator) -> None:
         """Test that regression threshold can be configured."""
         # Test default threshold
         assert comparator.regression_threshold == DEFAULT_REGRESSION_THRESHOLD
@@ -3062,7 +3078,7 @@ Time: [1.0, 1.0, 1.0] µs
         assert time_change == pytest.approx(7.0, abs=0.001)  # Use pytest.approx for floating-point comparison
         assert not is_regression
 
-    def test_write_error_file_baseline_not_found(self, comparator) -> None:
+    def test_write_error_file_baseline_not_found(self, comparator: PerformanceComparator) -> None:
         """Test writing error file when baseline is not found."""
         with tempfile.TemporaryDirectory() as temp_dir:
             output_file = Path(temp_dir) / "error_results.txt"
@@ -3077,7 +3093,7 @@ Time: [1.0, 1.0, 1.0] µs
             assert str(baseline_file) in content
             assert "This error prevented the benchmark comparison from completing successfully" in content
 
-    def test_write_error_file_benchmark_error(self, comparator) -> None:
+    def test_write_error_file_benchmark_error(self, comparator: PerformanceComparator) -> None:
         """Test writing error file when benchmark execution fails."""
         with tempfile.TemporaryDirectory() as temp_dir:
             output_file = Path(temp_dir) / "error_results.txt"
@@ -3091,7 +3107,7 @@ Time: [1.0, 1.0, 1.0] µs
             assert error_message in content
             assert "Please check the CI logs for more information" in content
 
-    def test_write_error_file_creates_parent_directory(self, comparator) -> None:
+    def test_write_error_file_creates_parent_directory(self, comparator: PerformanceComparator) -> None:
         """Test that _write_error_file creates parent directory if it doesn't exist."""
         with tempfile.TemporaryDirectory() as temp_dir:
             output_file = Path(temp_dir) / "nested" / "path" / "error_results.txt"
@@ -3103,7 +3119,7 @@ Time: [1.0, 1.0, 1.0] µs
             content = output_file.read_text(encoding=UTF8)
             assert "❌ Error: Test error" in content
 
-    def test_write_error_file_handles_write_failure(self, comparator) -> None:
+    def test_write_error_file_handles_write_failure(self, comparator: PerformanceComparator) -> None:
         """Test that _write_error_file handles write failures gracefully."""
         with tempfile.TemporaryDirectory() as temp_dir:
             output_file = Path(temp_dir) / "error_results.txt"
@@ -3137,7 +3153,7 @@ Criterion warm-up time: 1
             assert "Criterion measurement time: baseline=2, current=criterion-default" in warning
             assert "Criterion warm-up time: baseline=1, current=criterion-default" in warning
 
-    def test_sampling_warning_reports_missing_baseline_metadata(self, comparator, sample_baseline_content) -> None:
+    def test_sampling_warning_reports_missing_baseline_metadata(self, comparator: PerformanceComparator, sample_baseline_content: str) -> None:
         """Test that legacy baselines without sampling metadata produce a warning."""
         warning = comparator._sampling_warning(sample_baseline_content, dev_mode=False)
 
@@ -3162,7 +3178,7 @@ class TestBaselineGenerator:
     @patch("benchmark_utils.get_git_commit_hash", return_value="abc123")
     @patch("benchmark_utils.CriterionParser.find_criterion_results")
     @patch("benchmark_utils.run_cargo_command")
-    def test_generate_baseline_uses_perf_profile(self, mock_cargo, mock_find_results, mock_git) -> None:
+    def test_generate_baseline_uses_perf_profile(self, mock_cargo: MagicMock, mock_find_results: MagicMock, mock_git: MagicMock) -> None:
         """Test that full baseline generation benchmarks with the trusted Cargo profile."""
         mock_cargo.return_value = completed_process(CI_MANIFEST_STDOUT)
         mock_find_results.return_value = self._sample_benchmark_results()
@@ -3188,7 +3204,7 @@ class TestBaselineGenerator:
     @patch("benchmark_utils.get_git_commit_hash", return_value="abc123")
     @patch("benchmark_utils.CriterionParser.find_criterion_results")
     @patch("benchmark_utils.run_cargo_command")
-    def test_generate_baseline_dev_mode_keeps_perf_profile(self, mock_cargo, mock_find_results, mock_git) -> None:
+    def test_generate_baseline_dev_mode_keeps_perf_profile(self, mock_cargo: MagicMock, mock_find_results: MagicMock, mock_git: MagicMock) -> None:
         """Test that dev baseline mode reduces Criterion settings without changing Cargo profile."""
         mock_cargo.return_value = completed_process(CI_MANIFEST_STDOUT)
         mock_find_results.return_value = self._sample_benchmark_results()
@@ -3217,7 +3233,9 @@ class TestBaselineGenerator:
     @patch("benchmark_utils.get_git_commit_hash", return_value="abc123")
     @patch("benchmark_utils.CriterionParser.find_criterion_results")
     @patch("benchmark_utils.run_cargo_command")
-    def test_write_baseline_from_existing_results_does_not_rerun_benchmarks(self, mock_cargo, mock_find_results, mock_git) -> None:
+    def test_write_baseline_from_existing_results_does_not_rerun_benchmarks(
+        self, mock_cargo: MagicMock, mock_find_results: MagicMock, mock_git: MagicMock
+    ) -> None:
         """Test that existing Criterion results can be packaged as a baseline without rerunning Cargo."""
         mock_find_results.return_value = self._sample_benchmark_results()
 
@@ -3240,7 +3258,7 @@ class TestBaselineGenerator:
             assert "=== 10 Points (2D) ===" in content
 
     @patch("benchmark_utils.CriterionParser.find_criterion_results", return_value=[])
-    def test_write_baseline_from_existing_results_requires_criterion_data(self, mock_find_results, capsys) -> None:
+    def test_write_baseline_from_existing_results_requires_criterion_data(self, mock_find_results: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
         """Test that packaging fails loudly when no existing Criterion data is available."""
         with tempfile.TemporaryDirectory() as temp_dir:
             project_root = Path(temp_dir)
@@ -3254,7 +3272,7 @@ class TestBaselineGenerator:
             assert "No Criterion results found" in captured.err
 
     @patch("benchmark_utils.CriterionParser.find_criterion_results")
-    def test_write_baseline_from_existing_results_requires_ci_suite_data(self, mock_find_results, capsys) -> None:
+    def test_write_baseline_from_existing_results_requires_ci_suite_data(self, mock_find_results: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
         """Test that release baseline packaging rejects unrelated Criterion results."""
         mock_find_results.return_value = [BenchmarkData(10, "2D").with_timing(1.0, 2.0, 3.0, "µs")]
 
@@ -3272,16 +3290,18 @@ class TestBaselineGenerator:
     @patch("benchmark_utils.get_git_commit_hash", return_value="abc123def456")
     @patch("benchmark_utils.get_git_remote_url", return_value="git@github.com:acgetchell/delaunay.git")
     @patch("benchmark_utils.run_git_command")
-    def test_local_ref_baseline_uses_temporary_checkout(self, mock_git, mock_remote, mock_commit, capsys) -> None:
+    def test_local_ref_baseline_uses_temporary_checkout(
+        self, mock_git: MagicMock, mock_remote: MagicMock, mock_commit: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         """Test that local ref baseline generation cleans up its temporary checkout."""
         checkout_paths: list[Path] = []
 
-        def fake_git_command(args, _cwd=None, **_kwargs) -> subprocess.CompletedProcess[str]:
+        def fake_git_command(args: list[str], _cwd: Path | None = None, **_kwargs: object) -> subprocess.CompletedProcess[str]:
             if args[0] == "clone":
                 Path(args[-1]).mkdir(parents=True)
             return completed_process(args=args)
 
-        def fake_generate_baseline(self, *, dev_mode=False, output_file=None, bench_timeout=1800) -> bool:
+        def fake_generate_baseline(self: BaselineGenerator, *, dev_mode: bool = False, output_file: Path | None = None, bench_timeout: int = 1800) -> bool:
             checkout_paths.append(self.project_root)
             assert self.project_root.exists()
             assert dev_mode is True
@@ -3330,17 +3350,17 @@ class TestBaselineGenerator:
     @patch("benchmark_utils.run_git_command")
     def test_local_ref_baseline_metadata_failure_preserves_prior_pair(
         self,
-        mock_git,
-        tmp_path,
+        mock_git: MagicMock,
+        tmp_path: Path,
     ) -> None:
         """Test that staged results are not published when metadata creation fails."""
 
-        def fake_git_command(args, _cwd=None, **_kwargs) -> subprocess.CompletedProcess[str]:
+        def fake_git_command(args: list[str], _cwd: Path | None = None, **_kwargs: object) -> subprocess.CompletedProcess[str]:
             if args[0] == "clone":
                 Path(args[-1]).mkdir(parents=True)
             return completed_process(args=args)
 
-        def fake_generate_baseline(self, *, dev_mode=False, output_file=None, bench_timeout=1800) -> bool:
+        def fake_generate_baseline(self: BaselineGenerator, *, dev_mode: bool = False, output_file: Path | None = None, bench_timeout: int = 1800) -> bool:
             assert output_file is not None
             output_file.write_text("new baseline\n", encoding="utf-8")
             return True
@@ -3369,7 +3389,7 @@ class TestBaselineGenerator:
         assert metadata_file.read_text(encoding="utf-8") == '{"commit": "prior-commit"}\n'
         assert not list(project_root.glob(".baseline-artifact-staging-*"))
 
-    def test_local_ref_baseline_publish_failure_restores_prior_pair(self, tmp_path) -> None:
+    def test_local_ref_baseline_publish_failure_restores_prior_pair(self, tmp_path: Path) -> None:
         """Test rollback when the second staged artifact cannot be published."""
         out_dir = tmp_path / "baseline-artifact"
         staging_dir = tmp_path / "staging"
@@ -3406,7 +3426,7 @@ class TestBaselineGenerator:
         assert metadata_file.read_text(encoding="utf-8") == '{"commit": "prior-commit"}\n'
         assert not list(out_dir.glob(".delaunay-baseline-backup-*"))
 
-    def test_cached_ref_baseline_reuses_valid_cache(self, tmp_path) -> None:
+    def test_cached_ref_baseline_reuses_valid_cache(self, tmp_path: Path) -> None:
         """Test that a valid same-machine ref baseline is reused without benchmarking."""
         commit = "abc123def456"
         options = LocalRefBaselineCacheOptions(
@@ -3430,7 +3450,7 @@ class TestBaselineGenerator:
         assert result.reused is True
         mock_generate.assert_not_called()
 
-    def test_cached_ref_baseline_reuses_same_commit_alias(self, tmp_path) -> None:
+    def test_cached_ref_baseline_reuses_same_commit_alias(self, tmp_path: Path) -> None:
         """Test that refs resolving to the same commit can share a cached baseline."""
         commit = "abc123def456"
         options = LocalRefBaselineCacheOptions(
@@ -3469,7 +3489,7 @@ class TestBaselineGenerator:
         baseline_path.write_text(cached_ref_baseline_content(commit="stale-baseline"), encoding="utf-8")
 
         def fake_generate_for_ref(
-            self,
+            self: LocalRefBaselineGenerator,
             *,
             ref_name: str,
             out_dir: Path,
@@ -3494,7 +3514,7 @@ class TestBaselineGenerator:
         assert result.resolved_commit == commit
         assert result.reused is False
 
-    def test_compare_ref_skips_same_clean_commit(self, tmp_path) -> None:
+    def test_compare_ref_skips_same_clean_commit(self, tmp_path: Path) -> None:
         """Test that compare-ref skips before generating a same-commit clean baseline."""
         options = LocalRefBaselineCacheOptions(ref_name="main", dev_mode=True)
 
@@ -3509,7 +3529,7 @@ class TestBaselineGenerator:
         assert exit_code == 0
         mock_ensure.assert_not_called()
 
-    def test_compare_ref_uses_ref_named_results_file(self, tmp_path, capsys) -> None:
+    def test_compare_ref_uses_ref_named_results_file(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """Test that compare-ref writes a worktree-vs-ref report by default."""
         commit = "abc123def456"
         baseline_path = tmp_path / "baseline_results.txt"
@@ -3546,7 +3566,7 @@ class TestBaselineGenerator:
         )
 
     @patch("benchmark_utils.get_git_commit_hash", return_value="abc123")
-    def test_written_baseline_round_trips_through_parser(self, mock_git, tmp_path) -> None:
+    def test_written_baseline_round_trips_through_parser(self, mock_git: MagicMock, tmp_path: Path) -> None:
         """Test the baseline writer/parser contract for representative records."""
         benchmark_results = [
             BenchmarkData(1000, "2D").with_timing(1.0e-6, 1.1e-6, 1.2e-6, "µs").with_throughput(8.333e3, 9.091e3, 1.0e4, "Kelem/s"),
@@ -3586,7 +3606,7 @@ class TestIntegrationScenarios:
         project_root = Path("/fake/project")
         return PerformanceComparator(project_root)
 
-    def test_realistic_mixed_performance_scenario(self, comparator) -> None:
+    def test_realistic_mixed_performance_scenario(self, comparator: PerformanceComparator) -> None:
         """Test a realistic scenario with mixed performance changes."""
         # Simulate a realistic benchmark run with various performance changes
         current_results = [
@@ -3625,7 +3645,7 @@ class TestIntegrationScenarios:
         assert expected_average_line in result
         assert "⚠️ INDIVIDUAL REGRESSION" in result
 
-    def test_gradual_performance_degradation_scenario(self, comparator) -> None:
+    def test_gradual_performance_degradation_scenario(self, comparator: PerformanceComparator) -> None:
         """Test scenario where performance gradually degrades across all benchmarks."""
         # Simulate gradual performance degradation that individually isn't alarming
         # but collectively indicates a problem
@@ -3658,7 +3678,7 @@ class TestIntegrationScenarios:
         assert "Total time change: +9.0%" in result
         assert "🚨 OVERALL REGRESSION" in result
 
-    def test_noisy_benchmarks_scenario(self, comparator) -> None:
+    def test_noisy_benchmarks_scenario(self, comparator: PerformanceComparator) -> None:
         """Test scenario with noisy benchmarks that have high individual variance."""
         # Simulate noisy benchmarks where individual results vary significantly
         # but overall trend is acceptable
@@ -3703,7 +3723,7 @@ class TestEdgeCases:
         project_root = Path("/fake/project")
         return PerformanceComparator(project_root)
 
-    def test_empty_current_results(self, comparator) -> None:
+    def test_empty_current_results(self, comparator: PerformanceComparator) -> None:
         """A missing current keyset fails closed."""
         baseline_results = {
             "1000_2D": BenchmarkData(1000, "2D").with_timing(95.0, 100.0, 105.0, "µs"),
@@ -3716,7 +3736,7 @@ class TestEdgeCases:
         assert "Missing from current run: 1000_2D" in output.getvalue()
         assert "Aggregate timing comparison: NOT COMPARABLE" in output.getvalue()
 
-    def test_empty_baseline_results(self, comparator) -> None:
+    def test_empty_baseline_results(self, comparator: PerformanceComparator) -> None:
         """A missing baseline keyset fails closed."""
         current_results = [
             BenchmarkData(1000, "2D").with_timing(105.0, 110.0, 115.0, "µs"),
@@ -3731,7 +3751,7 @@ class TestEdgeCases:
         assert "Missing from baseline: 1000_2D" in result
         assert "Aggregate timing comparison: NOT COMPARABLE" in result
 
-    def test_all_zero_baseline_times(self, comparator) -> None:
+    def test_all_zero_baseline_times(self, comparator: PerformanceComparator) -> None:
         """Invalid timing evidence fails even when identity coverage matches."""
         current_results = [
             BenchmarkData(1000, "2D").with_timing(105.0, 110.0, 115.0, "µs"),
@@ -3752,7 +3772,7 @@ class TestEdgeCases:
         assert "Invalid baseline timings: 1000_2D, 2000_2D" in result
         assert "Aggregate timing comparison: NOT COMPARABLE" in result
 
-    def test_mixed_valid_invalid_baselines(self, comparator) -> None:
+    def test_mixed_valid_invalid_baselines(self, comparator: PerformanceComparator) -> None:
         """One invalid timing prevents a misleading matched-subset aggregate."""
         current_results = [
             BenchmarkData(1000, "2D").with_timing(105.0, 110.0, 115.0, "µs"),
@@ -3953,7 +3973,7 @@ class TestWorkflowHelper:
             assert output_dir.exists()
             assert (output_dir / "metadata.json").exists()
 
-    def test_display_baseline_summary_success(self, capsys) -> None:
+    def test_display_baseline_summary_success(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test successful baseline summary display."""
         baseline_content = """Date: 2023-12-15 14:30:00 UTC
 Git commit: abc123def456
@@ -3990,7 +4010,7 @@ Time: [220.0, 250.0, 280.0] µs
         finally:
             baseline_file.unlink()
 
-    def test_display_baseline_summary_nonexistent_file(self, capsys) -> None:
+    def test_display_baseline_summary_nonexistent_file(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test baseline summary with non-existent file."""
         baseline_file = Path("/nonexistent/file.txt")
 
@@ -4001,7 +4021,7 @@ Time: [220.0, 250.0, 280.0] µs
         captured = capsys.readouterr()
         assert "❌ Baseline file not found" in captured.err
 
-    def test_display_baseline_summary_long_file(self, capsys) -> None:
+    def test_display_baseline_summary_long_file(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test baseline summary with file longer than 10 lines."""
         baseline_content = "\n".join([f"Line {i}" for i in range(20)])
 
@@ -4055,7 +4075,7 @@ Time: [220.0, 250.0, 280.0] µs
             ("v1.0.0+build.123", "performance-baseline-v1_0_0_build_123"),
         ],
     )
-    def test_sanitize_artifact_name_edge_cases(self, input_tag, expected_output) -> None:
+    def test_sanitize_artifact_name_edge_cases(self, input_tag: str, expected_output: str) -> None:
         """Test artifact name sanitization with edge cases."""
         result = WorkflowHelper.sanitize_artifact_name(input_tag)
         assert result == expected_output
@@ -4071,7 +4091,7 @@ Time: [220.0, 250.0, 280.0] µs
 class TestBenchmarkRegressionHelper:
     """Test cases for BenchmarkRegressionHelper class."""
 
-    def test_prepare_baseline_success(self, capsys) -> None:
+    def test_prepare_baseline_success(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test successful baseline preparation."""
         with tempfile.TemporaryDirectory() as temp_dir:
             baseline_dir = Path(temp_dir)
@@ -4112,7 +4132,7 @@ Time: [95.0, 100.0, 105.0] µs
             finally:
                 Path(env_path).unlink(missing_ok=True)
 
-    def test_prepare_baseline_copy_error_handling(self, capsys) -> None:
+    def test_prepare_baseline_copy_error_handling(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test error handling when copying baseline file fails."""
         with tempfile.TemporaryDirectory() as temp_dir:
             baseline_dir = Path(temp_dir)
@@ -4153,7 +4173,7 @@ Tag: v1.0.0
             finally:
                 Path(env_path).unlink(missing_ok=True)
 
-    def test_prepare_baseline_read_summary_error_handling(self, capsys) -> None:
+    def test_prepare_baseline_read_summary_error_handling(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test graceful error handling when baseline summary cannot be read."""
         with tempfile.TemporaryDirectory() as temp_dir:
             baseline_dir = Path(temp_dir)
@@ -4179,11 +4199,18 @@ Time: [95.0, 100.0, 105.0] µs
                 # Mock Path.open method to fail for read operations on baseline_results.txt
                 original_path_open = Path.open
 
-                def mock_path_open(self, mode="r", *args, **kwargs) -> Any:
+                def mock_path_open(  # noqa: PLR0913, PLR0917 - preserve Path.open's call signature.
+                    self: Path,
+                    mode: str = "r",
+                    buffering: int = -1,
+                    encoding: str | None = None,
+                    errors: str | None = None,
+                    newline: str | None = None,
+                ) -> IO[Any]:
                     if self.name == "baseline_results.txt" and "r" in mode:
                         msg = "Read permission denied"
                         raise OSError(msg)
-                    return original_path_open(self, mode, *args, **kwargs)
+                    return original_path_open(self, mode, buffering, encoding, errors, newline)
 
                 with patch.dict(os.environ, {"GITHUB_ENV": env_path}), patch.object(Path, "open", mock_path_open):
                     success = BenchmarkRegressionHelper.prepare_baseline(baseline_dir)
@@ -4209,7 +4236,7 @@ Time: [95.0, 100.0, 105.0] µs
             finally:
                 Path(env_path).unlink(missing_ok=True)
 
-    def test_prepare_baseline_missing_file(self, capsys) -> None:
+    def test_prepare_baseline_missing_file(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test baseline preparation when baseline file is missing."""
         with tempfile.TemporaryDirectory() as temp_dir:
             baseline_dir = Path(temp_dir)
@@ -4236,7 +4263,7 @@ Time: [95.0, 100.0, 105.0] µs
             finally:
                 Path(env_path).unlink(missing_ok=True)
 
-    def test_set_no_baseline_status(self, capsys) -> None:
+    def test_set_no_baseline_status(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test setting no baseline status."""
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as env_file:
             env_path = env_file.name
@@ -4412,7 +4439,7 @@ Hardware Information:
         assert reason == "same_commit"
 
     @patch("benchmark_utils.run_git_command")
-    def test_determine_benchmark_skip_baseline_not_found(self, mock_git) -> None:
+    def test_determine_benchmark_skip_baseline_not_found(self, mock_git: MagicMock) -> None:
         """Test skip determination when baseline commit not found in history."""
         # Simulate git cat-file failing
         mock_git.side_effect = subprocess.CalledProcessError(1, "git")
@@ -4423,7 +4450,7 @@ Hardware Information:
         assert reason == "baseline_commit_not_found"
 
     @patch("benchmark_utils.run_git_command")
-    def test_determine_benchmark_skip_no_changes(self, mock_git) -> None:
+    def test_determine_benchmark_skip_no_changes(self, mock_git: MagicMock) -> None:
         """Test skip determination when no relevant changes found."""
         # Mock successful git commands
         mock_git.side_effect = [
@@ -4437,7 +4464,7 @@ Hardware Information:
         assert reason == "no_relevant_changes"
 
     @patch("benchmark_utils.run_git_command")
-    def test_determine_benchmark_skip_changes_detected(self, mock_git) -> None:
+    def test_determine_benchmark_skip_changes_detected(self, mock_git: MagicMock) -> None:
         """Test skip determination when relevant changes are detected."""
         # Mock successful git commands
         mock_git.side_effect = [
@@ -4450,14 +4477,14 @@ Hardware Information:
         assert not should_skip
         assert reason == "changes_detected"
 
-    def test_display_skip_message(self, capsys) -> None:
+    def test_display_skip_message(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test displaying skip messages."""
         BenchmarkRegressionHelper.display_skip_message("same_commit", "abc1234")
 
         captured = capsys.readouterr()
         assert "Current commit matches baseline (abc1234)" in captured.out
 
-    def test_display_no_baseline_message(self, capsys) -> None:
+    def test_display_no_baseline_message(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test displaying no baseline message."""
         BenchmarkRegressionHelper.display_no_baseline_message()
 
@@ -4465,7 +4492,7 @@ Hardware Information:
         assert "No performance baseline available" in captured.out
         assert "To enable performance regression testing:" in captured.out
 
-    def test_run_regression_test_success(self, capsys) -> None:
+    def test_run_regression_test_success(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test successful regression test run."""
         with tempfile.TemporaryDirectory() as temp_dir:
             baseline_file = Path(temp_dir) / "baseline.txt"
@@ -4484,7 +4511,7 @@ Hardware Information:
                 captured = capsys.readouterr()
                 assert "Running performance regression test" in captured.out
 
-    def test_run_regression_test_dev_mode(self, capsys) -> None:
+    def test_run_regression_test_dev_mode(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test regression test run with dev mode enabled."""
         with tempfile.TemporaryDirectory() as temp_dir:
             baseline_file = Path(temp_dir) / "baseline.txt"
@@ -4518,7 +4545,7 @@ Hardware Information:
 
                 assert not success
 
-    def test_run_regression_test_custom_timeout(self, capsys) -> None:
+    def test_run_regression_test_custom_timeout(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test regression test run with custom bench_timeout parameter."""
         with tempfile.TemporaryDirectory() as temp_dir:
             baseline_file = Path(temp_dir) / "baseline.txt"
@@ -4537,7 +4564,7 @@ Hardware Information:
                 captured = capsys.readouterr()
                 assert "Running performance regression test" in captured.out
 
-    def test_display_results_file_exists(self, capsys) -> None:
+    def test_display_results_file_exists(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test displaying results when file exists."""
         with tempfile.TemporaryDirectory() as temp_dir:
             results_file = Path(temp_dir) / "results.txt"
@@ -4550,7 +4577,7 @@ Hardware Information:
             assert "=== Performance Regression Test Results ===" in captured.out
             assert "All tests passed" in captured.out
 
-    def test_display_results_file_missing(self, capsys) -> None:
+    def test_display_results_file_missing(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test displaying results when file is missing."""
         missing_file = Path("/nonexistent/results.txt")
 
@@ -4559,7 +4586,9 @@ Hardware Information:
         captured = capsys.readouterr()
         assert "No comparison results file found" in captured.out
 
-    def test_generate_summary_with_regression(self, temp_chdir, capsys) -> None:
+    def test_generate_summary_with_regression(
+        self, temp_chdir: Callable[[os.PathLike[str] | str], AbstractContextManager[None]], capsys: pytest.CaptureFixture[str]
+    ) -> None:
         """Test generating summary when regression is detected."""
         with tempfile.TemporaryDirectory() as temp_dir:
             results_file = Path(temp_dir) / "benches" / MAIN_VS_RELEASE_COMPARISON_RESULTS_FILE
@@ -4585,7 +4614,7 @@ Hardware Information:
                 assert "Result:" in captured.out
                 assert "Performance regressions detected" in captured.out
 
-    def test_generate_summary_skip_same_commit(self, capsys) -> None:
+    def test_generate_summary_skip_same_commit(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test generating summary when benchmarks skipped due to same commit."""
         env_vars = {
             "BASELINE_SOURCE": "artifact",
@@ -4602,7 +4631,7 @@ Hardware Information:
             assert "Result:" in captured.out
             assert "Benchmarks skipped (same commit as baseline)" in captured.out
 
-    def test_generate_summary_no_baseline(self, capsys) -> None:
+    def test_generate_summary_no_baseline(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test generating summary when no baseline available."""
         env_vars = {
             "BASELINE_EXISTS": "false",
@@ -4616,7 +4645,9 @@ Hardware Information:
             assert "Result:" in captured.out
             assert "Benchmarks skipped (no baseline available)" in captured.out
 
-    def test_generate_summary_sets_regression_environment_variable(self, temp_chdir, capsys) -> None:
+    def test_generate_summary_sets_regression_environment_variable(
+        self, temp_chdir: Callable[[os.PathLike[str] | str], AbstractContextManager[None]], capsys: pytest.CaptureFixture[str]
+    ) -> None:
         """Test that generate_summary sets BENCHMARK_REGRESSION_DETECTED environment variable when regressions are found."""
         with tempfile.TemporaryDirectory() as temp_dir:
             results_file = Path(temp_dir) / "benches" / MAIN_VS_RELEASE_COMPARISON_RESULTS_FILE
@@ -4642,7 +4673,7 @@ Hardware Information:
                 captured = capsys.readouterr()
                 assert "Exported BENCHMARK_REGRESSION_DETECTED=true for downstream CI steps" in captured.out
 
-    def test_generate_summary_github_env_export(self, temp_chdir) -> None:
+    def test_generate_summary_github_env_export(self, temp_chdir: Callable[[os.PathLike[str] | str], AbstractContextManager[None]]) -> None:
         """Test that BENCHMARK_REGRESSION_DETECTED is also exported to GITHUB_ENV when available."""
         with tempfile.TemporaryDirectory() as temp_dir:
             results_file = Path(temp_dir) / "benches" / MAIN_VS_RELEASE_COMPARISON_RESULTS_FILE
@@ -4664,7 +4695,9 @@ Hardware Information:
                 github_env_content = github_env_file.read_text(encoding=UTF8)
                 assert "BENCHMARK_REGRESSION_DETECTED=true" in github_env_content
 
-    def test_generate_summary_with_error_file(self, temp_chdir, capsys) -> None:
+    def test_generate_summary_with_error_file(
+        self, temp_chdir: Callable[[os.PathLike[str] | str], AbstractContextManager[None]], capsys: pytest.CaptureFixture[str]
+    ) -> None:
         """Test generating summary when comparison failed with error file."""
         with tempfile.TemporaryDirectory() as temp_dir:
             results_file = Path(temp_dir) / "benches" / MAIN_VS_RELEASE_COMPARISON_RESULTS_FILE
@@ -4707,7 +4740,7 @@ Hardware Information:
 class TestProjectRootHandling:
     """Test cases for find_project_root functionality."""
 
-    def test_find_project_root_success(self, temp_chdir) -> None:
+    def test_find_project_root_success(self, temp_chdir: Callable[[os.PathLike[str] | str], AbstractContextManager[None]]) -> None:
         """Test finding project root when Cargo.toml exists."""
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
@@ -4725,7 +4758,7 @@ class TestProjectRootHandling:
                 # Resolve both paths to handle symlinks (macOS /var -> /private/var)
                 assert result.resolve() == temp_path.resolve()
 
-    def test_find_project_root_not_found(self, temp_chdir) -> None:
+    def test_find_project_root_not_found(self, temp_chdir: Callable[[os.PathLike[str] | str], AbstractContextManager[None]]) -> None:
         """Test finding project root when Cargo.toml doesn't exist."""
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
@@ -4752,7 +4785,7 @@ class TestTimeoutHandling:
             ),
         ],
     )
-    def test_timeout_parameter_passed(self, component_class, method_name, setup_func) -> None:
+    def test_timeout_parameter_passed(self, component_class: str, method_name: str, setup_func: Callable[[str], int | None]) -> None:
         """Test that benchmark components accept and use timeout parameter."""
         with tempfile.TemporaryDirectory() as temp_dir:
             project_root = Path(temp_dir)
@@ -4785,7 +4818,7 @@ class TestTimeoutHandling:
                 assert mock_cargo.call_count >= 1
                 assert any(call.kwargs.get("timeout") == 120 for call in mock_cargo.call_args_list)
 
-    def test_timeout_error_handling_baseline_generator(self, capsys) -> None:
+    def test_timeout_error_handling_baseline_generator(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test proper error handling when benchmark times out in BaselineGenerator."""
         with tempfile.TemporaryDirectory() as temp_dir:
             project_root = Path(temp_dir)
@@ -4803,7 +4836,7 @@ class TestTimeoutHandling:
                 assert "timed out after 1800 seconds" in captured.err
                 assert "Consider increasing --bench-timeout" in captured.err
 
-    def test_timeout_error_handling_performance_comparator(self, capsys) -> None:
+    def test_timeout_error_handling_performance_comparator(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test proper error handling when benchmark times out in PerformanceComparator."""
         with tempfile.TemporaryDirectory() as temp_dir:
             project_root = Path(temp_dir)
@@ -4833,7 +4866,9 @@ class TestTimeoutHandling:
                 assert "cargo bench" in error_content  # Command from exception
                 assert "timeout after 1800 seconds" in error_content  # Explicit timeout value
 
-    def test_cli_bench_timeout_validation(self, monkeypatch, temp_chdir) -> None:
+    def test_cli_bench_timeout_validation(
+        self, monkeypatch: pytest.MonkeyPatch, temp_chdir: Callable[[os.PathLike[str] | str], AbstractContextManager[None]]
+    ) -> None:
         """Test that CLI validates bench_timeout is positive via main()."""
         # Create a temporary project with Cargo.toml to satisfy find_project_root
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -4868,7 +4903,7 @@ class TestTimeoutHandling:
         assert args.verbose
         assert args.command == "generate-summary"
 
-    def test_parser_suggests_close_subcommand_name(self, capsys) -> None:
+    def test_parser_suggests_close_subcommand_name(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Python 3.14 argparse suggestions should help recover from CLI typos."""
         parser = create_argument_parser()
 
@@ -5057,7 +5092,7 @@ class TestTimeoutHandling:
         )
 
     @patch("benchmark_utils.PerformanceSummaryGenerator")
-    def test_execute_command_passes_strict_summary_generation(self, mock_generator_class) -> None:
+    def test_execute_command_passes_strict_summary_generation(self, mock_generator_class: MagicMock) -> None:
         """Test that CLI dispatch passes strict mode and exits nonzero on summary failure."""
         parser = create_argument_parser()
         args = parser.parse_args(
@@ -5122,7 +5157,7 @@ class TestTimeoutHandling:
             ({"poll_seconds": True}, "poll_seconds must be a positive integer"),
         ],
     )
-    def test_baseline_fetch_options_reject_invalid_waits(self, kwargs, message) -> None:
+    def test_baseline_fetch_options_reject_invalid_waits(self, kwargs: InvalidWaitOptions, message: str) -> None:
         """BaselineFetchOptions rejects durations that would break polling."""
         with pytest.raises(ValueError, match=message):
             BaselineFetchOptions(**kwargs)
@@ -5140,7 +5175,14 @@ class TestTimeoutHandling:
             ("compare-tags", "--poll-seconds", "-1"),
         ],
     )
-    def test_cli_rejects_invalid_baseline_fetch_waits(self, monkeypatch, temp_chdir, command: str, option: str, value: str) -> None:
+    def test_cli_rejects_invalid_baseline_fetch_waits(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        temp_chdir: Callable[[os.PathLike[str] | str], AbstractContextManager[None]],
+        command: str,
+        option: str,
+        value: str,
+    ) -> None:
         """CLI wait/poll validation fails before GitHub workflow dispatch."""
         with tempfile.TemporaryDirectory() as temp_dir:
             project_root = Path(temp_dir)
@@ -5201,7 +5243,7 @@ class TestCompareBaselinesCliFailures:
             argv.extend(["--output", str(output)])
         return create_argument_parser().parse_args(argv)
 
-    def test_rejects_directory_baseline_without_stdout(self, tmp_path: Path, capsys) -> None:
+    def test_rejects_directory_baseline_without_stdout(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         old_baseline = tmp_path / "old"
         old_baseline.mkdir()
         new_baseline = tmp_path / "new.txt"
@@ -5215,7 +5257,7 @@ class TestCompareBaselinesCliFailures:
         assert captured.out == ""
         assert captured.err == f"benchmark-utils compare-baselines: error: --old must name a regular file: {old_baseline}\n"
 
-    def test_reports_malformed_utf8_without_traceback(self, tmp_path: Path, capsys) -> None:
+    def test_reports_malformed_utf8_without_traceback(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         old_baseline = tmp_path / "old.txt"
         new_baseline = tmp_path / "new.txt"
         old_baseline.write_bytes(b"\xff")
@@ -5230,7 +5272,9 @@ class TestCompareBaselinesCliFailures:
         assert captured.err.startswith("benchmark-utils compare-baselines: error: baseline input is not valid UTF-8:")
         assert "Traceback" not in captured.err
 
-    def test_reports_input_permission_failure_without_traceback(self, tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_reports_input_permission_failure_without_traceback(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         old_baseline = tmp_path / "old.txt"
         new_baseline = tmp_path / "new.txt"
         old_baseline.write_text("old\n", encoding=UTF8)
@@ -5253,7 +5297,7 @@ class TestCompareBaselinesCliFailures:
     def test_output_failure_preserves_destination_and_suppresses_report(
         self,
         tmp_path: Path,
-        capsys,
+        capsys: pytest.CaptureFixture[str],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         old_baseline = tmp_path / "old.txt"
@@ -5298,7 +5342,7 @@ class TestPerformanceSummaryGenerator:
             assert isinstance(generator.current_version, str)
             assert isinstance(generator.current_date, str)
 
-    def test_parse_single_method_result_accepts_valid_estimate(self, tmp_path) -> None:
+    def test_parse_single_method_result_accepts_valid_estimate(self, tmp_path: Path) -> None:
         """Test circumsphere method parsing accepts finite ordered Criterion estimates."""
         criterion_path = tmp_path / "target" / "criterion" / "basic_2d_insphere"
         estimates_dir = criterion_path / "base"
@@ -5335,7 +5379,7 @@ class TestPerformanceSummaryGenerator:
             {"mean": {"point_estimate": 100000.0, "confidence_interval": {"lower_bound": 120000.0, "upper_bound": 110000.0}}},
         ],
     )
-    def test_parse_single_method_result_rejects_invalid_estimates(self, tmp_path, estimates_data) -> None:
+    def test_parse_single_method_result_rejects_invalid_estimates(self, tmp_path: Path, estimates_data: object) -> None:
         """Test circumsphere method parsing rejects malformed or invalid Criterion estimates."""
         criterion_path = tmp_path / "target" / "criterion" / "basic_2d_insphere"
         estimates_dir = criterion_path / "base"
@@ -5354,7 +5398,7 @@ class TestPerformanceSummaryGenerator:
         assert args.bench_timeout == 1800
 
     @patch("benchmark_utils.run_git_command")
-    def test_get_current_version_prefers_cargo_package_version(self, mock_git_command) -> None:
+    def test_get_current_version_prefers_cargo_package_version(self, mock_git_command: MagicMock) -> None:
         """Test getting current version from Cargo.toml before falling back to tags."""
         mock_git_command.side_effect = RuntimeError("git unavailable")
 
@@ -5370,7 +5414,7 @@ class TestPerformanceSummaryGenerator:
             assert generator.current_version == "1.2.3"
 
     @patch("benchmark_utils.run_git_command")
-    def test_get_current_version_with_tag(self, mock_git_command) -> None:
+    def test_get_current_version_with_tag(self, mock_git_command: MagicMock) -> None:
         """Test getting current version from git tags."""
         mock_git_command.return_value = completed_process("v1.2.3\n")
 
@@ -5383,14 +5427,14 @@ class TestPerformanceSummaryGenerator:
             mock_git_command.assert_called_with(["describe", "--tags", "--abbrev=0", "--match=v*"], cwd=project_root)
 
     @patch("benchmark_utils.run_git_command")
-    def test_get_current_version_fallback(self, mock_git_command) -> None:
+    def test_get_current_version_fallback(self, mock_git_command: MagicMock) -> None:
         """Test fallback version detection when describe fails."""
         # First call (describe) fails, second call (tag -l) succeeds
         mock_result = completed_process("v0.1.0\nv0.2.0")
 
         # The second call is made within the exception handler
-        def side_effect(*args, **kwargs) -> subprocess.CompletedProcess[str]:
-            if "describe" in args[0]:
+        def side_effect(args: list[str], _cwd: Path | None = None, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            if "describe" in args:
                 raise subprocess.CalledProcessError(1, "git describe", "describe failed")
             return mock_result
 
@@ -5404,7 +5448,7 @@ class TestPerformanceSummaryGenerator:
             assert version == "0.1.0"
 
     @patch("benchmark_utils.run_git_command")
-    def test_get_current_version_no_tags(self, mock_git_command) -> None:
+    def test_get_current_version_no_tags(self, mock_git_command: MagicMock) -> None:
         """Test version detection when no tags are found."""
         mock_git_command.side_effect = RuntimeError("No tags found")
 
@@ -5417,7 +5461,7 @@ class TestPerformanceSummaryGenerator:
 
     @patch("benchmark_utils.run_git_command")
     @patch("benchmark_utils.datetime")
-    def test_get_version_date_with_tag(self, mock_datetime, mock_git_command) -> None:  # noqa: ARG002
+    def test_get_version_date_with_tag(self, mock_datetime: MagicMock, mock_git_command: MagicMock) -> None:  # noqa: ARG002
         """Test getting version date from git tag."""
         mock_git_command.return_value = completed_process("2024-01-15\n")
 
@@ -5432,7 +5476,7 @@ class TestPerformanceSummaryGenerator:
 
     @patch("benchmark_utils.run_git_command")
     @patch("benchmark_utils.datetime")
-    def test_get_version_date_fallback(self, mock_datetime, mock_git_command) -> None:
+    def test_get_version_date_fallback(self, mock_datetime: MagicMock, mock_git_command: MagicMock) -> None:
         """Test version date fallback to current date."""
         mock_git_command.side_effect = RuntimeError("Git command failed")
         mock_now = Mock()
@@ -5594,7 +5638,7 @@ OK: Time change -1.8% within acceptable range
     @patch("benchmark_utils.get_git_commit_hash")
     @patch("benchmark_utils.run_git_command")
     @patch("benchmark_utils.datetime")
-    def test_generate_markdown_content(self, mock_datetime, mock_run_git, mock_git_commit) -> None:
+    def test_generate_markdown_content(self, mock_datetime: MagicMock, mock_run_git: MagicMock, mock_git_commit: MagicMock) -> None:
         """Test generating complete markdown content."""
         # Avoid calling actual git in __init__ helpers
         mock_run_git.side_effect = RuntimeError("git unavailable in test")
@@ -5730,7 +5774,7 @@ Benchmark completed."""
             assert result is None
 
     @patch("benchmark_utils.run_cargo_command")
-    def test_run_circumsphere_benchmarks_success(self, mock_cargo) -> None:
+    def test_run_circumsphere_benchmarks_success(self, mock_cargo: MagicMock) -> None:
         """Test running circumsphere benchmarks successfully."""
         mock_cargo.return_value = completed_process()
 
@@ -5756,7 +5800,7 @@ Benchmark completed."""
             ]
 
     @patch("benchmark_utils.run_cargo_command")
-    def test_run_circumsphere_benchmarks_uses_requested_cargo_profile(self, mock_cargo) -> None:
+    def test_run_circumsphere_benchmarks_uses_requested_cargo_profile(self, mock_cargo: MagicMock) -> None:
         """Test running circumsphere benchmarks with an explicit Cargo profile."""
         mock_cargo.return_value = completed_process()
 
@@ -5774,7 +5818,7 @@ Benchmark completed."""
             assert args[:5] == ["bench", "--profile", requested_profile, "--bench", "circumsphere_containment"]
 
     @patch("benchmark_utils.run_cargo_command")
-    def test_run_circumsphere_benchmarks_with_numerical_data(self, mock_cargo) -> None:
+    def test_run_circumsphere_benchmarks_with_numerical_data(self, mock_cargo: MagicMock) -> None:
         """Test running circumsphere benchmarks with numerical accuracy data."""
         # Mock cargo command to return output with numerical accuracy data
         mock_result = completed_process(
@@ -5814,7 +5858,7 @@ Benchmark completed.""",
             ]
 
     @patch("benchmark_utils.run_cargo_command")
-    def test_run_circumsphere_benchmarks_failure(self, mock_cargo, capsys) -> None:
+    def test_run_circumsphere_benchmarks_failure(self, mock_cargo: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
         """Test handling circumsphere benchmark failures."""
         mock_cargo.side_effect = RuntimeError("Benchmark failed")
 
@@ -5832,7 +5876,7 @@ Benchmark completed.""",
             assert "Error running circumsphere benchmarks" in captured.out
 
     @patch("benchmark_utils.run_cargo_command")
-    def test_run_ci_performance_suite_success(self, mock_cargo) -> None:
+    def test_run_ci_performance_suite_success(self, mock_cargo: MagicMock) -> None:
         """Test running the public API CI performance suite successfully."""
         mock_cargo.return_value = completed_process(CI_MANIFEST_STDOUT)
 
@@ -5867,7 +5911,7 @@ Benchmark completed.""",
             assert "completed_at" in metadata
 
     @patch("benchmark_utils.run_cargo_command")
-    def test_run_ci_performance_suite_uses_requested_cargo_profile(self, mock_cargo) -> None:
+    def test_run_ci_performance_suite_uses_requested_cargo_profile(self, mock_cargo: MagicMock) -> None:
         """Test running the public API CI performance suite with an explicit profile."""
         mock_cargo.return_value = completed_process(CI_MANIFEST_STDOUT)
 
@@ -5885,7 +5929,7 @@ Benchmark completed.""",
             assert "--" not in args
 
     @patch("benchmark_utils.run_cargo_command")
-    def test_run_ci_performance_suite_uses_requested_timeout(self, mock_cargo) -> None:
+    def test_run_ci_performance_suite_uses_requested_timeout(self, mock_cargo: MagicMock) -> None:
         """Test that release callers can extend the public API benchmark budget."""
         mock_cargo.return_value = completed_process(CI_MANIFEST_STDOUT)
 
@@ -5912,7 +5956,7 @@ Benchmark completed.""",
             mock_cargo.assert_not_called()
 
     @patch("benchmark_utils.run_cargo_command")
-    def test_run_ci_performance_suite_dev_mode_uses_reduced_sampling(self, mock_cargo) -> None:
+    def test_run_ci_performance_suite_dev_mode_uses_reduced_sampling(self, mock_cargo: MagicMock) -> None:
         """Test dev mode appends reduced Criterion sampling args explicitly."""
         mock_cargo.return_value = completed_process(CI_MANIFEST_STDOUT)
 
@@ -5932,7 +5976,7 @@ Benchmark completed.""",
             assert metadata["sampling_mode"] == "dev"
 
     @patch("benchmark_utils.run_cargo_command")
-    def test_run_ci_performance_suite_requires_manifest(self, mock_cargo) -> None:
+    def test_run_ci_performance_suite_requires_manifest(self, mock_cargo: MagicMock) -> None:
         """Test successful ci_performance_suite runs must emit the manifest."""
         mock_cargo.return_value = completed_process()
 
@@ -5949,7 +5993,7 @@ Benchmark completed.""",
             assert stale_manifest_path.read_text(encoding="utf-8") == "stale/benchmark/id\n"
 
     @patch("benchmark_utils.run_cargo_command")
-    def test_run_ci_performance_suite_requires_metrics(self, mock_cargo) -> None:
+    def test_run_ci_performance_suite_requires_metrics(self, mock_cargo: MagicMock) -> None:
         """Test fresh ci_performance_suite runs must emit construction metrics."""
         stdout_without_metrics = CI_MANIFEST_STDOUT.split("api_benchmark_metric", maxsplit=1)[0]
         mock_cargo.return_value = completed_process(stdout_without_metrics)
@@ -5970,7 +6014,7 @@ Benchmark completed.""",
             assert stale_metrics_path.read_text(encoding="utf-8") == "{}\n"
 
     @patch("benchmark_utils.run_cargo_command")
-    def test_run_ci_performance_suite_nonzero_exit(self, mock_cargo, capsys) -> None:
+    def test_run_ci_performance_suite_nonzero_exit(self, mock_cargo: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
         """Test handling ci_performance_suite nonzero process exits."""
         mock_cargo.return_value = completed_process(returncode=101, stderr="benchmark failed")
 
@@ -5985,7 +6029,7 @@ Benchmark completed.""",
             assert "cargo exited with status 101" in captured.out
 
     @patch("benchmark_utils.run_cargo_command")
-    def test_run_ci_performance_suite_failure(self, mock_cargo, capsys) -> None:
+    def test_run_ci_performance_suite_failure(self, mock_cargo: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
         """Test handling ci_performance_suite benchmark failures."""
         mock_cargo.side_effect = OSError("Benchmark failed")
 
@@ -6000,7 +6044,7 @@ Benchmark completed.""",
             assert "Error running ci_performance_suite benchmarks" in captured.out
 
     @patch("benchmark_utils.run_git_command")
-    def test_generate_summary_success(self, mock_git, capsys) -> None:
+    def test_generate_summary_success(self, mock_git: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
         """Test successful generation of performance summary."""
         mock_git.side_effect = RuntimeError("git unavailable in test")
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -6033,7 +6077,7 @@ Benchmark completed.""",
                 generator.generate_summary(bench_timeout=bench_timeout)
 
     @patch("benchmark_utils.run_release_signal_measurement_plan")
-    def test_generate_summary_with_benchmarks(self, mock_run_plan) -> None:
+    def test_generate_summary_with_benchmarks(self, mock_run_plan: MagicMock) -> None:
         """Test generating summary with fresh benchmark run."""
         mock_run_plan.return_value = {measurement.target: "" for measurement in benchmark_utils.RELEASE_SIGNAL_MEASUREMENT_PLAN}
 
@@ -6059,7 +6103,7 @@ Benchmark completed.""",
             assert output_file.exists()
 
     @patch("benchmark_utils.run_release_signal_measurement_plan")
-    def test_generate_summary_passes_cargo_profile_to_benchmarks(self, mock_run_plan) -> None:
+    def test_generate_summary_passes_cargo_profile_to_benchmarks(self, mock_run_plan: MagicMock) -> None:
         """Test generating a summary with fresh benchmarks under a specific Cargo profile."""
         mock_run_plan.return_value = {measurement.target: "" for measurement in benchmark_utils.RELEASE_SIGNAL_MEASUREMENT_PLAN}
 
@@ -6086,7 +6130,7 @@ Benchmark completed.""",
             assert output_file.exists()
 
     @patch("benchmark_utils.run_release_signal_measurement_plan")
-    def test_generate_summary_fresh_benchmark_failure_preserves_previous_report(self, mock_run_plan, capsys) -> None:
+    def test_generate_summary_fresh_benchmark_failure_preserves_previous_report(self, mock_run_plan: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
         """A failed fresh run must fail closed without replacing prior evidence."""
         mock_run_plan.side_effect = RuntimeError("benchmark failed")
 
@@ -6105,7 +6149,7 @@ Benchmark completed.""",
             assert "Fresh benchmark run failed" in captured.err
 
     @patch("benchmark_utils.run_release_signal_measurement_plan")
-    def test_generate_summary_strict_benchmark_failure_fails(self, mock_run_plan, capsys) -> None:
+    def test_generate_summary_strict_benchmark_failure_fails(self, mock_run_plan: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
         """Test that strict summary generation fails instead of using fallback data."""
         mock_run_plan.side_effect = RuntimeError("benchmark failed")
 
@@ -6125,7 +6169,7 @@ Benchmark completed.""",
             captured = capsys.readouterr()
             assert "Fresh benchmark run failed" in captured.err
 
-    def test_generate_summary_strict_rejects_structural_fallback_provenance(self, capsys) -> None:
+    def test_generate_summary_strict_rejects_structural_fallback_provenance(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Strict generation rejects fallback based on provenance, not rendered prose."""
         with tempfile.TemporaryDirectory() as temp_dir:
             project_root = Path(temp_dir)
@@ -6179,7 +6223,7 @@ Benchmark completed.""",
         for measurement in benchmark_utils.RELEASE_SIGNAL_MEASUREMENT_PLAN:
             assert f"| `{measurement.target}` | {measurement.report_section} |" in rendered
 
-    def test_generate_summary_strict_rejects_missing_planned_report_section(self, tmp_path: Path, capsys) -> None:
+    def test_generate_summary_strict_rejects_missing_planned_report_section(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """A planned target without Criterion groups must block strict publication."""
         generator = PerformanceSummaryGenerator(tmp_path)
         for measurement in benchmark_utils.RELEASE_SIGNAL_MEASUREMENT_PLAN[:-1]:
@@ -6198,7 +6242,7 @@ Benchmark completed.""",
         captured = capsys.readouterr()
         assert "realization_validation report section 'Realization validation' is incomplete" in captured.err
 
-    def test_generate_summary_strict_rejects_missing_circumsphere_results(self, capsys) -> None:
+    def test_generate_summary_strict_rejects_missing_circumsphere_results(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test that strict summary generation fails when circumsphere results are absent."""
         with tempfile.TemporaryDirectory() as temp_dir:
             project_root = Path(temp_dir)
@@ -6216,7 +6260,7 @@ Benchmark completed.""",
             captured = capsys.readouterr()
             assert "circumsphere evidence uses reference fallback timings" in captured.err
 
-    def test_generate_summary_strict_rejects_partial_circumsphere_estimates(self, tmp_path: Path, capsys) -> None:
+    def test_generate_summary_strict_rejects_partial_circumsphere_estimates(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """One missing method estimate makes the fixed circumsphere contract incomplete."""
         generator = PerformanceSummaryGenerator(tmp_path)
         circumsphere_results = complete_circumsphere_results(generator)
@@ -6237,7 +6281,7 @@ Benchmark completed.""",
         assert "circumsphere Criterion evidence is incomplete" in captured.err
         assert "2d_insphere" in captured.err
 
-    def test_generate_summary_strict_rejects_manifest_result_with_malformed_estimate(self, tmp_path: Path, capsys) -> None:
+    def test_generate_summary_strict_rejects_manifest_result_with_malformed_estimate(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """The runtime manifest makes a skipped malformed CI estimate an explicit gap."""
         generator = PerformanceSummaryGenerator(tmp_path)
         manifest_path = tmp_path / "target" / "criterion" / _CI_PERFORMANCE_SUITE_MANIFEST_IDS_FILE
@@ -6258,7 +6302,7 @@ Benchmark completed.""",
         assert "runtime-manifest" in captured.err
         assert "validation/malformed/20" in captured.err
 
-    def test_generate_summary_atomic_replace_failure_preserves_previous_report(self, tmp_path: Path, capsys) -> None:
+    def test_generate_summary_atomic_replace_failure_preserves_previous_report(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """A final replacement failure leaves the previous tracked report byte-identical."""
         generator = PerformanceSummaryGenerator(tmp_path)
         write_complete_release_signal_coverage(tmp_path)
@@ -6278,7 +6322,7 @@ Benchmark completed.""",
         captured = capsys.readouterr()
         assert "injected replace failure" in captured.err
 
-    def test_generate_summary_exception_handling(self, capsys) -> None:
+    def test_generate_summary_exception_handling(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test exception handling in generate_summary."""
         with tempfile.TemporaryDirectory() as temp_dir:
             project_root = Path(temp_dir)
@@ -6587,7 +6631,7 @@ Hardware Information:
 class TestTagSpecificBaselineHandling:
     """Test cases for tag-specific baseline file handling functionality."""
 
-    def test_prepare_baseline_with_tag_specific_file(self, capsys) -> None:
+    def test_prepare_baseline_with_tag_specific_file(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test baseline preparation with tag-specific file (baseline-v*.txt)."""
         with tempfile.TemporaryDirectory() as temp_dir:
             baseline_dir = Path(temp_dir)
@@ -6639,7 +6683,7 @@ Time: [160.1, 168.18, 177.67] µs
             finally:
                 Path(env_path).unlink(missing_ok=True)
 
-    def test_prepare_baseline_with_generic_baseline_file(self, capsys) -> None:
+    def test_prepare_baseline_with_generic_baseline_file(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test baseline preparation with generic baseline*.txt file."""
         with tempfile.TemporaryDirectory() as temp_dir:
             baseline_dir = Path(temp_dir)
@@ -6686,7 +6730,7 @@ Time: [95.0, 100.0, 105.0] µs
             finally:
                 Path(env_path).unlink(missing_ok=True)
 
-    def test_prepare_baseline_prefers_standard_name(self, capsys) -> None:
+    def test_prepare_baseline_prefers_standard_name(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test that prepare_baseline prefers baseline_results.txt over tag-specific files."""
         with tempfile.TemporaryDirectory() as temp_dir:
             baseline_dir = Path(temp_dir)
@@ -6728,7 +6772,7 @@ Time: [95.0, 100.0, 105.0] µs
             finally:
                 Path(env_path).unlink(missing_ok=True)
 
-    def test_prepare_baseline_no_matching_files(self, capsys) -> None:
+    def test_prepare_baseline_no_matching_files(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test baseline preparation when no matching baseline files are found."""
         with tempfile.TemporaryDirectory() as temp_dir:
             baseline_dir = Path(temp_dir)

--- a/scripts/tests/test_hardware_utils.py
+++ b/scripts/tests/test_hardware_utils.py
@@ -19,6 +19,7 @@ from subprocess_utils import ExecutableNotFoundError
 
 if TYPE_CHECKING:
     from pathlib import Path
+    from unittest.mock import MagicMock
 
 
 @pytest.fixture
@@ -30,25 +31,25 @@ def hardware() -> HardwareInfo:
 class TestHardwareInfo:
     """Test cases for HardwareInfo class."""
 
-    def test_init(self, hardware) -> None:
+    def test_init(self, hardware: HardwareInfo) -> None:
         """Test HardwareInfo initialization."""
         assert hardware.os_type == platform.system()
         assert hardware.machine == platform.machine()
 
     @patch("hardware_utils.platform.system")
-    def test_init_with_different_os(self, mock_system) -> None:
+    def test_init_with_different_os(self, mock_system: MagicMock) -> None:
         """Test initialization with different OS types."""
         mock_system.return_value = "Linux"
         hardware = HardwareInfo()
         assert hardware.os_type == "Linux"
 
-    def test_run_command_empty_cmd(self, hardware) -> None:
+    def test_run_command_empty_cmd(self, hardware: HardwareInfo) -> None:
         """Test _run_command with empty command list."""
         with pytest.raises(ValueError, match="Command list cannot be empty"):
             hardware._run_command([])
 
     @patch("hardware_utils.run_safe_command")
-    def test_run_command_success(self, mock_run_safe, hardware) -> None:
+    def test_run_command_success(self, mock_run_safe: MagicMock, hardware: HardwareInfo) -> None:
         """Test successful command execution."""
         mock_run_safe.return_value = subprocess.CompletedProcess(
             args=["echo", "test"],
@@ -70,7 +71,7 @@ class TestHardwareInfo:
         )
 
     @patch("hardware_utils.run_safe_command")
-    def test_run_command_failure(self, mock_run_safe, hardware) -> None:
+    def test_run_command_failure(self, mock_run_safe: MagicMock, hardware: HardwareInfo) -> None:
         """Test command execution failure."""
         mock_run_safe.side_effect = subprocess.CalledProcessError(1, "cmd")
 
@@ -79,7 +80,7 @@ class TestHardwareInfo:
 
     @patch("hardware_utils.platform.system")
     @patch.object(HardwareInfo, "_run_command")
-    def test_get_cpu_info_darwin(self, mock_run_command, mock_system) -> None:
+    def test_get_cpu_info_darwin(self, mock_run_command: MagicMock, mock_system: MagicMock) -> None:
         """Test CPU info detection on macOS."""
         mock_system.return_value = "Darwin"
         mock_run_command.side_effect = ["Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz", "6", "12"]
@@ -94,7 +95,7 @@ class TestHardwareInfo:
     @patch("hardware_utils.platform.system")
     @patch("hardware_utils.shutil.which")
     @patch.object(HardwareInfo, "_run_command")
-    def test_get_cpu_info_linux_with_lscpu(self, mock_run_command, mock_which, mock_system) -> None:
+    def test_get_cpu_info_linux_with_lscpu(self, mock_run_command: MagicMock, mock_which: MagicMock, mock_system: MagicMock) -> None:
         """Test CPU info detection on Linux with lscpu available."""
         mock_system.return_value = "Linux"
         mock_which.side_effect = lambda cmd: cmd in ["lscpu", "nproc"]
@@ -122,7 +123,7 @@ Thread(s) per core:  2"""
     @patch("hardware_utils.platform.system")
     @patch("hardware_utils.shutil.which")
     @patch("builtins.open", new_callable=mock_open, read_data="processor\t: 0\nmodel name\t: AMD Ryzen 5 3600\nprocessor\t: 1\n")
-    def test_get_cpu_info_linux_fallback_cpuinfo(self, _mock_file, mock_which, mock_system) -> None:  # noqa: PT019
+    def test_get_cpu_info_linux_fallback_cpuinfo(self, _mock_file: MagicMock, mock_which: MagicMock, mock_system: MagicMock) -> None:  # noqa: PT019
         """Test CPU info detection on Linux using /proc/cpuinfo fallback."""
         mock_system.return_value = "Linux"
         mock_which.return_value = None  # No commands available
@@ -137,7 +138,9 @@ Thread(s) per core:  2"""
     @patch("hardware_utils.shutil.which")
     @patch.object(HardwareInfo, "_get_linux_cpu_cores_from_proc")
     @patch.object(HardwareInfo, "_get_linux_cpu_cores_from_lscpu")
-    def test_get_linux_cpu_cores_falls_back_when_lscpu_unknown(self, mock_lscpu_cores, mock_proc_cores, mock_which, hardware) -> None:
+    def test_get_linux_cpu_cores_falls_back_when_lscpu_unknown(
+        self, mock_lscpu_cores: MagicMock, mock_proc_cores: MagicMock, mock_which: MagicMock, hardware: HardwareInfo
+    ) -> None:
         """Test Linux CPU core fallback when lscpu output is unusable."""
         mock_which.side_effect = lambda cmd: cmd == "lscpu"
         mock_lscpu_cores.return_value = "Unknown"
@@ -150,7 +153,9 @@ Thread(s) per core:  2"""
     @patch("hardware_utils.shutil.which")
     @patch.object(HardwareInfo, "_get_linux_cpu_cores_from_proc")
     @patch.object(HardwareInfo, "_get_linux_cpu_cores_from_lscpu")
-    def test_get_linux_cpu_cores_falls_back_when_lscpu_raises(self, mock_lscpu_cores, mock_proc_cores, mock_which, hardware) -> None:
+    def test_get_linux_cpu_cores_falls_back_when_lscpu_raises(
+        self, mock_lscpu_cores: MagicMock, mock_proc_cores: MagicMock, mock_which: MagicMock, hardware: HardwareInfo
+    ) -> None:
         """Test Linux CPU core fallback when lscpu parsing raises."""
         mock_which.side_effect = lambda cmd: cmd == "lscpu"
         mock_lscpu_cores.side_effect = RuntimeError("bad lscpu output")
@@ -163,7 +168,7 @@ Thread(s) per core:  2"""
     @patch("hardware_utils.platform.system")
     @patch("hardware_utils.shutil.which")
     @patch.object(HardwareInfo, "_run_command")
-    def test_get_cpu_info_windows(self, mock_run_command, mock_which, mock_system) -> None:
+    def test_get_cpu_info_windows(self, mock_run_command: MagicMock, mock_which: MagicMock, mock_system: MagicMock) -> None:
         """Test CPU info detection on Windows."""
         mock_system.return_value = "Windows"
         mock_which.side_effect = lambda cmd: cmd == "powershell"
@@ -179,7 +184,7 @@ Thread(s) per core:  2"""
 
     @patch("hardware_utils.platform.processor", return_value="")
     @patch("hardware_utils.platform.system")
-    def test_get_cpu_info_unknown_os(self, mock_system, mock_processor) -> None:
+    def test_get_cpu_info_unknown_os(self, mock_system: MagicMock, mock_processor: MagicMock) -> None:
         """Test CPU info detection on unknown OS."""
         mock_system.return_value = "UnknownOS"
 
@@ -196,9 +201,9 @@ Thread(s) per core:  2"""
     @patch("hardware_utils.shutil.which", return_value=None)
     def test_get_cpu_info_windows_uses_processor_identifier(
         self,
-        mock_which,
-        mock_system,
-        mock_processor,
+        mock_which: MagicMock,
+        mock_system: MagicMock,
+        mock_processor: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Windows provenance uses the concrete environment CPU identifier."""
@@ -216,7 +221,7 @@ Thread(s) per core:  2"""
 
     @patch("hardware_utils.platform.processor", return_value="Apple M4 Pro")
     @patch("hardware_utils.platform.system", return_value="UnknownOS")
-    def test_get_cpu_info_uses_concrete_platform_fallback(self, mock_system, mock_processor) -> None:
+    def test_get_cpu_info_uses_concrete_platform_fallback(self, mock_system: MagicMock, mock_processor: MagicMock) -> None:
         """Unknown platforms retain a concrete processor model when exposed."""
         cpu_model, cpu_cores, cpu_threads = HardwareInfo().get_cpu_info()
 
@@ -229,7 +234,7 @@ Thread(s) per core:  2"""
     @patch("hardware_utils.platform.processor", return_value="ppc64le")
     @patch("hardware_utils.platform.machine", return_value="PPC64LE")
     @patch("hardware_utils.platform.system", return_value="UnknownOS")
-    def test_get_cpu_info_rejects_processor_equal_to_machine(self, mock_system, mock_machine, mock_processor) -> None:
+    def test_get_cpu_info_rejects_processor_equal_to_machine(self, mock_system: MagicMock, mock_machine: MagicMock, mock_processor: MagicMock) -> None:
         """Architecture strings are not retained as concrete processor models."""
         cpu_model, cpu_cores, cpu_threads = HardwareInfo().get_cpu_info()
 
@@ -243,7 +248,7 @@ Thread(s) per core:  2"""
     @patch("hardware_utils.platform.processor", return_value="")
     @patch("hardware_utils.platform.system")
     @patch.object(HardwareInfo, "_run_command")
-    def test_get_cpu_info_command_failure(self, mock_run_command, mock_system, mock_processor) -> None:
+    def test_get_cpu_info_command_failure(self, mock_run_command: MagicMock, mock_system: MagicMock, mock_processor: MagicMock) -> None:
         """Test CPU info detection when commands fail."""
         mock_system.return_value = "Darwin"
         mock_run_command.side_effect = subprocess.CalledProcessError(1, "cmd")
@@ -259,7 +264,7 @@ Thread(s) per core:  2"""
     @patch("hardware_utils.platform.processor", return_value="Apple M4 Max")
     @patch("hardware_utils.platform.system", return_value="Darwin")
     @patch.object(HardwareInfo, "_run_command", side_effect=ExecutableNotFoundError("sysctl missing"))
-    def test_get_cpu_info_missing_command_uses_platform_fallback(self, mock_run_command, mock_system, mock_processor) -> None:
+    def test_get_cpu_info_missing_command_uses_platform_fallback(self, mock_run_command: MagicMock, mock_system: MagicMock, mock_processor: MagicMock) -> None:
         """A missing primary probe still reaches the concrete processor fallback."""
         cpu_model, cpu_cores, cpu_threads = HardwareInfo().get_cpu_info()
 
@@ -272,7 +277,7 @@ Thread(s) per core:  2"""
 
     @patch("hardware_utils.platform.system")
     @patch.object(HardwareInfo, "_run_command")
-    def test_get_memory_info_darwin(self, mock_run_command, mock_system) -> None:
+    def test_get_memory_info_darwin(self, mock_run_command: MagicMock, mock_system: MagicMock) -> None:
         """Test memory info detection on macOS."""
         mock_system.return_value = "Darwin"
         mock_run_command.return_value = "17179869184"  # 16 GB in bytes
@@ -284,7 +289,7 @@ Thread(s) per core:  2"""
 
     @patch("hardware_utils.platform.system")
     @patch("builtins.open", new_callable=mock_open, read_data="MemTotal:       16384000 kB\n")
-    def test_get_memory_info_linux(self, _mock_file, mock_system) -> None:  # noqa: PT019
+    def test_get_memory_info_linux(self, _mock_file: MagicMock, mock_system: MagicMock) -> None:  # noqa: PT019
         """Test memory info detection on Linux."""
         mock_system.return_value = "Linux"
 
@@ -296,7 +301,7 @@ Thread(s) per core:  2"""
     @patch("hardware_utils.platform.system")
     @patch("hardware_utils.shutil.which")
     @patch.object(HardwareInfo, "_run_command")
-    def test_get_memory_info_windows(self, mock_run_command, mock_which, mock_system) -> None:
+    def test_get_memory_info_windows(self, mock_run_command: MagicMock, mock_which: MagicMock, mock_system: MagicMock) -> None:
         """Test memory info detection on Windows."""
         mock_system.return_value = "Windows"
         mock_which.side_effect = lambda cmd: cmd == "powershell"
@@ -308,7 +313,7 @@ Thread(s) per core:  2"""
         assert memory == "32.0 GB"
 
     @patch("hardware_utils.platform.system")
-    def test_get_memory_info_unknown_os(self, mock_system) -> None:
+    def test_get_memory_info_unknown_os(self, mock_system: MagicMock) -> None:
         """Test memory info detection on unknown OS."""
         mock_system.return_value = "UnknownOS"
 
@@ -319,7 +324,7 @@ Thread(s) per core:  2"""
 
     @patch("hardware_utils.shutil.which")
     @patch.object(HardwareInfo, "_run_command")
-    def test_get_rust_info_success(self, mock_run_command, mock_which, hardware) -> None:
+    def test_get_rust_info_success(self, mock_run_command: MagicMock, mock_which: MagicMock, hardware: HardwareInfo) -> None:
         """Test Rust info detection when rustc is available."""
         mock_which.return_value = "/usr/bin/rustc"
         mock_run_command.side_effect = ["rustc 1.70.0 (90c541806 2023-05-31)", "rustc 1.70.0 (90c541806 2023-05-31)\nhost: x86_64-apple-darwin\n"]
@@ -330,7 +335,7 @@ Thread(s) per core:  2"""
         assert rust_target == "x86_64-apple-darwin"
 
     @patch("hardware_utils.shutil.which")
-    def test_get_rust_info_no_rustc(self, mock_which, hardware) -> None:
+    def test_get_rust_info_no_rustc(self, mock_which: MagicMock, hardware: HardwareInfo) -> None:
         """Test Rust info detection when rustc is not available."""
         mock_which.return_value = None
 
@@ -341,7 +346,7 @@ Thread(s) per core:  2"""
 
     @patch("hardware_utils.shutil.which")
     @patch.object(HardwareInfo, "_run_command")
-    def test_get_rust_info_command_failure(self, mock_run_command, mock_which, hardware) -> None:
+    def test_get_rust_info_command_failure(self, mock_run_command: MagicMock, mock_which: MagicMock, hardware: HardwareInfo) -> None:
         """Test Rust info detection when rustc commands fail."""
         mock_which.return_value = "/usr/bin/rustc"
         mock_run_command.side_effect = subprocess.CalledProcessError(1, "cmd")
@@ -351,7 +356,7 @@ Thread(s) per core:  2"""
         assert rust_version == "Unknown"
         assert rust_target == "Unknown"
 
-    def test_get_hardware_info(self, hardware) -> None:
+    def test_get_hardware_info(self, hardware: HardwareInfo) -> None:
         """Test comprehensive hardware info collection."""
         with (
             patch.object(hardware, "get_cpu_info") as mock_cpu,
@@ -377,7 +382,7 @@ Thread(s) per core:  2"""
         ("system_name", "expected_os"), [("Darwin", "macOS"), ("Linux", "Linux"), ("Windows", "Windows"), ("FreeBSD", "Unknown (FreeBSD)")]
     )
     @patch("hardware_utils.platform.system")
-    def test_get_hardware_info_os_mapping(self, mock_system, system_name, expected_os) -> None:
+    def test_get_hardware_info_os_mapping(self, mock_system: MagicMock, system_name: str, expected_os: str) -> None:
         """Test OS name mapping in hardware info."""
         mock_system.return_value = system_name
         hardware = HardwareInfo()
@@ -394,7 +399,7 @@ Thread(s) per core:  2"""
             info = hardware.get_hardware_info()
             assert info["OS"] == expected_os
 
-    def test_format_hardware_info(self, hardware) -> None:
+    def test_format_hardware_info(self, hardware: HardwareInfo) -> None:
         """Test hardware info formatting."""
         test_info = {
             "OS": "macOS",
@@ -417,7 +422,7 @@ Thread(s) per core:  2"""
         assert "Rust: rustc 1.70.0" in formatted
         assert "Target: x86_64-apple-darwin" in formatted
 
-    def test_format_hardware_info_none(self, hardware) -> None:
+    def test_format_hardware_info_none(self, hardware: HardwareInfo) -> None:
         """Test hardware info formatting with None input."""
         with patch.object(hardware, "get_hardware_info") as mock_get_info:
             mock_get_info.return_value = {
@@ -645,7 +650,7 @@ Other content here...
             ("", None),
         ],
     )
-    def test_extract_memory_value(self, memory_str, expected) -> None:
+    def test_extract_memory_value(self, memory_str: str, expected: float | None) -> None:
         """Test memory value extraction from strings."""
         result = HardwareComparator._extract_memory_value(memory_str)
         if expected is None:
@@ -657,7 +662,7 @@ Other content here...
 class TestHardwareUtilsIntegration:
     """Integration tests for hardware_utils functionality."""
 
-    def test_info_json_option_writes_only_json_to_stdout(self, capsys, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_info_json_option_writes_only_json_to_stdout(self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
         expected = {"OS": "TestOS", "CPU": "Test CPU"}
         monkeypatch.setattr(HardwareInfo, "get_hardware_info", lambda _self: expected)
 
@@ -676,7 +681,7 @@ class TestHardwareUtilsIntegration:
             ["compare", "--json", "--baseline-file", "baseline.txt"],
         ],
     )
-    def test_command_specific_options_are_rejected_for_other_commands(self, argv: list[str], capsys) -> None:
+    def test_command_specific_options_are_rejected_for_other_commands(self, argv: list[str], capsys: pytest.CaptureFixture[str]) -> None:
         with pytest.raises(SystemExit) as exc_info:
             main(argv)
 
@@ -685,7 +690,7 @@ class TestHardwareUtilsIntegration:
         assert captured.out == ""
         assert "unrecognized arguments:" in captured.err
 
-    def test_compare_requires_baseline_file(self, capsys) -> None:
+    def test_compare_requires_baseline_file(self, capsys: pytest.CaptureFixture[str]) -> None:
         with pytest.raises(SystemExit) as exc_info:
             main(["compare"])
 
@@ -694,7 +699,7 @@ class TestHardwareUtilsIntegration:
         assert captured.out == ""
         assert "the following arguments are required: --baseline-file" in captured.err
 
-    def test_compare_reports_result_on_stdout_only(self, tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_compare_reports_result_on_stdout_only(self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
         baseline = tmp_path / "baseline.txt"
         baseline.write_text("Hardware Information:\n  OS: TestOS\n", encoding="utf-8")
         monkeypatch.setattr(HardwareInfo, "get_hardware_info", lambda _self: {"OS": "TestOS"})
@@ -707,7 +712,7 @@ class TestHardwareUtilsIntegration:
         assert captured.out == "compatible\n"
         assert captured.err == ""
 
-    def test_main_suggests_close_command_name(self, capsys, monkeypatch) -> None:
+    def test_main_suggests_close_command_name(self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
         """Python 3.14 argparse suggestions should help recover from command typos."""
         monkeypatch.setattr(sys, "argv", ["hardware_utils.py", "inf"])
 

--- a/scripts/tests/test_justfile_discoverability.py
+++ b/scripts/tests/test_justfile_discoverability.py
@@ -5,13 +5,16 @@ import re
 import shlex
 import shutil
 import subprocess
+import sys
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
+import pytest
 import yaml
 
 import update_cargo_tool_pins
+from subprocess_utils import run_safe_command
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 JUSTFILE = REPO_ROOT / "justfile"
@@ -33,7 +36,37 @@ def run_just(*args: str) -> subprocess.CompletedProcess[str]:
         check=True,
         capture_output=True,
         encoding="utf-8",
+        timeout=30,
     )
+
+
+def run_python_source_probe(tmp_path: Path, paths: list[str], *, git_returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    """Exercise the rendered recipe with isolated Git output and a tool-argument recorder."""
+    git_output = tmp_path / "git-output.bin"
+    git_output.write_bytes(b"".join(path.encode("utf-8") + b"\0" for path in paths))
+    version = run_just("--evaluate", "uv_version").stdout.strip()
+    rendered = run_just("--dry-run", "_python-tool", "ruff check")
+    expected_git_args = "--no-pager ls-files --cached --others --exclude-standard --deduplicate -z -- *.py *.pyi"
+    script = f"""
+git() {{
+    if [[ "$*" != {shlex.quote(expected_git_args)} ]]; then
+        echo "Unexpected Git arguments: $*" >&2
+        return 2
+    fi
+    cat {shlex.quote(git_output.as_posix())}
+    return {git_returncode}
+}}
+uv() {{
+    if [[ "$*" == "--version" ]]; then
+        printf '%s\\n' {shlex.quote("uv " + version)}
+    else
+        printf '%s\\0' "$@"
+    fi
+}}
+TMPDIR="$PWD"
+{rendered.stdout}{rendered.stderr}
+"""
+    return run_safe_command("bash", ["-c", script], cwd=tmp_path, check=False, timeout=30)
 
 
 def just_recipes() -> dict[str, dict[str, Any]]:
@@ -126,6 +159,123 @@ def test_check_code_includes_dependency_hygiene() -> None:
     dependencies = {dependency["recipe"] for dependency in just_recipes()["check-code"]["dependencies"]}
 
     assert "unused-deps" in dependencies
+
+
+def test_ci_directly_lints_python_fixtures_with_full_ruff_policy() -> None:
+    """CI must not drop fixture lint or replace configured rules with a subset."""
+    recipes = just_recipes()
+    dependencies = {dependency["recipe"] for dependency in recipes["ci"]["dependencies"]}
+    result = run_just("--dry-run", "python-fixture-lint")
+    commands = [shlex.split(line) for line in (result.stdout + result.stderr).splitlines() if line.startswith("uv run ")]
+
+    assert "python-fixture-lint" in dependencies
+    assert commands == [["uv", "run", "--locked", "ruff", "check", "tests/semgrep/"]]
+
+
+def test_python_checks_and_fixer_share_source_discovery() -> None:
+    """Every Python tool should consume the same file inventory."""
+    recipes = just_recipes()
+    expected_commands = {
+        "python-format-check": ["ruff format --check"],
+        "python-lint": ["ruff check"],
+        "python-typecheck": ["--group notebooks ty check --error all"],
+        "python-fix": ["ruff check --fix", "ruff format"],
+    }
+    for name, commands in expected_commands.items():
+        result = run_just("--dry-run", name)
+        rendered = result.stdout + result.stderr
+        assert {dependency["recipe"] for dependency in recipes[name]["dependencies"]} == {"_python-tool"}
+        for command in commands:
+            assert f'uv run --locked {command} -- "${{python_files[@]}}"' in rendered
+
+
+def test_python_source_discovery_preserves_paths_and_skips_deleted_files(tmp_path: Path) -> None:
+    """Git-selected sources must reach the tool as paths, including leading dashes."""
+    paths = ["scripts/owned.py", "tests/semgrep/scripts/tests/python_style.py", "new module.py", "new module.pyi", "--new.py"]
+    for name in paths:
+        path = tmp_path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('"""Source discovery probe."""\n', encoding="utf-8")
+
+    result = run_python_source_probe(tmp_path, [*paths, "deleted.py"])
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.split("\0") == ["run", "--locked", "ruff", "check", "--", *paths, ""]
+    assert not list(tmp_path.glob("delaunay-python-sources.*"))
+
+
+def test_python_source_discovery_rejects_an_empty_file_set(tmp_path: Path) -> None:
+    """Empty discovery must not let the tool fall back to an implicit root scan."""
+    result = run_python_source_probe(tmp_path, [])
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "No Python source files found" in result.stderr
+    assert not list(tmp_path.glob("delaunay-python-sources.*"))
+
+
+def test_python_source_discovery_stops_after_partial_git_failure(tmp_path: Path) -> None:
+    """A failing Git listing must stop before a partial source set reaches the tool."""
+    (tmp_path / "partial.py").write_text('"""Partial listing probe."""\n', encoding="utf-8")
+    result = run_python_source_probe(tmp_path, ["partial.py"], git_returncode=128)
+
+    assert result.returncode == 128
+    assert result.stdout == ""
+    assert not list(tmp_path.glob("delaunay-python-sources.*"))
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "scripts/typing_probe.py",
+        "tests/semgrep/scripts/tests/python_exceptions.py",
+        "tests/semgrep/scripts/tests/python_parse_boundaries.py",
+        "tests/semgrep/scripts/tests/python_style.py",
+    ],
+)
+def test_full_ruff_typing_policy_reaches_scripts_and_fixtures(filename: str) -> None:
+    """Negative probes prove annotation and import guards remain blocking."""
+    # Keep deliberately untyped probe text distinct from actual definitions so
+    # Semgrep's source-level return-annotation regex does not mistake it for code.
+    source_lines = [
+        '"""Typing policy probe."""',
+        "from pathlib import Path",
+        "",
+        "def missing_arguments(value, *args, **kwargs):",
+        "    return value",
+        "",
+        "def _private():",
+        "    return None",
+        "",
+        'def quoted(value: "Path") -> None:',
+        "    pass",
+        "",
+        "class Example:",
+        "    def __init__(self):",
+        "        pass",
+        "",
+        "    @staticmethod",
+        "    def static():",
+        "        return None",
+        "",
+        "    @classmethod",
+        "    def class_method(cls):",
+        "        return None",
+        "",
+    ]
+    source = "\n".join(source_lines)
+    result = run_safe_command(
+        sys.executable,
+        ["-m", "ruff", "check", "--config", str(REPO_ROOT / "pyproject.toml"), "--output-format", "json", "--stdin-filename", filename, "-"],
+        cwd=REPO_ROOT,
+        input=source,
+        check=False,
+        timeout=30,
+    )
+    codes = {finding["code"] for finding in json.loads(result.stdout)}
+
+    assert result.returncode == 1
+    assert {"ANN001", "ANN002", "ANN003", "ANN201", "ANN202", "ANN204", "ANN205", "ANN206", "TC003", "UP037"} <= codes
 
 
 def test_release_signal_benchmark_recipes_match_python_runner() -> None:

--- a/scripts/tests/test_performance_artifacts.py
+++ b/scripts/tests/test_performance_artifacts.py
@@ -29,6 +29,7 @@ from performance_artifacts import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 SHA_A = "a" * 64
@@ -126,7 +127,7 @@ def bundle(*, current: str = "v0.8.0", baseline: str = "v0.7.8") -> PerformanceB
     )
 
 
-def replace_csv_rows(csv_payload: bytes, transform) -> bytes:
+def replace_csv_rows(csv_payload: bytes, transform: Callable[[list[dict[str, str]]], None]) -> bytes:
     reader = csv.DictReader(io.StringIO(csv_payload.decode("utf-8"), newline=""))
     rows = [dict(row) for row in reader]
     transform(rows)

--- a/scripts/tests/test_postprocess_changelog.py
+++ b/scripts/tests/test_postprocess_changelog.py
@@ -1168,7 +1168,7 @@ class TestIntegration:
         assert changelog.read_bytes().decode("utf-8") == original
         assert list(tmp_path.glob(".CHANGELOG.md.*.tmp")) == []
 
-    def test_cli_reports_malformed_utf8_without_traceback(self, tmp_path: Path, capsys) -> None:
+    def test_cli_reports_malformed_utf8_without_traceback(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         changelog = tmp_path / "CHANGELOG.md"
         changelog.write_bytes(b"# Changelog\n\xff\n")
 
@@ -1186,7 +1186,7 @@ class TestIntegration:
         self,
         operation: str,
         tmp_path: Path,
-        capsys,
+        capsys: pytest.CaptureFixture[str],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         changelog = tmp_path / "CHANGELOG.md"

--- a/scripts/tests/test_subprocess_utils.py
+++ b/scripts/tests/test_subprocess_utils.py
@@ -16,7 +16,10 @@ import pytest
 # Add scripts directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from typing import IO, Any, Never, cast
+from typing import IO, TYPE_CHECKING, Any, Never, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 from subprocess_utils import (
     ExecutableNotFoundError,
@@ -36,7 +39,7 @@ class TestGetSafeExecutable:
     """Test get_safe_executable function."""
 
     @pytest.mark.parametrize("command", ["echo", "git", "ls"])
-    def test_finds_existing_executables(self, command) -> None:
+    def test_finds_existing_executables(self, command: str) -> None:
         """Test that it finds common executables."""
         result = get_safe_executable(command)
         assert isinstance(result, str)
@@ -49,7 +52,7 @@ class TestGetSafeExecutable:
             pytest.skip(f"{command} may not be an external executable on Windows")
 
     @pytest.mark.parametrize("fake_command", ["definitely-nonexistent-command-xyz", "fake-command-for-testing", "nonexistent123"])
-    def test_raises_on_nonexistent_executables(self, fake_command) -> None:
+    def test_raises_on_nonexistent_executables(self, fake_command: str) -> None:
         """Test that it raises ExecutableNotFoundError for nonexistent commands."""
         with pytest.raises(ExecutableNotFoundError, match="not found in PATH") as exc_info:
             get_safe_executable(fake_command)
@@ -211,11 +214,11 @@ class TestErrorHandling:
         assert str(error) == "test message"
         assert isinstance(error, Exception)
 
-    def test_git_functions_handle_missing_git(self, monkeypatch) -> None:
+    def test_git_functions_handle_missing_git(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test git functions handle missing git executable gracefully."""
 
         # Mock get_safe_executable to raise ExecutableNotFoundError for git
-        def mock_get_safe_executable(command) -> str:
+        def mock_get_safe_executable(command: str) -> str:
             if command == "git":
                 raise ExecutableNotFoundError(f"Required executable '{command}' not found in PATH")
             return "/bin/echo"  # Return echo for other commands
@@ -233,10 +236,10 @@ class TestErrorHandling:
         with pytest.raises(ExecutableNotFoundError):
             get_git_remote_url()
 
-    def test_git_discovery_checks_handle_failed_git_commands(self, monkeypatch) -> None:
+    def test_git_discovery_checks_handle_failed_git_commands(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Git discovery helpers return False for nonzero git probes."""
 
-        def mock_run_git_command(_args) -> None:
+        def mock_run_git_command(_args: list[str]) -> None:
             raise subprocess.CalledProcessError(128, "git")
 
         monkeypatch.setattr("subprocess_utils.run_git_command", mock_run_git_command)
@@ -279,11 +282,17 @@ class TestSecurityFeatures:
             (run_safe_command, ("echo", ["test"]), {"executable": "/malicious/fake/command"}),
         ],
     )
-    def test_rejects_executable_override(self, function, args, kwargs, monkeypatch) -> None:
+    def test_rejects_executable_override(
+        self,
+        function: Callable[..., subprocess.CompletedProcess[str]],
+        args: tuple[list[str]] | tuple[str, list[str]],
+        kwargs: dict[str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Test that functions reject executable override for security."""
         called = {"run": False}
 
-        def fake_run(*_a, **_k) -> Never:
+        def fake_run(*_a: object, **_k: object) -> Never:
             called["run"] = True  # should never be set
             msg = "subprocess.run should not be called on override"
             raise AssertionError(msg)

--- a/scripts/tests/test_tag_release.py
+++ b/scripts/tests/test_tag_release.py
@@ -3,11 +3,15 @@
 import subprocess
 from datetime import date
 from pathlib import PureWindowsPath
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from tag_release import _citation_release_date, _get_repo_url, _package_version, create_tag, main, validate_semver
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # ---------------------------------------------------------------------------
 # _get_repo_url
@@ -23,40 +27,40 @@ class TestGetRepoUrl:
     """Tests for _get_repo_url normalization and credential refusal."""
 
     @patch("tag_release.run_git_command")
-    def test_github_ssh(self, mock_git) -> None:
+    def test_github_ssh(self, mock_git: MagicMock) -> None:
         mock_git.return_value = _fake_remote("git@github.com:owner/repo.git")
         assert _get_repo_url() == "https://github.com/owner/repo"
 
     @patch("tag_release.run_git_command")
-    def test_github_https(self, mock_git) -> None:
+    def test_github_https(self, mock_git: MagicMock) -> None:
         mock_git.return_value = _fake_remote("https://github.com/owner/repo.git")
         assert _get_repo_url() == "https://github.com/owner/repo"
 
     @patch("tag_release.run_git_command")
-    def test_github_ssh_protocol(self, mock_git) -> None:
+    def test_github_ssh_protocol(self, mock_git: MagicMock) -> None:
         mock_git.return_value = _fake_remote("ssh://git@github.com/owner/repo.git")
         assert _get_repo_url() == "https://github.com/owner/repo"
 
     @patch("tag_release.run_git_command")
-    def test_plain_non_github_url_rejected(self, mock_git) -> None:
+    def test_plain_non_github_url_rejected(self, mock_git: MagicMock) -> None:
         mock_git.return_value = _fake_remote("https://gitlab.com/owner/repo.git")
         with pytest.raises(ValueError, match="Origin remote"):
             _get_repo_url()
 
     @patch("tag_release.run_git_command")
-    def test_rejects_https_user_pass(self, mock_git) -> None:
+    def test_rejects_https_user_pass(self, mock_git: MagicMock) -> None:
         mock_git.return_value = _fake_remote("https://user:token@github.com/owner/repo.git")
         with pytest.raises(ValueError, match="credentials"):
             _get_repo_url()
 
     @patch("tag_release.run_git_command")
-    def test_rejects_https_user_only(self, mock_git) -> None:
+    def test_rejects_https_user_only(self, mock_git: MagicMock) -> None:
         mock_git.return_value = _fake_remote("https://user@github.com/owner/repo.git")
         with pytest.raises(ValueError, match="credentials"):
             _get_repo_url()
 
     @patch("tag_release.run_git_command")
-    def test_rejects_ssh_style_non_github(self, mock_git) -> None:
+    def test_rejects_ssh_style_non_github(self, mock_git: MagicMock) -> None:
         mock_git.return_value = _fake_remote("deploy@gitlab.com:owner/repo.git")
         with pytest.raises(ValueError, match="Origin remote"):
             _get_repo_url()
@@ -69,7 +73,7 @@ class TestGetRepoUrl:
         ],
     )
     @patch("tag_release.run_git_command")
-    def test_rejects_query_and_fragment_without_echoing_them(self, mock_git, raw: str) -> None:
+    def test_rejects_query_and_fragment_without_echoing_them(self, mock_git: MagicMock, raw: str) -> None:
         mock_git.return_value = _fake_remote(raw)
 
         with pytest.raises(ValueError, match="query parameters or fragments") as exc_info:
@@ -93,7 +97,7 @@ class TestGetRepoUrl:
         ],
     )
     @patch("tag_release.run_git_command")
-    def test_rejects_unsupported_remotes_without_echoing_them(self, mock_git, raw: str) -> None:
+    def test_rejects_unsupported_remotes_without_echoing_them(self, mock_git: MagicMock, raw: str) -> None:
         mock_git.return_value = _fake_remote(raw)
 
         with pytest.raises(ValueError, match="Origin remote") as exc_info:
@@ -137,7 +141,7 @@ class TestCreateTag:
         monkeypatch.setattr("tag_release._citation_release_date", lambda _changelog: date(2026, 8, 24))
         monkeypatch.setattr("tag_release._current_utc_date", lambda: date(2026, 8, 24))
 
-    def test_package_version_reads_adjacent_cargo_manifest(self, tmp_path) -> None:
+    def test_package_version_reads_adjacent_cargo_manifest(self, tmp_path: Path) -> None:
         """The preflight source of truth is the package table beside the changelog."""
         changelog = tmp_path / "CHANGELOG.md"
         changelog.write_text("# Changelog\n", encoding="utf-8")
@@ -157,7 +161,7 @@ class TestCreateTag:
     )
     def test_package_version_rejects_invalid_manifests(
         self,
-        tmp_path,
+        tmp_path: Path,
         manifest: str,
         error_type: type[Exception],
         message: str,
@@ -172,7 +176,7 @@ class TestCreateTag:
 
         assert "Cargo.toml" in str(exc_info.value)
 
-    def test_package_version_reports_manifest_read_failure(self, tmp_path) -> None:
+    def test_package_version_reports_manifest_read_failure(self, tmp_path: Path) -> None:
         """Filesystem failures become controlled release-preflight errors."""
         changelog = tmp_path / "CHANGELOG.md"
         cargo_toml = tmp_path / "Cargo.toml"
@@ -185,7 +189,7 @@ class TestCreateTag:
 
         assert str(cargo_toml) in str(exc_info.value)
 
-    def test_citation_release_date_reads_one_valid_top_level_date(self, tmp_path) -> None:
+    def test_citation_release_date_reads_one_valid_top_level_date(self, tmp_path: Path) -> None:
         """The tag preflight reads the intended publication day from citation metadata."""
         changelog = tmp_path / "CHANGELOG.md"
         (tmp_path / "CITATION.cff").write_text("date-released: '2026-08-24'\n", encoding="utf-8")
@@ -200,7 +204,7 @@ class TestCreateTag:
             ("date-released: 2026-08-24\ndate-released: 2026-08-25\n", "duplicate top-level date-released"),
         ],
     )
-    def test_citation_release_date_rejects_invalid_contracts(self, tmp_path, citation: str, message: str) -> None:
+    def test_citation_release_date_rejects_invalid_contracts(self, tmp_path: Path, citation: str, message: str) -> None:
         """Missing, impossible, or ambiguous publication dates fail closed."""
         changelog = tmp_path / "CHANGELOG.md"
         (tmp_path / "CITATION.cff").write_text(citation, encoding="utf-8")
@@ -210,7 +214,7 @@ class TestCreateTag:
 
     def test_next_step_sets_release_title(
         self,
-        tmp_path,
+        tmp_path: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         changelog = tmp_path / "CHANGELOG.md"
@@ -229,7 +233,7 @@ class TestCreateTag:
 
     def test_truncated_message_uses_posix_source_url(
         self,
-        tmp_path,
+        tmp_path: Path,
     ) -> None:
         changelog = tmp_path / "CHANGELOG.md"
         with (
@@ -251,7 +255,7 @@ class TestCreateTag:
         assert "<https://github.com/owner/repo/blob/v1.2.3/docs/archive/changelog/1.2.md#v123>" in tag_message
         assert "docs\\archive\\changelog\\1.2.md" not in tag_message
 
-    def test_force_replaces_existing_tag_without_delete(self, tmp_path) -> None:
+    def test_force_replaces_existing_tag_without_delete(self, tmp_path: Path) -> None:
         changelog = tmp_path / "CHANGELOG.md"
         with (
             patch("tag_release._tag_exists", return_value=True),
@@ -266,7 +270,7 @@ class TestCreateTag:
 
     def test_invalid_remote_does_not_replace_existing_tag(
         self,
-        tmp_path,
+        tmp_path: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         changelog = tmp_path / "CHANGELOG.md"
@@ -289,7 +293,7 @@ class TestCreateTag:
         assert marker not in output.out
         assert marker not in output.err
 
-    def test_rejects_tag_that_differs_from_cargo_before_git(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_rejects_tag_that_differs_from_cargo_before_git(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """A mismatched requested tag fails before querying or mutating tags."""
         changelog = tmp_path / "CHANGELOG.md"
         changelog.write_text("# Changelog\n", encoding="utf-8")
@@ -303,7 +307,7 @@ class TestCreateTag:
 
         mock_tag_exists.assert_not_called()
 
-    def test_rejects_stale_publication_date_before_git(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_rejects_stale_publication_date_before_git(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """A release delayed across UTC midnight cannot create or replace a tag."""
         changelog = tmp_path / "CHANGELOG.md"
         changelog.write_text("# Changelog\n", encoding="utf-8")
@@ -327,7 +331,7 @@ class TestCreateTag:
 # ---------------------------------------------------------------------------
 
 
-def test_main_handles_git_timeout(capsys) -> None:
+def test_main_handles_git_timeout(capsys: pytest.CaptureFixture[str]) -> None:
     with (
         patch("sys.argv", ["tag-release", "v1.2.3"]),
         patch(
@@ -342,7 +346,7 @@ def test_main_handles_git_timeout(capsys) -> None:
     assert "Error: Command '['git', 'tag']' timed out after 30 seconds" in capsys.readouterr().err
 
 
-def test_main_handles_package_metadata_error_before_git(tmp_path, capsys) -> None:
+def test_main_handles_package_metadata_error_before_git(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """Manifest contract failures use the normal CLI diagnostic and avoid Git."""
     changelog = tmp_path / "CHANGELOG.md"
     mock_tag_exists = MagicMock()

--- a/src/triangulation/editing.rs
+++ b/src/triangulation/editing.rs
@@ -156,7 +156,7 @@ where
 mod tests {
     use super::*;
     use crate::DelaunayRefinementBuilder;
-    use crate::core::tds::{Tds, TdsBuilder, TopologyOwner};
+    use crate::core::tds::{EntityKind, Tds, TdsBuilder, TopologyOwner};
     use crate::geometry::kernel::RobustKernel;
     use crate::triangulation::builder::TriangulationBuilder;
     use crate::triangulation::validation::ValidationPolicy;
@@ -326,5 +326,46 @@ mod tests {
                 if matches!(*source, InsertionError::DuplicateCoordinates { .. }))
         );
         assert_eq!(serde_json::to_value(&tri.tds).unwrap(), before);
+    }
+
+    #[test]
+    fn duplicate_uuid_at_distinct_coordinates_preserves_the_owner() {
+        let mut tri = non_delaunay_quad();
+        tri.validate_realization().unwrap();
+        let uuid = tri.vertices().next().unwrap().1.uuid();
+        let candidate = vertex!([0.2, 0.3]; data = 99).unwrap();
+        let duplicate = Vertex::try_new_with_uuid(*candidate.point(), uuid, Some(99)).unwrap();
+        let storage = tri.tds.clone_for_rollback();
+        let serialized = serde_json::to_value(&tri.tds).unwrap();
+        let hints = tri
+            .vertices()
+            .map(|(key, vertex)| (key, vertex.incident_simplex()))
+            .collect::<Vec<_>>();
+        let identity = tri.topology_owner_id();
+        let generation = tri.topology_generation();
+        let evidence = tri.topology_construction_provenance;
+        let policy = tri.validation_policy();
+        assert_eq!(
+            tri.insert_vertex(duplicate),
+            Err(TriangulationEditError::Insertion {
+                source: Box::new(InsertionError::DuplicateUuid {
+                    entity: EntityKind::Vertex,
+                    uuid
+                }),
+            })
+        );
+        assert_eq!(tri.tds, storage);
+        assert_eq!(serde_json::to_value(&tri.tds).unwrap(), serialized);
+        assert_eq!(
+            tri.vertices()
+                .map(|(key, vertex)| (key, vertex.incident_simplex()))
+                .collect::<Vec<_>>(),
+            hints
+        );
+        assert_eq!(tri.topology_owner_id(), identity);
+        assert_eq!(tri.topology_generation(), generation);
+        assert_eq!(tri.topology_construction_provenance, evidence);
+        assert_eq!(tri.validation_policy(), policy);
+        tri.validate_realization().unwrap();
     }
 }

--- a/src/triangulation/repair.rs
+++ b/src/triangulation/repair.rs
@@ -919,6 +919,9 @@ where
     /// This handles fallback paths that do not retriangulate a cavity, such as isolated vertices
     /// or empty-boundary removals. Those paths can otherwise leave lower-dimensional remnants that
     /// are structurally valid at the TDS layer but invalid as a triangulation.
+    /// Every fallback candidate must pass the complete Level 4 `tri.is_valid_realization()` check
+    /// before publication. `full_realization_validation` controls only non-empty fan-retriangulation
+    /// paths and must not gate this fallback validation.
     fn remove_vertex_with_invariant_checks(
         &mut self,
         vertex_key: VertexKey,

--- a/src/triangulation/serialization.rs
+++ b/src/triangulation/serialization.rs
@@ -329,8 +329,11 @@ mod tests {
     use crate::core::tds::TdsBuilder;
     use crate::geometry::kernel::RobustKernel;
     use crate::triangulation::builder::TriangulationBuilderError;
-    use crate::triangulation::validation::TopologyConstructionProvenance;
-    use crate::vertex;
+    use crate::triangulation::realization::TriangulationRealizationValidationError;
+    use crate::triangulation::validation::{
+        TopologyConstructionProvenance, ValidationConfigurationError,
+    };
+    use crate::{DelaunayTriangulationBuilder, vertex};
     use serde_json::Value;
 
     #[derive(Debug, Serialize, Deserialize)]
@@ -396,6 +399,25 @@ mod tests {
         );
     }
 
+    /// Builds a realized quotient for detecting an incompatible stored chart mode.
+    fn periodic_torus() -> Triangulation<RobustKernel<f64>, u32, (), 2> {
+        let vertices = (0_u32..7)
+            .map(|index| {
+                let index_f64 = f64::from(index);
+                vertex!([
+                    0.9_f64.mul_add(((index_f64 + 1.0) * 0.618_033_988_749_894_8).fract(), 0.05),
+                    0.9_f64.mul_add(((index_f64 + 1.0) * 0.414_213_562_373_095_03).fract(), 0.05),
+                ]; data = index)
+                .unwrap()
+            })
+            .collect::<Vec<_>>();
+        DelaunayTriangulationBuilder::new(&vertices)
+            .try_toroidal([1.0; 2])
+            .unwrap()
+            .build_triangulation_with_kernel(&RobustKernel::new())
+            .unwrap()
+    }
+
     macro_rules! dimension_tests {
         ($($dimension:literal),+) => { $(pastey::paste! {
             #[test]
@@ -403,6 +425,179 @@ mod tests {
         })+ };
     }
     dimension_tests!(2, 3, 4, 5);
+
+    #[test]
+    fn nested_null_payloads_are_rejected_before_encoding() {
+        let payloads = [
+            CborValue::Array(vec![CborValue::from(7), CborValue::Null]),
+            CborValue::Map(vec![(CborValue::from("value"), CborValue::Null)]),
+            CborValue::Map(vec![(CborValue::Null, CborValue::from(7))]),
+            CborValue::Tag(42, Box::new(CborValue::Null)),
+        ];
+        for payload in payloads {
+            let result = capture_payload::<_, serde_json::Error>(&payload);
+            let error = result
+                .err()
+                .expect("nested null must not be silently collapsed");
+            assert!(error.to_string().contains("ambiguous CBOR null/unit data"));
+        }
+    }
+
+    #[test]
+    fn structured_payload_capture_retains_arrays_maps_and_tags() {
+        let payload = CborValue::Map(vec![(
+            CborValue::from("samples"),
+            CborValue::Array(vec![
+                CborValue::from(7),
+                CborValue::Tag(42, Box::new(CborValue::from(9))),
+            ]),
+        )]);
+        let captured = capture_payload::<_, serde_json::Error>(&payload).unwrap();
+        let mut bytes = Vec::new();
+        ciborium::ser::into_writer(&captured, &mut bytes).unwrap();
+        let restored: StoredPayload<CborValue> =
+            ciborium::de::from_reader(bytes.as_slice()).unwrap();
+        assert_eq!(restored.value, payload);
+    }
+
+    #[test]
+    fn snapshots_preserve_each_compatible_guarantee_and_validation_policy() {
+        let storage = sample::<2>().into_tds();
+        let expected = serde_json::to_value(&storage).unwrap();
+        for guarantee in [
+            TopologyGuarantee::PLManifold,
+            TopologyGuarantee::Pseudomanifold,
+        ] {
+            for policy in [
+                ValidationPolicy::Never,
+                ValidationPolicy::ExplicitOnly,
+                ValidationPolicy::OnSuspicion,
+                ValidationPolicy::Always,
+                ValidationPolicy::DebugOnly,
+            ] {
+                // Never is the one policy explicitly forbidden for PL manifolds.
+                if guarantee == TopologyGuarantee::PLManifold && policy == ValidationPolicy::Never {
+                    continue;
+                }
+                let tri = TriangulationBuilder::new(storage.clone(), RobustKernel::new())
+                    .topology_guarantee(guarantee)
+                    .validation_policy(policy)
+                    .build()
+                    .unwrap();
+                let restored: Triangulation<RobustKernel<f64>, u32, u32, 2> =
+                    serde_json::from_str(&serde_json::to_string(&tri).unwrap()).unwrap();
+                assert_eq!(restored.topology_guarantee(), guarantee);
+                assert_eq!(restored.validation_policy(), policy);
+                assert_eq!(serde_json::to_value(&restored.tds).unwrap(), expected);
+                restored.validate_realization().unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn explicit_mode_cannot_be_reinterpreted_as_periodic_image_geometry() {
+        let tri = periodic_torus();
+        tri.validate_realization().unwrap();
+        let expected = serde_json::to_value(&tri.tds).unwrap();
+        assert!(tri.simplices().any(|(_, simplex)| {
+            simplex
+                .periodic_vertex_offsets()
+                .is_some_and(|offsets| offsets.iter().flatten().any(|&offset| offset != 0))
+        }));
+        let mut encoded = serde_json::to_value(&tri).unwrap();
+        encoded["global_topology"]["mode"] = Value::from("explicit");
+        assert_eq!(
+            encoded["global_topology"]["period_bits"],
+            serde_json::to_value([1.0_f64.to_bits(); 2]).unwrap()
+        );
+        let decoded: TriangulationSnapshot<u32, (), 2> = serde_json::from_value(encoded).unwrap();
+        assert_eq!(
+            decoded.global_topology,
+            GlobalTopology::try_toroidal([1.0; 2], ToroidalConstructionMode::Explicit).unwrap()
+        );
+        assert_eq!(serde_json::to_value(&decoded.tds).unwrap(), expected);
+        let failure = decoded
+            .try_into_triangulation(RobustKernel::new())
+            .unwrap_err();
+        assert!(
+            matches!(failure.reason(), TriangulationBuilderError::RealizationValidation { source }
+            if matches!(source.as_ref(), TriangulationRealizationValidationError::NegativeSimplexOrientation { .. }))
+        );
+        assert_eq!(serde_json::to_value(failure.owner()).unwrap(), expected);
+    }
+
+    #[test]
+    fn malformed_toroidal_domains_fail_during_snapshot_decoding() {
+        let original = serde_json::to_value(sample::<2>()).unwrap();
+        let unit = 1.0_f64.to_bits();
+        for (periods, diagnostic) in [
+            (vec![unit], "expected 2 periods, got 1"),
+            (vec![unit; 3], "expected 2 periods, got 3"),
+            (vec![unit, 0.0_f64.to_bits()], "axis 1"),
+            (vec![unit, (-1.0_f64).to_bits()], "axis 1"),
+            (vec![unit, f64::INFINITY.to_bits()], "axis 1"),
+            (vec![unit, f64::NAN.to_bits()], "axis 1"),
+        ] {
+            let mut invalid = original.clone();
+            invalid["global_topology"] = serde_json::json!({
+                "kind": "toroidal", "mode": "explicit", "period_bits": periods,
+            });
+            let error =
+                serde_json::from_value::<TriangulationSnapshot<u32, u32, 2>>(invalid).unwrap_err();
+            assert!(error.to_string().contains(diagnostic), "{error}");
+        }
+    }
+
+    #[test]
+    fn restored_policy_cannot_bypass_pl_manifold_requirements() {
+        let mut invalid = serde_json::to_value(sample::<2>()).unwrap();
+        invalid["validation_policy"] = Value::from("never");
+        let decoded: TriangulationSnapshot<u32, u32, 2> = serde_json::from_value(invalid).unwrap();
+        let expected = serde_json::to_value(&decoded.tds).unwrap();
+        let failure = decoded
+            .try_into_triangulation(RobustKernel::new())
+            .unwrap_err();
+        assert_eq!(
+            failure.reason(),
+            &TriangulationBuilderError::ValidationConfiguration {
+                source: ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
+                    topology_guarantee: TopologyGuarantee::PLManifold,
+                    validation_policy: ValidationPolicy::Never,
+                },
+            }
+        );
+        assert_eq!(serde_json::to_value(failure.owner()).unwrap(), expected);
+    }
+
+    #[test]
+    fn decoded_curved_metadata_cannot_publish_an_unsupported_owner() {
+        let empty = TriangulationBuilder::new(Tds::<(), (), 2>::empty(), RobustKernel::new())
+            .build()
+            .unwrap();
+        let original = serde_json::to_value(empty).unwrap();
+        for (topology, selected) in [
+            ("spherical", GlobalTopology::Spherical),
+            ("hyperbolic", GlobalTopology::Hyperbolic),
+        ] {
+            let mut invalid = original.clone();
+            invalid["global_topology"] = serde_json::json!({"kind": topology});
+            let decoded: TriangulationSnapshot<(), (), 2> =
+                serde_json::from_value(invalid).unwrap();
+            let expected = serde_json::to_value(&decoded.tds).unwrap();
+            assert_eq!(decoded.global_topology, selected);
+            let failure = decoded
+                .try_into_triangulation(RobustKernel::new())
+                .unwrap_err();
+            assert!(
+                matches!(failure.reason(), TriangulationBuilderError::RealizationValidation { source }
+                if matches!(source.as_ref(), TriangulationRealizationValidationError::UnsupportedTopology {
+                    topology, dimension: 2,
+                } if *topology == selected.kind()))
+            );
+            assert_eq!(serde_json::to_value(failure.owner()).unwrap(), expected);
+            failure.owner().validate().unwrap();
+        }
+    }
 
     #[test]
     fn serialization_and_transport_decoding_do_not_require_clone() {

--- a/tests/semgrep/scripts/tests/python_exceptions.py
+++ b/tests/semgrep/scripts/tests/python_exceptions.py
@@ -1,6 +1,11 @@
+"""Positive and negative fixtures for Python exception and test policies."""
+
 import subprocess
-from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, Mock
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 UTF8 = "utf-8"
 
@@ -33,7 +38,7 @@ def catches_broad_exception_in_tuple() -> None:
     try:
         pass
     # ruleid: delaunay.python.no-broad-exception
-    except (OSError, Exception):
+    except (OSError, Exception):  # fmt: skip
         pass
 
 
@@ -49,7 +54,7 @@ def catches_specific_exception_tuple() -> None:
     try:
         pass
     # ok: delaunay.python.no-broad-exception
-    except (OSError, RuntimeError):
+    except (OSError, RuntimeError):  # fmt: skip
         pass
 
 
@@ -78,10 +83,12 @@ def explicit_path_text_encoding(path: Path) -> None:
     path.read_text(encoding="utf-8")
     # ok: delaunay.python.explicit-path-text-encoding-in-tests
     path.write_text("Time: [1.0, 1.0, 1.0] µs\n", encoding="utf-8")
+    # fmt: off
     # ok: delaunay.python.explicit-path-text-encoding-in-tests
-    path.read_text(encoding='utf-8')
+    path.read_text(encoding='utf-8')  # noqa: Q000 - exercise both literal quote styles.
     # ok: delaunay.python.explicit-path-text-encoding-in-tests
-    path.write_text("Time: [1.0, 1.0, 1.0] µs\n", encoding='utf-8')
+    path.write_text("Time: [1.0, 1.0, 1.0] µs\n", encoding='utf-8')  # noqa: Q000 - exercise both literal quote styles.
+    # fmt: on
     # ok: delaunay.python.explicit-path-text-encoding-in-tests
     path.read_text(encoding=UTF8)
     # ok: delaunay.python.explicit-path-text-encoding-in-tests
@@ -121,7 +128,7 @@ def direct_subprocess_run() -> None:
 
 
 # ruleid: delaunay.python.no-untyped-defs-in-scripts
-def missing_return_annotation():
+def missing_return_annotation():  # noqa: ANN201 - deliberate missing-return fixture.
     return None
 
 

--- a/tests/semgrep/scripts/tests/python_parse_boundaries.py
+++ b/tests/semgrep/scripts/tests/python_parse_boundaries.py
@@ -1,6 +1,10 @@
+"""Positive and negative fixtures for Python data boundary policies."""
+
 import json
-from io import StringIO
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from io import StringIO
 
 
 def reject_json_constant(value: str) -> object:

--- a/tests/semgrep/scripts/tests/python_style.py
+++ b/tests/semgrep/scripts/tests/python_style.py
@@ -4,13 +4,52 @@
 from __future__ import annotations
 
 import asyncio
+import csv
 import os
 import subprocess
 import tempfile
-from pathlib import Path
 
 # ok: delaunay.python.no-future-annotations-on-python314
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
+
+from subprocess_utils import run_safe_command
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+    from tarfile import TarFile
+
+
+class DataFrameReader(Protocol):
+    """Minimal eager Parquet reader, without requiring optional packages."""
+
+    def read_parquet(self, path: Path) -> object:
+        """Read the supplied Parquet file."""
+        ...
+
+
+class PolarsReader(DataFrameReader, Protocol):
+    """The additional lazy reader used by the Polars fixture."""
+
+    def scan_parquet(self, path: Path) -> object:
+        """Scan the supplied Parquet file."""
+        ...
+
+
+class ArrowParquet(Protocol):
+    """The PyArrow Parquet API shapes exercised by the fixture."""
+
+    ParquetFile: Callable[[Path], object]
+
+    def read_table(self, path: Path) -> object:
+        """Read the supplied Parquet table."""
+        ...
+
+
+class ArrowModule(Protocol):
+    """Expose PyArrow's Parquet namespace for static analysis."""
+
+    parquet: ArrowParquet
 
 
 def direct_process_spawning() -> None:
@@ -30,7 +69,7 @@ def direct_process_spawning() -> None:
     # ruleid: delaunay.python.no-direct-subprocess-run-outside-wrapper
     subprocess.getstatusoutput("true")
     # ruleid: delaunay.python.no-direct-subprocess-run-outside-wrapper
-    os.system("true")
+    os.system("true")  # ty: ignore[deprecated] - deliberate direct-spawn fixture.
 
 
 async def direct_async_process_spawning() -> None:
@@ -47,7 +86,7 @@ def wrapped_process_spawning() -> None:
     run_safe_command("true", [])
 
 
-def tar_extraction(archive: object, target: Path) -> None:
+def tar_extraction(archive: TarFile, target: Path) -> None:
     """Exercise unsafe and filtered tar extraction calls."""
     # ruleid: delaunay.python.safe-tar-extraction
     archive.extractall(target)
@@ -97,7 +136,7 @@ def performance_artifact_writes(path: Path) -> None:
     tempfile.NamedTemporaryFile("wb", dir=path.parent)
 
 
-def parquet_promotion_inputs(path: Path) -> None:
+def parquet_promotion_inputs(path: Path, pl: PolarsReader, pandas: DataFrameReader, pq: ArrowParquet, pyarrow: ArrowModule) -> None:
     """Exercise Parquet readers that would add a second promotion contract."""
     # ruleid: delaunay.python.performance-promotion-is-csv-only
     pl.read_parquet(path)

--- a/ty.toml
+++ b/ty.toml
@@ -1,10 +1,7 @@
 # ty.toml
 # Astral ty configuration for delaunay
-# Python is auxiliary tooling only (scripts/), Rust is primary
-
-[src]
-# Restrict analysis strictly to Python tooling.
-include = [ "scripts" ]
+# Python is auxiliary tooling and static-analysis fixtures; Rust is primary.
+# The Just recipes pass every tracked and new, unignored Python source file.
 
 [terminal]
 # Keep output concise by default.


### PR DESCRIPTION
- Apply complete annotation requirements and shared, filename-safe formatting, linting, and type checks across Python sources.
- Add full-policy Semgrep fixture linting to CI while preserving deliberate violations through narrow exceptions.
- Exclude Semgrep fixtures from general CodeRabbit review and delegate Python docstring policy to Ruff.
- Expand triangulation rollback and snapshot coverage for payload, topology, and validation-policy contracts.
- Document mandatory Level 4 validation for fallback vertex removal and include src/lib.rs in coverage reporting.

Closes #595