### PR TITLE
fix(tooling): preflight uv updates and align zizmor audits

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -32,7 +32,25 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up just
+        uses: $/.github/actions/setup-just
+
+      - name: Resolve zizmor version
+        id: zizmor_version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(just --evaluate zizmor_version)"
+          if [[ -z "$version" ]]; then
+            echo "::error::Could not resolve zizmor_version from justfile"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3
+        uses: zizmorcore/zizmor-action@cc914d7f3750a2d13d75c7f184a1060aa0e9d482 # v0.6.4
         with:
           inputs: .github
+          version: ${{ steps.zizmor_version.outputs.version }}
+          online-audits: true
+          persona: regular

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -79,7 +79,7 @@ changed surface.
 | Touched surface | Iteration validation | Final validation / PR readiness |
 |-----|-----|-----|
 | Markdown documentation (`*.md`) | `just markdown-check` | `just check-docs` |
-| Python sources and fixtures | Targeted pytest and `just python-check` | `just python-check` and `just test-python` |
+| Python sources and fixtures | Targeted pytest and `just python-check` | `just python-check`, `just python-fixture-lint`, and `just test-python` |
 | Jupyter notebooks (`notebooks/**/*.ipynb`) | `just notebook-check` | `just notebook-check` |
 | Paper sources and figures (`papers/**/*`, paper notebooks) | `just paper-check` | `just papers` |
 | Configuration only (JSON, TOML, YAML, CFF, workflows) | Matching config validator | `just check-config` |
@@ -198,7 +198,7 @@ version, then upgrades `uv.lock`, with
 packages owned by `setup-tools` and atomically reconciles their root `justfile`
 pins plus the active uv version after every requested package updates
 successfully. uv remains an external prerequisite managed outside this
-repository; the update workflow accepts its active version long enough to
+repository; the update workflow accepts its active stable `X.Y.Z` version long enough to
 record the new pin but does not replace the uv installation. Ordinary uv-backed
 recipes continue to require the exact reconciled pin. The Cargo tool updater
 requires `cargo-install-update` from the `cargo-update` package and does not
@@ -206,8 +206,13 @@ touch other Cargo-installed executables or uv's user-global tool environments.
 `setup-tools` and CI consume the reconciled declarations. The exact-pin step
 leaves ranged development requirements, project/runtime dependencies, optional
 dependencies, build requirements, and intentional uv overrides unchanged.
-The aggregate `just update` runs its `cargo-install-update` preflight before
-either dependency updater can change declarations or lockfiles.
+The aggregate `just update` runs its `cargo-install-update` and stable-uv
+preflights before either dependency updater can change declarations or
+lockfiles. Direct `just update-cargo-tools` also checks stable uv before
+updating installed Cargo tools. Both reuse the pin reconciler's version parser
+without requiring uv to match the tracked pin. This check uses an already
+installed Python interpreter with dependency syncing and Python downloads
+disabled; invalid uv output fails before updates begin.
 
 Agents should **prefer running `just` commands instead of invoking the
 underlying tools directly**. The justfile ensures the correct flags,
@@ -969,6 +974,20 @@ Run with:
 just action-lint
 ```
 
+`just zizmor` uses the repository's pinned scanner with the `regular` persona.
+It takes a token from `ZIZMOR_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN`, in
+that order, then tries `gh auth token` for `GH_HOST` (default `github.com`).
+Tokens are passed through the environment without being printed. With
+authentication, online audits include action SHA/version-comment checks;
+without it, the recipe reports that it is running offline. Explicit zizmor
+environment settings such as `ZIZMOR_OFFLINE` still apply.
+
+The `zizmor.yml` SARIF workflow reads `zizmor_version` from `justfile` and
+explicitly enables online audits with the same persona. Zizmor resolves action
+SHAs against release tags; repository Semgrep rules require an explicit scanner
+version and disabled setup-uv caching in release workflows without duplicating
+that remote resolution.
+
 ---
 
 ## Recommended Command Matrix
@@ -1018,7 +1037,8 @@ CI enforces:
 - Markdown, JSON, TOML, YAML, CFF, and spell checks
 - release-version reference synchronization
 - `Cargo.toml`/`Cargo.lock` synchronization
-- Python lint, type checks, and tests
+- Python formatting, full-policy lint, type checks, and tests
+- direct Python Semgrep fixture lint
 - notebook hygiene and extracted-code checks
 - shell script formatting and lint checks
 - core Rust formatting, Clippy, rustdoc, and Semgrep checks

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -208,12 +208,12 @@ leaves ranged development requirements, project/runtime dependencies, optional
 dependencies, build requirements, and intentional uv overrides unchanged.
 The aggregate `just update` runs its `cargo-install-update` and stable-uv
 preflights before either dependency updater can change declarations or
-lockfiles. Direct `just update-dependencies` and `just update-cargo-tools` also
-check stable uv before their updates. These entry points reuse the pin
-reconciler's version parser without requiring uv to match the tracked pin.
-This check uses an already installed Python interpreter with dependency
-syncing and Python downloads disabled; invalid uv output fails before updates
-begin.
+lockfiles. Direct `just update-dependencies`, `just update-python-dependencies`,
+and `just update-cargo-tools` also check stable uv before their updates.
+These entry points reuse the pin reconciler's version parser without requiring
+uv to match the tracked pin. This check uses an already installed Python
+interpreter with dependency syncing and Python downloads disabled; invalid uv
+output fails before updates begin.
 
 Agents should **prefer running `just` commands instead of invoking the
 underlying tools directly**. The justfile ensures the correct flags,

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -208,11 +208,12 @@ leaves ranged development requirements, project/runtime dependencies, optional
 dependencies, build requirements, and intentional uv overrides unchanged.
 The aggregate `just update` runs its `cargo-install-update` and stable-uv
 preflights before either dependency updater can change declarations or
-lockfiles. Direct `just update-cargo-tools` also checks stable uv before
-updating installed Cargo tools. Both reuse the pin reconciler's version parser
-without requiring uv to match the tracked pin. This check uses an already
-installed Python interpreter with dependency syncing and Python downloads
-disabled; invalid uv output fails before updates begin.
+lockfiles. Direct `just update-dependencies` and `just update-cargo-tools` also
+check stable uv before their updates. These entry points reuse the pin
+reconciler's version parser without requiring uv to match the tracked pin.
+This check uses an already installed Python interpreter with dependency
+syncing and Python downloads disabled; invalid uv output fails before updates
+begin.
 
 Agents should **prefer running `just` commands instead of invoking the
 underlying tools directly**. The justfile ensures the correct flags,

--- a/just/helpers.just
+++ b/just/helpers.just
@@ -145,6 +145,10 @@ _ensure-uv-available:
     }
     uv --version >/dev/null
 
+_ensure-uv-stable: _ensure-uv-available
+    # Check the reconciler's contract without syncing dependencies or installing Python.
+    uv run --locked --no-sync --no-python-downloads python scripts/update_cargo_tool_pins.py --check-uv
+
 _ensure-yamllint: _ensure-uv
     #!/usr/bin/env bash
     set -euo pipefail

--- a/justfile
+++ b/justfile
@@ -29,7 +29,7 @@ taplo_version := "0.10.0"
 tectonic_version := "0.17.0"
 tex_fmt_version := "0.5.7"
 typos_version := "1.50.1"
-uv_version := "0.12.10"
+uv_version := "0.12.11"
 zizmor_version := "1.30.1"
 
 # Common cargo-llvm-cov arguments for all coverage runs.
@@ -1658,7 +1658,7 @@ update-cargo-tools: _ensure-cargo-install-update _ensure-uv-stable
 # Advance Cargo and exact Python development requirements plus their lockfiles.
 [doc('Update Cargo and Python development requirements plus all Cargo/uv locked dependencies.')]
 [group('build and setup')]
-update-dependencies: _ensure-cargo-edit _ensure-uv-available update-cargo-dependencies update-python-dependencies
+update-dependencies: _ensure-cargo-edit _ensure-uv-stable update-cargo-dependencies update-python-dependencies
 
 # Resolve latest exact Python development tools, retain ranged requirements, and sync.
 [doc('Update exact dependency-groups.dev pins and uv.lock through uv.')]

--- a/justfile
+++ b/justfile
@@ -30,7 +30,7 @@ tectonic_version := "0.17.0"
 tex_fmt_version := "0.5.7"
 typos_version := "1.50.1"
 uv_version := "0.12.10"
-zizmor_version := "1.30.0"
+zizmor_version := "1.30.1"
 
 # Common cargo-llvm-cov arguments for all coverage runs.
 # Excludes benches/examples from reports while allowing integration tests to
@@ -1617,7 +1617,7 @@ unused-deps: _ensure-cargo-machete
 
 # Update dependency requirements, locks, managed Cargo tools, and the active uv pin.
 [group('build and setup')]
-update: _ensure-cargo-install-update update-dependencies update-cargo-tools
+update: _ensure-cargo-install-update _ensure-uv-stable update-dependencies update-cargo-tools
     @echo "✅ Repository dependencies and tools updated."
 
 # Advance Cargo dependency declarations and lockfile entries for every resolution root.
@@ -1632,7 +1632,7 @@ update-cargo-dependencies: _ensure-cargo-edit
 # Update locally installed Cargo CLI tools and reconcile their pins plus the active uv version.
 [doc('Update managed Cargo CLI tools and reconcile all root justfile tool pins.')]
 [group('build and setup')]
-update-cargo-tools: _ensure-cargo-install-update _ensure-uv-available
+update-cargo-tools: _ensure-cargo-install-update _ensure-uv-stable
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -1776,4 +1776,20 @@ yaml-lint: _ensure-yamllint
 # Audit GitHub Actions workflows with zizmor.
 [group('validation')]
 zizmor: _ensure-zizmor
-    zizmor .github
+    #!/usr/bin/env bash
+    set +x
+    set -euo pipefail
+    zizmor_token="${ZIZMOR_GITHUB_TOKEN:-${GH_TOKEN:-${GITHUB_TOKEN:-}}}"
+    if [[ -z "$zizmor_token" ]] && command -v gh >/dev/null; then
+        if resolved_token="$(gh auth token --hostname "${GH_HOST:-github.com}" 2>/dev/null)"; then
+            zizmor_token="$resolved_token"
+        fi
+    fi
+    if [[ -n "$zizmor_token" ]]; then
+        # Honor our token precedence regardless of zizmor's environment lookup order.
+        unset GH_TOKEN GITHUB_TOKEN
+        ZIZMOR_GITHUB_TOKEN="$zizmor_token" zizmor --persona regular .github
+    else
+        echo "No GitHub token available; running zizmor offline (online audits disabled)." >&2
+        zizmor --offline --persona regular .github
+    fi

--- a/justfile
+++ b/justfile
@@ -1663,7 +1663,7 @@ update-dependencies: _ensure-cargo-edit _ensure-uv-stable update-cargo-dependenc
 # Resolve latest exact Python development tools, retain ranged requirements, and sync.
 [doc('Update exact dependency-groups.dev pins and uv.lock through uv.')]
 [group('build and setup')]
-update-python-dependencies: _ensure-uv-available
+update-python-dependencies: _ensure-uv-stable
     uv run --locked update-python-dev-pins
     uv lock --upgrade
     uv sync --locked --group dev

--- a/scripts/tests/test_justfile_discoverability.py
+++ b/scripts/tests/test_justfile_discoverability.py
@@ -573,13 +573,13 @@ def test_uv_backed_recipes_reuse_pinned_guard() -> None:
         dependencies = {dependency["recipe"] for dependency in recipes[name]["dependencies"]}
         assert "_ensure-uv" in dependencies, name
 
-    for name in ("_ensure-uv-stable", "update-dependencies", "update-python-dependencies"):
+    for name in ("_ensure-uv-stable", "update-python-dependencies"):
         dependencies = {dependency["recipe"] for dependency in recipes[name]["dependencies"]}
         assert "_ensure-uv-available" in dependencies, name
         assert "_ensure-uv" not in dependencies, name
 
 
-@pytest.mark.parametrize("recipe", ["update", "update-cargo-tools"])
+@pytest.mark.parametrize("recipe", ["update", "update-cargo-tools", "update-dependencies"])
 def test_update_preflights_stable_uv_before_mutations(recipe: str) -> None:
     """Reject unsupported uv output before dependency or installed-tool updates."""
     rendered_result = run_just("--dry-run", recipe)
@@ -588,10 +588,13 @@ def test_update_preflights_stable_uv_before_mutations(recipe: str) -> None:
 
     assert rendered.count(preflight) == 1
     assert rendered.index("uv --version") < rendered.index(preflight)
-    assert rendered.index(preflight) < rendered.index("cargo install-update --locked")
-    if recipe == "update":
+    if recipe in {"update", "update-cargo-tools"}:
+        assert rendered.index(preflight) < rendered.index("cargo install-update --locked")
+    if recipe in {"update", "update-dependencies"}:
         assert rendered.index(preflight) < rendered.index("cargo upgrade --incompatible allow")
         assert rendered.index(preflight) < rendered.index("uv run --locked update-python-dev-pins")
+        assert rendered.index(preflight) < rendered.index("uv lock --upgrade")
+        assert rendered.index(preflight) < rendered.index("uv sync --locked --group dev")
     assert "installed_version=" not in rendered.split(preflight)[0]
 
 
@@ -704,7 +707,7 @@ def test_update_workflow_composes_scoped_dependency_and_tool_updates() -> None:
     dependency_result = run_just("--dry-run", "update-dependencies")
     dependency_update = dependency_result.stdout + dependency_result.stderr
     dependency_preflights = [dependency["recipe"] for dependency in recipes["update-dependencies"]["dependencies"]]
-    assert dependency_preflights[:2] == ["_ensure-cargo-edit", "_ensure-uv-available"]
+    assert dependency_preflights[:2] == ["_ensure-cargo-edit", "_ensure-uv-stable"]
     assert dependency_update.index("cargo_tool_has_exact_version") < dependency_update.index("cargo upgrade --incompatible allow")
     assert dependency_update.index("uv --version") < dependency_update.index("cargo upgrade --incompatible allow")
     assert "cargo upgrade --incompatible allow" in dependency_update

--- a/scripts/tests/test_justfile_discoverability.py
+++ b/scripts/tests/test_justfile_discoverability.py
@@ -573,13 +573,11 @@ def test_uv_backed_recipes_reuse_pinned_guard() -> None:
         dependencies = {dependency["recipe"] for dependency in recipes[name]["dependencies"]}
         assert "_ensure-uv" in dependencies, name
 
-    for name in ("_ensure-uv-stable", "update-python-dependencies"):
-        dependencies = {dependency["recipe"] for dependency in recipes[name]["dependencies"]}
-        assert "_ensure-uv-available" in dependencies, name
-        assert "_ensure-uv" not in dependencies, name
+    stable_dependencies = {dependency["recipe"] for dependency in recipes["_ensure-uv-stable"]["dependencies"]}
+    assert stable_dependencies == {"_ensure-uv-available"}
 
 
-@pytest.mark.parametrize("recipe", ["update", "update-cargo-tools", "update-dependencies"])
+@pytest.mark.parametrize("recipe", ["update", "update-cargo-tools", "update-dependencies", "update-python-dependencies"])
 def test_update_preflights_stable_uv_before_mutations(recipe: str) -> None:
     """Reject unsupported uv output before dependency or installed-tool updates."""
     rendered_result = run_just("--dry-run", recipe)
@@ -592,6 +590,7 @@ def test_update_preflights_stable_uv_before_mutations(recipe: str) -> None:
         assert rendered.index(preflight) < rendered.index("cargo install-update --locked")
     if recipe in {"update", "update-dependencies"}:
         assert rendered.index(preflight) < rendered.index("cargo upgrade --incompatible allow")
+    if recipe in {"update", "update-dependencies", "update-python-dependencies"}:
         assert rendered.index(preflight) < rendered.index("uv run --locked update-python-dev-pins")
         assert rendered.index(preflight) < rendered.index("uv lock --upgrade")
         assert rendered.index(preflight) < rendered.index("uv sync --locked --group dev")

--- a/scripts/tests/test_justfile_discoverability.py
+++ b/scripts/tests/test_justfile_discoverability.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import sys
 from collections import defaultdict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -24,6 +25,18 @@ JUST_VERSION_RESOLVER = REPO_ROOT / ".github" / "actions" / "setup-just" / "reso
 RECIPE_DECLARATION = re.compile(r"^([A-Za-z_][A-Za-z0-9_-]*)(?:\s+.*?)?:(?=\s|$)", re.MULTILINE)
 WORKFLOW_VERSION_LOOKUP = re.compile(r"just --evaluate ([a-z0-9_]+_version)")
 UNLOCKED_UV_RUN = re.compile(r"\buv\s+run\b(?!\s+--locked\b)")
+
+
+@dataclass(frozen=True, kw_only=True)
+class ZizmorAuthCase:
+    """Synthetic credential sources and the token expected at the scanner boundary."""
+
+    tokens: dict[str, str]
+    expected_value: str
+    gh_available: bool = True
+    gh_stdout: str = ""
+    gh_returncode: int = 0
+    trace: bool = False
 
 
 def run_just(*args: str) -> subprocess.CompletedProcess[str]:
@@ -76,6 +89,52 @@ def just_recipes() -> dict[str, dict[str, Any]]:
     recipes = document["recipes"]
     assert isinstance(recipes, dict)
     return recipes
+
+
+def run_zizmor_probe(
+    tmp_path: Path,
+    case: ZizmorAuthCase,
+    scan_returncode: int,
+) -> subprocess.CompletedProcess[str]:
+    """Exercise the rendered recipe with fake authentication and scanner commands."""
+    version = run_just("--evaluate", "zizmor_version").stdout.strip()
+    rendered = run_just("--dry-run", "zizmor")
+    exports = "\n".join(f"export {name}={shlex.quote(value)}" for name, value in case.tokens.items())
+    script = f"""
+unset ZIZMOR_GITHUB_TOKEN GH_TOKEN GITHUB_TOKEN GH_HOST ZIZMOR_OFFLINE ZIZMOR_NO_ONLINE_AUDITS
+{exports}
+command() {{
+    if [[ "$*" == "-v gh" ]]; then
+        return {0 if case.gh_available else 1}
+    fi
+    builtin command "$@"
+}}
+gh() {{
+    printf '%s\\n' "$*" >> {shlex.quote((tmp_path / "gh.log").as_posix())}
+    printf '%s\\n' {shlex.quote(case.gh_stdout)}
+    echo "fixture-auth-diagnostic" >&2
+    return {case.gh_returncode}
+}}
+zizmor() {{
+    if [[ "$*" == "--version" ]]; then
+        printf '%s\\n' {shlex.quote("zizmor " + version)}
+        return 0
+    fi
+    if [[ "${{ZIZMOR_GITHUB_TOKEN:-}}" != {shlex.quote(case.expected_value)} ]]; then
+        echo "Unexpected scanner credential" >&2
+        return 97
+    fi
+    if [[ -n "${{GH_TOKEN:-}}" || -n "${{GITHUB_TOKEN:-}}" ]]; then
+        echo "Conflicting scanner credential" >&2
+        return 98
+    fi
+    printf 'scan:%s\\n' "$*"
+    return {scan_returncode}
+}}
+{"set -x" if case.trace else ""}
+{rendered.stdout}{rendered.stderr}
+"""
+    return run_safe_command("bash", ["-c", script], cwd=REPO_ROOT, check=False, timeout=30)
 
 
 def workflow_trigger_paths(path: Path) -> tuple[set[str], set[str]]:
@@ -514,10 +573,26 @@ def test_uv_backed_recipes_reuse_pinned_guard() -> None:
         dependencies = {dependency["recipe"] for dependency in recipes[name]["dependencies"]}
         assert "_ensure-uv" in dependencies, name
 
-    for name in ("update-cargo-tools", "update-dependencies", "update-python-dependencies"):
+    for name in ("_ensure-uv-stable", "update-dependencies", "update-python-dependencies"):
         dependencies = {dependency["recipe"] for dependency in recipes[name]["dependencies"]}
         assert "_ensure-uv-available" in dependencies, name
         assert "_ensure-uv" not in dependencies, name
+
+
+@pytest.mark.parametrize("recipe", ["update", "update-cargo-tools"])
+def test_update_preflights_stable_uv_before_mutations(recipe: str) -> None:
+    """Reject unsupported uv output before dependency or installed-tool updates."""
+    rendered_result = run_just("--dry-run", recipe)
+    rendered = rendered_result.stdout + rendered_result.stderr
+    preflight = "uv run --locked --no-sync --no-python-downloads python scripts/update_cargo_tool_pins.py --check-uv"
+
+    assert rendered.count(preflight) == 1
+    assert rendered.index("uv --version") < rendered.index(preflight)
+    assert rendered.index(preflight) < rendered.index("cargo install-update --locked")
+    if recipe == "update":
+        assert rendered.index(preflight) < rendered.index("cargo upgrade --incompatible allow")
+        assert rendered.index(preflight) < rendered.index("uv run --locked update-python-dev-pins")
+    assert "installed_version=" not in rendered.split(preflight)[0]
 
 
 def test_setup_tools_closes_external_and_cargo_update_prerequisites() -> None:
@@ -620,7 +695,7 @@ def test_update_workflow_composes_scoped_dependency_and_tool_updates() -> None:
     recipes = just_recipes()
     update_dependencies = [dependency["recipe"] for dependency in recipes["update"]["dependencies"]]
 
-    assert update_dependencies == ["_ensure-cargo-install-update", "update-dependencies", "update-cargo-tools"]
+    assert update_dependencies == ["_ensure-cargo-install-update", "_ensure-uv-stable", "update-dependencies", "update-cargo-tools"]
 
     aggregate_result = run_just("--dry-run", "update")
     aggregate_update = aggregate_result.stdout + aggregate_result.stderr
@@ -675,3 +750,64 @@ def test_workflow_tool_version_lookups_resolve_from_just() -> None:
     for name in version_names:
         result = run_just("--evaluate", name)
         assert result.stdout.strip(), name
+
+
+@pytest.mark.parametrize("scan_returncode", [0, 23])
+@pytest.mark.parametrize(
+    "case",
+    [
+        ZizmorAuthCase(
+            tokens={"ZIZMOR_GITHUB_TOKEN": "fixture-zizmor", "GH_TOKEN": "fixture-gh", "GITHUB_TOKEN": "fixture-github"}, expected_value="fixture-zizmor"
+        ),
+        ZizmorAuthCase(tokens={"GH_TOKEN": "fixture-gh", "GITHUB_TOKEN": "fixture-github"}, expected_value="fixture-gh"),
+        ZizmorAuthCase(tokens={"GITHUB_TOKEN": "fixture-github"}, expected_value="fixture-github"),
+        ZizmorAuthCase(tokens={}, gh_stdout="fixture-auth", expected_value="fixture-auth"),
+        ZizmorAuthCase(tokens={}, gh_stdout="fixture-partial-auth", gh_returncode=1, expected_value=""),
+        ZizmorAuthCase(tokens={}, expected_value=""),
+        ZizmorAuthCase(tokens={}, gh_available=False, expected_value=""),
+        ZizmorAuthCase(tokens={"ZIZMOR_GITHUB_TOKEN": "fixture-traced"}, expected_value="fixture-traced", trace=True),
+    ],
+)
+def test_zizmor_authentication_and_offline_fallback(
+    tmp_path: Path,
+    case: ZizmorAuthCase,
+    scan_returncode: int,
+) -> None:
+    """Select credentials privately, report offline scans, and preserve scanner failures."""
+    result = run_zizmor_probe(tmp_path, case, scan_returncode)
+
+    assert result.returncode == scan_returncode, result.stderr
+    expected_args = "--persona regular .github" if case.expected_value else "--offline --persona regular .github"
+    assert result.stdout == f"scan:{expected_args}\n"
+    assert ("online audits disabled" in result.stderr) == (not case.expected_value)
+    assert "fixture-" not in result.stdout + result.stderr
+    gh_log = tmp_path / "gh.log"
+    if case.gh_available and not case.tokens:
+        assert gh_log.read_text(encoding="utf-8") == "auth token --hostname github.com\n"
+    else:
+        assert not gh_log.exists()
+
+
+def test_zizmor_sarif_workflow_uses_local_pin_and_online_persona(tmp_path: Path) -> None:
+    """The hosted scanner must consume the evaluated local pin with online audits."""
+    workflow_path = REPO_ROOT / ".github" / "workflows" / "zizmor.yml"
+    workflow: Any = yaml.load(workflow_path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)  # noqa: S506 - BaseLoader constructs data only.
+    steps = workflow["jobs"]["analyze"]["steps"]
+    setup = next(step for step in steps if step.get("uses") == "$/.github/actions/setup-just")
+    resolver = next(step for step in steps if step.get("id") == "zizmor_version")
+    scanners = [step for step in steps if step.get("uses", "").startswith("zizmorcore/zizmor-action@")]
+
+    assert len(scanners) == 1
+    scanner = scanners[0]
+    assert steps.index(setup) < steps.index(resolver) < steps.index(scanner)
+    assert scanner["with"]["version"] == "${{ steps.zizmor_version.outputs.version }}"
+    assert scanner["with"]["online-audits"] == "true"
+    assert scanner["with"]["persona"] == "regular"
+    assert scanner["with"]["inputs"] == ".github"
+    assert scanner["with"].get("advanced-security", "true") == "true"
+
+    output_path = tmp_path / "github-output"
+    script = f"export GITHUB_OUTPUT={shlex.quote(output_path.as_posix())}\n{resolver['run']}"
+    run_safe_command("bash", ["-c", script], cwd=REPO_ROOT, timeout=30)
+    expected_version = run_just("--evaluate", "zizmor_version").stdout.strip()
+    assert output_path.read_text(encoding="utf-8") == f"version={expected_version}\n"

--- a/scripts/tests/test_update_cargo_tool_pins.py
+++ b/scripts/tests/test_update_cargo_tool_pins.py
@@ -63,6 +63,62 @@ def test_reconcile_pins_rejects_missing_package_without_writing(tmp_path: Path) 
     assert justfile.read_text(encoding="utf-8") == original
 
 
+@pytest.mark.parametrize(
+    ("cargo_output", "message"),
+    [
+        (installed_output() + "rumdl v2.0.0:\n    rumdl\n", "duplicate installed Cargo package: rumdl"),
+        (installed_output(override=("rumdl", "2.0")), "invalid installed version for rumdl: 2.0"),
+    ],
+)
+def test_reconcile_pins_rejects_invalid_cargo_inventory_without_writing(
+    cargo_output: str,
+    message: str,
+    tmp_path: Path,
+) -> None:
+    justfile = tmp_path / "justfile"
+    original = justfile_text()
+    justfile.write_text(original, encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message):
+        update_cargo_tool_pins.reconcile_pins(justfile, cargo_output, "uv 2.0.0")
+
+    assert justfile.read_text(encoding="utf-8") == original
+    assert list(tmp_path.iterdir()) == [justfile]
+
+
+def test_reconcile_pins_preserves_file_and_cleans_up_failed_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    justfile = tmp_path / "justfile"
+    original = justfile_text()
+    justfile.write_text(original, encoding="utf-8")
+    original_mode = justfile.stat().st_mode
+
+    def failed_replace(temporary: Path, destination: Path) -> Never:
+        assert temporary.parent == tmp_path
+        assert temporary != justfile
+        assert destination == justfile
+        msg = "replacement denied"
+        raise PermissionError(msg)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(type(justfile), "replace", failed_replace)
+        with pytest.raises(PermissionError, match="replacement denied"):
+            update_cargo_tool_pins.reconcile_pins(justfile, installed_output(), "uv 2.0.0")
+
+    assert justfile.read_text(encoding="utf-8") == original
+    assert justfile.stat().st_mode == original_mode
+    assert list(tmp_path.iterdir()) == [justfile]
+
+    changes = update_cargo_tool_pins.reconcile_pins(justfile, installed_output(), "uv 2.0.0")
+
+    assert changes == {"uv_version": ("1.2.3", "2.0.0")}
+    assert justfile.read_text(encoding="utf-8") == original.replace('uv_version := "1.2.3"', 'uv_version := "2.0.0"')
+    assert justfile.stat().st_mode == original_mode
+    assert list(tmp_path.iterdir()) == [justfile]
+
+
 def test_update_pin_text_rejects_duplicate_assignment() -> None:
     duplicated = justfile_text() + 'rumdl_version := "1.2.3"\n'
     installed = update_cargo_tool_pins.parse_installed_packages(installed_output())
@@ -182,6 +238,43 @@ def test_uv_preflight_reports_command_failure_without_traceback(
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == f"failed uv preflight (requires stable X.Y.Z): {error}\n"
+
+
+def test_main_reports_updated_pins_and_leaves_matching_file_untouched(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    justfile = tmp_path / "justfile"
+    original = justfile_text()
+    justfile.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(
+        update_cargo_tool_pins,
+        "run_cargo_command",
+        lambda _args, **_kwargs: subprocess.CompletedProcess([], 0, stdout=installed_output(), stderr=""),
+    )
+    monkeypatch.setattr(
+        update_cargo_tool_pins,
+        "run_safe_command",
+        lambda _command, _args, **_kwargs: subprocess.CompletedProcess([], 0, stdout="uv 2.0.0", stderr=""),
+    )
+
+    assert update_cargo_tool_pins.main(["--justfile", str(justfile)]) == 0
+    captured = capsys.readouterr()
+    assert captured.out == "Updated uv_version: 1.2.3 -> 2.0.0\n"
+    assert captured.err == ""
+    expected = original.replace('uv_version := "1.2.3"', 'uv_version := "2.0.0"')
+    assert justfile.read_text(encoding="utf-8") == expected
+    updated_stat = justfile.stat()
+
+    assert update_cargo_tool_pins.main(["--justfile", str(justfile)]) == 0
+    captured = capsys.readouterr()
+    assert captured.out == "Tool pins already match installed repository tools.\n"
+    assert captured.err == ""
+    assert justfile.read_text(encoding="utf-8") == expected
+    assert justfile.stat().st_ino == updated_stat.st_ino
+    assert justfile.stat().st_mtime_ns == updated_stat.st_mtime_ns
+    assert list(tmp_path.iterdir()) == [justfile]
 
 
 def test_main_reports_missing_cargo_without_traceback(

--- a/scripts/tests/test_update_cargo_tool_pins.py
+++ b/scripts/tests/test_update_cargo_tool_pins.py
@@ -95,10 +95,93 @@ def test_reconcile_pins_preserves_prerelease_with_build_metadata(tmp_path: Path)
     assert f'rumdl_version := "{version}"' in justfile.read_text(encoding="utf-8").splitlines()
 
 
-@pytest.mark.parametrize("output", ["uv 1.2.3-rc.1", "uv 1.2.3.4", "uv release-1.2.3"])
-def test_parse_tool_version_rejects_nonstable_or_embedded_versions(output: str) -> None:
+@pytest.mark.parametrize(
+    "output",
+    ["", "uv unknown", "uv 1.2", "uv 1.2.3-rc.1", "uv 1.2.3+build.1", "uv 1.2.3.4", "uv release-1.2.3", "uv 1.2.3 2.0.0", "uv 1.2.3\nuv 1.2.3"],
+)
+def test_uv_preflight_and_reconciler_reject_invalid_versions_without_writing(
+    output: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    justfile = tmp_path / "justfile"
+    original = justfile_text()
+    justfile.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(
+        update_cargo_tool_pins,
+        "run_safe_command",
+        lambda _command, _args, **_kwargs: subprocess.CompletedProcess([], 0, stdout=output, stderr=""),
+    )
+
+    def unexpected_cargo(_args: list[str], **_kwargs: object) -> Never:
+        pytest.fail("uv preflight must not inspect Cargo packages")
+
+    monkeypatch.setattr(update_cargo_tool_pins, "run_cargo_command", unexpected_cargo)
+
+    assert update_cargo_tool_pins.main(["--check-uv", "--justfile", str(justfile)]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "failed uv preflight (requires stable X.Y.Z): expected exactly one uv version" in captured.err
+    assert justfile.read_text(encoding="utf-8") == original
+
     with pytest.raises(ValueError, match="expected exactly one uv version"):
-        update_cargo_tool_pins.parse_tool_version(output, "uv")
+        update_cargo_tool_pins.reconcile_pins(justfile, installed_output(), output)
+
+    assert justfile.read_text(encoding="utf-8") == original
+    assert list(tmp_path.iterdir()) == [justfile]
+
+
+@pytest.mark.parametrize("output", ["uv 99.0.0", "uv v99.0.0", "uv 99.0.0 (Homebrew 2026-09-04 aarch64-apple-darwin)\n"])
+def test_uv_preflight_accepts_stable_versions_without_reading_pins_or_cargo(
+    output: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    missing_justfile = tmp_path / "justfile"
+
+    def uv_version(command: str, args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert command == "uv"
+        assert args == ["--version"]
+        assert kwargs == {"timeout": 30}
+        return subprocess.CompletedProcess([], 0, stdout=output, stderr="")
+
+    def unexpected_cargo(_args: list[str], **_kwargs: object) -> Never:
+        pytest.fail("uv preflight must not inspect Cargo packages")
+
+    monkeypatch.setattr(update_cargo_tool_pins, "run_safe_command", uv_version)
+    monkeypatch.setattr(update_cargo_tool_pins, "run_cargo_command", unexpected_cargo)
+
+    assert update_cargo_tool_pins.main(["--check-uv", "--justfile", str(missing_justfile)]) == 0
+    captured = capsys.readouterr()
+    assert captured.out == captured.err == ""
+    assert not missing_justfile.exists()
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ExecutableNotFoundError("uv missing"),
+        OSError("uv unavailable"),
+        subprocess.CalledProcessError(2, ["uv", "--version"]),
+        subprocess.TimeoutExpired("uv", 30),
+    ],
+)
+def test_uv_preflight_reports_command_failure_without_traceback(
+    error: Exception,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def failed_uv(_command: str, _args: list[str], **_kwargs: object) -> Never:
+        raise error
+
+    monkeypatch.setattr(update_cargo_tool_pins, "run_safe_command", failed_uv)
+
+    assert update_cargo_tool_pins.main(["--check-uv"]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == f"failed uv preflight (requires stable X.Y.Z): {error}\n"
 
 
 def test_main_reports_missing_cargo_without_traceback(

--- a/scripts/update_cargo_tool_pins.py
+++ b/scripts/update_cargo_tool_pins.py
@@ -110,6 +110,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--justfile", type=Path, default=Path("justfile"), help="Just source containing repository tool pins")
+    parser.add_argument("--check-uv", action="store_true", help="Only check that active uv reports one stable X.Y.Z version; do not read Cargo or pins")
     return parser.parse_args(argv)
 
 
@@ -117,11 +118,16 @@ def main(argv: list[str] | None = None) -> int:
     """Reconcile managed pins from the active Cargo and uv installations."""
     args = parse_args(argv)
     try:
+        if args.check_uv:
+            uv = run_safe_command("uv", ["--version"], timeout=30)
+            parse_tool_version(uv.stdout, "uv")
+            return 0
         cargo = run_cargo_command(["install", "--list"], timeout=30)
         uv = run_safe_command("uv", ["--version"], timeout=30)
         changes = reconcile_pins(args.justfile, cargo.stdout, uv.stdout)
     except (ExecutableNotFoundError, OSError, subprocess.SubprocessError, ValueError) as error:
-        print(f"failed to update tool pins: {error}", file=sys.stderr)
+        context = "failed uv preflight (requires stable X.Y.Z)" if args.check_uv else "failed to update tool pins"
+        print(f"{context}: {error}", file=sys.stderr)
         return 1
 
     if not changes:

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -2981,6 +2981,82 @@ rules:
     patterns:
       - pattern-regex: '(?m)^[ \t]*(?:-[ \t]*)?uses:[ \t]*actions/checkout@[a-fA-F0-9]{40}[^\n]*\n(?!(?:[ \t]*with:\n)?(?:[ \t]{10,}\S[^\n]*\n){0,8}[ \t]{10,}persist-credentials:[ \t]*false\b)' # yamllint disable-line rule:line-length
 
+  - id: delaunay.github-actions.zizmor-tool-version-pinned
+    languages:
+      - yaml
+    severity: WARNING
+    message: "Declare a stable zizmor version or an expression resolving the justfile pin in zizmor-action's with.version."
+    metadata:
+      category: security
+      rationale: "A floating scanner version can make local audits disagree with GitHub SARIF findings."
+    paths:
+      include:
+        - "/.github/workflows/**/*.yml"
+        - "/.github/workflows/**/*.yaml"
+        - "/tests/semgrep/.github/workflows/**/*.yml"
+        - "/tests/semgrep/.github/workflows/**/*.yaml"
+    patterns:
+      - pattern-either:
+          - patterns:
+              - pattern: |
+                  uses: $ACTION
+                  ...
+              - pattern-not: |
+                  uses: $ACTION
+                  with:
+                    version: $VERSION
+                    ...
+                  ...
+          - patterns:
+              - pattern: |
+                  uses: $ACTION
+                  with:
+                    version: $VERSION
+                    ...
+                  ...
+              - metavariable-regex:
+                  metavariable: $VERSION
+                  regex: ^(?!(?:["']?(?:[0-9]+\.[0-9]+\.[0-9]+|\$\{\{.+\}\})["']?)$)
+      - metavariable-regex:
+          metavariable: $ACTION
+          regex: ^["']?zizmorcore/zizmor-action@
+      - focus-metavariable: $ACTION
+
+  - id: delaunay.github-actions.release-setup-uv-cache-disabled
+    languages:
+      - yaml
+    severity: ERROR
+    message: "Set enable-cache: false on setup-uv steps that produce release artifacts."
+    metadata:
+      category: security
+      rationale: "Release artifact producers must not restore writable dependency caches."
+    paths:
+      include:
+        - "/.github/workflows/release-*.yml"
+        - "/.github/workflows/release-*.yaml"
+        - "/tests/semgrep/.github/workflows/release-*.yml"
+        - "/tests/semgrep/.github/workflows/release-*.yaml"
+    patterns:
+      - pattern: |
+          uses: $ACTION
+          ...
+      - metavariable-regex:
+          metavariable: $ACTION
+          regex: ^["']?astral-sh/setup-uv@
+      - pattern-not: |
+          uses: $ACTION
+          with:
+            enable-cache: false
+            ...
+          ...
+      - pattern-not: |
+          uses: $ACTION
+          with:
+            enable-cache: "false"
+            ...
+          ...
+      - focus-metavariable: $ACTION
+
   - id: delaunay.github-actions.no-pull-request-target
     languages:
       - regex

--- a/src/core/tds/mutation.rs
+++ b/src/core/tds/mutation.rs
@@ -2159,6 +2159,9 @@ impl<U, V, const D: usize> Tds<U, V, D> {
             }
         }
 
+        for &simplex_key in &targets {
+            self.journal_simplex_before_write(simplex_key);
+        }
         for (simplex_key, simplex) in self.simplices.iter_mut() {
             if targets.contains(&simplex_key) {
                 simplex.swap_vertex_slots(0, 1);
@@ -3153,6 +3156,49 @@ mod tests {
         }
     }
 
+    fn assert_reverse_simplex_orientations_retains_nested_rollback<const D: usize>() {
+        let StageNeighborSlotFixture {
+            mut tds,
+            simplex_key,
+            neighbor_key,
+            ..
+        } = stage_neighbor_slot_fixture::<D>();
+        tds.assign_neighbors().unwrap();
+        tds.assign_incident_simplices().unwrap();
+        tds.normalize_coherent_orientation().unwrap();
+        tds.force_construction_complete_for_test();
+        tds.validate().unwrap();
+        let before = serde_json::to_value(&tds).unwrap();
+        let owner = tds.topology_owner_id();
+        let generation = tds.generation();
+        let vertex_keys: Vec<_> = tds.vertex_keys().collect();
+        let simplex_keys: Vec<_> = tds.simplex_keys().collect();
+        let simplex_vertices = tds.simplex(simplex_key).unwrap().vertices().to_vec();
+
+        let outer = tds.begin_rollback_savepoint();
+        tds.reverse_simplex_orientations(&[simplex_key, simplex_key])
+            .unwrap();
+        assert_eq!(tds.generation(), generation + 1);
+        let reversed = tds.simplex(simplex_key).unwrap().vertices();
+        assert_eq!(reversed[0], simplex_vertices[1]);
+        assert_eq!(reversed[1], simplex_vertices[0]);
+        assert_eq!(reversed[2..], simplex_vertices[2..]);
+
+        let inner = tds.begin_rollback_savepoint();
+        tds.reverse_simplex_orientations(&[neighbor_key]).unwrap();
+        tds.commit_savepoint(inner);
+        assert_eq!(tds.generation(), generation + 2);
+        tds.validate().unwrap();
+
+        tds.rollback_savepoint(outer);
+        assert_eq!(tds.topology_owner_id(), owner);
+        assert_eq!(tds.generation(), generation);
+        assert_eq!(tds.vertex_keys().collect::<Vec<_>>(), vertex_keys);
+        assert_eq!(tds.simplex_keys().collect::<Vec<_>>(), simplex_keys);
+        assert_eq!(serde_json::to_value(&tds).unwrap(), before);
+        tds.validate().unwrap();
+    }
+
     fn assert_reverse_simplex_orientations_rejects_malformed_neighbors_without_mutation<
         const D: usize,
     >() {
@@ -3434,6 +3480,11 @@ mod tests {
         ($($dim:expr),+ $(,)?) => {
             pastey::paste! {
                 $(
+                    #[test]
+                    fn [<reverse_simplex_orientations_retains_nested_rollback_ $dim d>]() {
+                        assert_reverse_simplex_orientations_retains_nested_rollback::<$dim>();
+                    }
+
                     #[test]
                     fn [<reverse_simplex_orientations_rejects_malformed_neighbors_without_mutation_ $dim d>]() {
                         assert_reverse_simplex_orientations_rejects_malformed_neighbors_without_mutation::<$dim>();

--- a/src/triangulation/draft.rs
+++ b/src/triangulation/draft.rs
@@ -263,9 +263,12 @@ mod test_support {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::tds::TdsBuilder;
+    use crate::core::tds::{GeometricError, InvariantError, TdsBuilder, TdsError};
     use crate::geometry::kernel::AdaptiveKernel;
+    use crate::topology::traits::topological_space::TopologyKind;
+    use crate::triangulation::validation::TriangulationValidationError;
     use crate::vertex;
+    use std::assert_matches;
 
     #[test]
     fn explicit_connectivity_publishes_without_selecting_delaunay_connectivity() {
@@ -327,5 +330,122 @@ mod tests {
                 .finish(TriangulationBuildMode::Canonicalizing)
                 .is_err()
         );
+    }
+
+    #[test]
+    fn transactional_publication_rejects_degeneracy_and_retains_the_journal() {
+        let vertices = [
+            vertex![0.0, 0.0].unwrap(),
+            vertex![1.0, 0.0].unwrap(),
+            vertex![2.0, 0.0].unwrap(),
+        ];
+        let mut tds = TdsBuilder::new(&vertices, &[vec![0, 1, 2]])
+            .build()
+            .unwrap();
+        let expected_snapshot = serde_json::to_value(&tds).unwrap();
+        let expected_owner = tds.topology_owner_id();
+        let expected_generation = tds.generation();
+        let savepoint = tds.begin_rollback_savepoint();
+
+        let failure = TriangulationDraft::with_topology_context(
+            tds,
+            AdaptiveKernel::new(),
+            TopologyGuarantee::DEFAULT,
+            GlobalTopology::DEFAULT,
+        )
+        .finish_canonicalizing_in_transaction()
+        .expect_err("a zero-area simplex must fail geometric publication");
+        assert_matches!(
+            failure.reason(),
+            TriangulationBuilderError::GeometricNondegeneracy { source }
+                if matches!(source.as_ref(), TdsError::Geometric {
+                    source: GeometricError::DegenerateOrientation { .. },
+                })
+        );
+
+        let mut recovered = failure.into_owner();
+        recovered.rollback_savepoint(savepoint);
+        assert_eq!(recovered.topology_owner_id(), expected_owner);
+        assert_eq!(recovered.generation(), expected_generation);
+        assert_eq!(serde_json::to_value(&recovered).unwrap(), expected_snapshot);
+        recovered.validate().unwrap();
+    }
+
+    #[test]
+    fn transactional_publication_rolls_back_late_failure_and_can_retry() {
+        let vertices = [
+            vertex![0.0, 0.0].unwrap(),
+            vertex![1.0, 0.0].unwrap(),
+            vertex![0.0, 1.0].unwrap(),
+        ];
+        let mut tds = TdsBuilder::new(&vertices, &[vec![0, 2, 1]])
+            .build()
+            .unwrap();
+        let expected_snapshot = serde_json::to_value(&tds).unwrap();
+        let expected_owner = tds.topology_owner_id();
+        let expected_generation = tds.generation();
+        let expected_vertex_keys: Vec<_> = tds.vertex_keys().collect();
+        let (simplex_key, simplex) = tds.simplices().next().unwrap();
+        let simplex_uuid = simplex.uuid();
+        let savepoint = tds.begin_rollback_savepoint();
+
+        let failure = TriangulationDraft::with_topology_context(
+            tds,
+            AdaptiveKernel::new(),
+            TopologyGuarantee::DEFAULT,
+            GlobalTopology::Spherical,
+        )
+        .finish_canonicalizing_in_transaction()
+        .expect_err("an open triangle cannot publish as a closed sphere");
+        assert_matches!(
+            failure.reason(),
+            TriangulationBuilderError::TopologyValidation { source }
+                if matches!(source.as_ref(), InvariantError::Triangulation {
+                    source: TriangulationValidationError::BoundaryFacetInClosedTopology {
+                        topology: TopologyKind::Spherical,
+                        simplex_key: key,
+                        simplex_uuid: uuid,
+                        ..
+                    },
+                } if *key == simplex_key && *uuid == simplex_uuid)
+        );
+
+        let mut recovered = failure.into_owner();
+        assert_ne!(recovered.generation(), expected_generation);
+        assert_ne!(serde_json::to_value(&recovered).unwrap(), expected_snapshot);
+        recovered.rollback_savepoint(savepoint);
+        assert_eq!(recovered.topology_owner_id(), expected_owner);
+        assert_eq!(recovered.generation(), expected_generation);
+        assert_eq!(
+            recovered.vertex_keys().collect::<Vec<_>>(),
+            expected_vertex_keys
+        );
+        assert_eq!(recovered.simplex_keys().collect::<Vec<_>>(), [simplex_key]);
+        assert_eq!(serde_json::to_value(&recovered).unwrap(), expected_snapshot);
+        recovered.validate().unwrap();
+
+        let retry_savepoint = recovered.begin_rollback_savepoint();
+        let triangulation = TriangulationDraft::with_topology_context(
+            recovered,
+            AdaptiveKernel::new(),
+            TopologyGuarantee::DEFAULT,
+            GlobalTopology::Euclidean,
+        )
+        .finish_canonicalizing_in_transaction()
+        .expect("the recovered triangle should publish with Euclidean topology");
+        assert_eq!(
+            triangulation.validation_policy(),
+            TopologyGuarantee::DEFAULT.default_validation_policy()
+        );
+        triangulation.validate_realization().unwrap();
+        let mut published = triangulation.into_tds();
+        published.commit_savepoint(retry_savepoint);
+        assert_eq!(published.topology_owner_id(), expected_owner);
+        assert_eq!(
+            published.vertex_keys().collect::<Vec<_>>(),
+            expected_vertex_keys
+        );
+        assert_eq!(published.simplex_keys().collect::<Vec<_>>(), [simplex_key]);
+        assert_eq!(published.simplex(simplex_key).unwrap().uuid(), simplex_uuid);
     }
 }

--- a/src/triangulation/realization.rs
+++ b/src/triangulation/realization.rs
@@ -2544,6 +2544,155 @@ mod tests {
         }
     }
 
+    fn assert_periodic_shift_range_limits<const D: usize>() {
+        // Quarter-unit simplices leave a margin inside a unit-period chart.
+        let mut base_coords = vec![[0.0; D]; D + 1];
+        for axis in 0..D {
+            base_coords[axis + 1][axis] = 0.25;
+        }
+        let axis = D - 1;
+        // These exact integer bounds straddle each end of the i32 range.
+        let cases = [
+            (2_147_483_647.0, Ok((i32::MIN, -2_147_483_646))),
+            (2_147_483_648.0, Err((-2_147_483_649.0, -2_147_483_647.0))),
+            (-2_147_483_646.0, Ok((2_147_483_645, i32::MAX))),
+            (-2_147_483_647.0, Err((2_147_483_646.0, 2_147_483_648.0))),
+        ];
+        for (displacement, expected) in cases {
+            let mut coords = base_coords.clone();
+            coords.extend(base_coords.iter().map(|point| {
+                let mut translated = *point;
+                translated[axis] += displacement;
+                translated
+            }));
+            let (tds, keys) = tds_from_vertices_and_simplices_with_keys(
+                &coords,
+                &[(0..=D).collect(), (D + 1..2 * (D + 1)).collect()],
+            );
+            let tri = tri_from_tds(tds);
+            let realized = tri.collect_realized_simplices().unwrap();
+            let first = realized
+                .iter()
+                .find(|simplex| simplex.key == keys[0])
+                .unwrap();
+            let second = realized
+                .iter()
+                .find(|simplex| simplex.key == keys[1])
+                .unwrap();
+            let result = periodic_shift_ranges(first, second, &[1.0; D]);
+
+            match expected {
+                Ok(bounds) => {
+                    let ranges = result.expect("representable shift bounds must be accepted");
+                    assert_eq!(ranges.len(), D);
+                    assert_eq!(ranges[axis], bounds);
+                    assert!(ranges[..axis].iter().all(|range| *range == (-1, 1)));
+                }
+                Err((expected_lower, expected_upper)) => {
+                    let error = result.expect_err("out-of-range shifts must not truncate or clamp");
+                    let TriangulationRealizationValidationError::PeriodicTranslateRangeOverflow {
+                        first_simplex_key,
+                        first_simplex_uuid,
+                        second_simplex_key,
+                        second_simplex_uuid,
+                        detail,
+                        axis: reported_axis,
+                        lower_bound,
+                        upper_bound,
+                    } = error
+                    else {
+                        panic!("expected periodic range overflow, got {error:?}");
+                    };
+                    assert_eq!(reported_axis, axis);
+                    assert_abs_diff_eq!(lower_bound, expected_lower, epsilon = 0.0);
+                    assert_abs_diff_eq!(upper_bound, expected_upper, epsilon = 0.0);
+                    assert_eq!(
+                        (first_simplex_key, first_simplex_uuid),
+                        (first.key, first.uuid)
+                    );
+                    assert_eq!(
+                        (second_simplex_key, second_simplex_uuid),
+                        (second.key, second.uuid)
+                    );
+                    assert_eq!(detail.first_simplex, first.detail());
+                    assert_eq!(detail.second_simplex, second.detail());
+                }
+            }
+        }
+    }
+
+    fn assert_translation_overflow_preserves_vertex_diagnostic<const D: usize>() {
+        let axis = D - 1;
+        for (extreme, step, expected_value) in [
+            (f64::MAX, 1, InvalidCoordinateValue::PositiveInfinity),
+            (-f64::MAX, -1, InvalidCoordinateValue::NegativeInfinity),
+        ] {
+            let mut coords = vec![[0.0; D]; D + 1];
+            for coordinate_axis in 0..D {
+                coords[coordinate_axis + 1][coordinate_axis] = 0.25;
+            }
+            coords[D][axis] = extreme;
+            let tri = tri_from_tds(tds_from_vertices_and_simplices(
+                &coords,
+                &[(0..=D).collect()],
+            ));
+            let realized = tri.collect_realized_simplices().unwrap().pop().unwrap();
+            let mut periods = [1.0; D];
+            periods[axis] = f64::MAX;
+            let mut shift = [0; D];
+            shift[axis] = step;
+
+            // Earlier vertices translate to finite +/-MAX. Only the last vertex overflows.
+            let error = translated_simplex(&realized, &periods, &shift)
+                .expect_err("an unrepresentable translated coordinate must be rejected");
+            let TriangulationRealizationValidationError::CoordinateValidation {
+                simplex_key,
+                simplex_uuid,
+                vertex_key,
+                vertex_uuid,
+                source,
+            } = error
+            else {
+                panic!("expected coordinate validation failure, got {error:?}");
+            };
+            assert_eq!((simplex_key, simplex_uuid), (realized.key, realized.uuid));
+            assert_eq!(vertex_key, realized.vertex_keys[D]);
+            assert_eq!(vertex_uuid, realized.vertex_uuids[D]);
+            assert_eq!(
+                source,
+                CoordinateValidationError::InvalidCoordinate {
+                    coordinate_index: axis,
+                    coordinate_value: expected_value,
+                    dimension: D,
+                }
+            );
+
+            let retry = translated_simplex(&realized, &periods, &[0; D]).unwrap();
+            assert_eq!(retry.realization.coordinates(), coords.as_slice());
+            assert_eq!(retry.realization.labels(), realized.realization.labels());
+        }
+    }
+
+    macro_rules! periodic_numeric_boundary_tests {
+        ($($dim:literal),+ $(,)?) => {
+            pastey::paste! {
+                $(
+                    #[test]
+                    fn [<periodic_shift_ranges_enforce_i32_limits_ $dim d>]() {
+                        assert_periodic_shift_range_limits::<$dim>();
+                    }
+
+                    #[test]
+                    fn [<translation_overflow_preserves_vertex_diagnostic_ $dim d>]() {
+                        assert_translation_overflow_preserves_vertex_diagnostic::<$dim>();
+                    }
+                )+
+            }
+        };
+    }
+
+    periodic_numeric_boundary_tests!(2, 3, 4, 5);
+
     #[test]
     fn point_for_identity_reports_missing_lifted_offset() {
         let coords = [[0.9, 0.1], [0.1, 0.1], [0.9, 0.3]];

--- a/tests/semgrep/.github/workflows/release-uv-cache.yml
+++ b/tests/semgrep/.github/workflows/release-uv-cache.yml
@@ -1,0 +1,72 @@
+name: Release uv cache fixtures
+on: workflow_dispatch
+jobs:
+  fixtures:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release cache explicitly disabled
+        # ok: delaunay.github-actions.release-setup-uv-cache-disabled
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: ${{ steps.uv_version.outputs.version }}
+          enable-cache: false
+
+      - name: Release cache defaults are forbidden
+        # ruleid: delaunay.github-actions.release-setup-uv-cache-disabled
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: ${{ steps.uv_version.outputs.version }}
+
+      # ok: delaunay.github-actions.release-setup-uv-cache-disabled
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: false
+
+      # ruleid: delaunay.github-actions.release-setup-uv-cache-disabled
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+
+      - name: Inputs before uses
+        with:
+          enable-cache: false
+        # ok: delaunay.github-actions.release-setup-uv-cache-disabled
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
+      - name: Enabled cache before uses
+        with:
+          enable-cache: true
+        # ruleid: delaunay.github-actions.release-setup-uv-cache-disabled
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
+      - name: Cache setting on another step does not apply
+        # ruleid: delaunay.github-actions.release-setup-uv-cache-disabled
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
+      - name: Quoted false is also an explicit cache disablement
+        # ok: delaunay.github-actions.release-setup-uv-cache-disabled
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: "false"
+
+      - name: Quoted true still enables the release cache
+        # ruleid: delaunay.github-actions.release-setup-uv-cache-disabled
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: "true"
+
+      - name: An unrelated release action needs no uv cache setting
+        # ok: delaunay.github-actions.release-setup-uv-cache-disabled
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          enable-cache: false
+
+      - name: Quoted action with release cache disabled
+        # ok: delaunay.github-actions.release-setup-uv-cache-disabled
+        uses: "astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d" # v10.0.1
+        with:
+          enable-cache: false
+
+      - name: Quoted action missing release cache setting
+        # ruleid: delaunay.github-actions.release-setup-uv-cache-disabled
+        uses: "astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d" # v10.0.1

--- a/tests/semgrep/.github/workflows/zizmor_policy.yml
+++ b/tests/semgrep/.github/workflows/zizmor_policy.yml
@@ -1,0 +1,80 @@
+name: Zizmor policy fixtures
+on: workflow_dispatch
+jobs:
+  fixtures:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scanner pin resolved from justfile
+        # ok: delaunay.github-actions.zizmor-tool-version-pinned
+        uses: zizmorcore/zizmor-action@cc914d7f3750a2d13d75c7f184a1060aa0e9d482 # v0.6.4
+        with:
+          inputs: .github
+          version: ${{ steps.zizmor_version.outputs.version }}
+          online-audits: true
+          persona: regular
+
+      - name: Missing scanner version
+        # ruleid: delaunay.github-actions.zizmor-tool-version-pinned
+        uses: zizmorcore/zizmor-action@cc914d7f3750a2d13d75c7f184a1060aa0e9d482 # v0.6.4
+        with:
+          inputs: .github
+          online-audits: true
+          persona: regular
+
+      # ok: delaunay.github-actions.zizmor-tool-version-pinned
+      - uses: zizmorcore/zizmor-action@cc914d7f3750a2d13d75c7f184a1060aa0e9d482 # v0.6.4
+        with:
+          version: "1.30.1"
+
+      # ruleid: delaunay.github-actions.zizmor-tool-version-pinned
+      - uses: zizmorcore/zizmor-action@cc914d7f3750a2d13d75c7f184a1060aa0e9d482 # v0.6.4
+        with:
+          version: latest
+
+      - name: Inputs before uses
+        with:
+          version: 1.30.1
+        # ok: delaunay.github-actions.zizmor-tool-version-pinned
+        uses: zizmorcore/zizmor-action@cc914d7f3750a2d13d75c7f184a1060aa0e9d482 # v0.6.4
+
+      - name: Empty version before uses
+        with:
+          version: ""
+        # ruleid: delaunay.github-actions.zizmor-tool-version-pinned
+        uses: zizmorcore/zizmor-action@cc914d7f3750a2d13d75c7f184a1060aa0e9d482 # v0.6.4
+
+      - name: Version in another mapping does not pin the scanner
+        env:
+          version: "1.30.1"
+        # ruleid: delaunay.github-actions.zizmor-tool-version-pinned
+        uses: zizmorcore/zizmor-action@cc914d7f3750a2d13d75c7f184a1060aa0e9d482 # v0.6.4
+
+      - name: Quoted version expression
+        # ok: delaunay.github-actions.zizmor-tool-version-pinned
+        uses: zizmorcore/zizmor-action@cc914d7f3750a2d13d75c7f184a1060aa0e9d482 # v0.6.4
+        with:
+          version: "${{ steps.zizmor_version.outputs.version }}"
+
+      - name: Null scanner version
+        # ruleid: delaunay.github-actions.zizmor-tool-version-pinned
+        uses: zizmorcore/zizmor-action@cc914d7f3750a2d13d75c7f184a1060aa0e9d482 # v0.6.4
+        with:
+          version:
+
+      - name: Quoted action with scanner pin
+        # ok: delaunay.github-actions.zizmor-tool-version-pinned
+        uses: "zizmorcore/zizmor-action@cc914d7f3750a2d13d75c7f184a1060aa0e9d482" # v0.6.4
+        with:
+          version: "1.30.1"
+
+      - name: Quoted action missing scanner pin
+        # ruleid: delaunay.github-actions.zizmor-tool-version-pinned
+        uses: "zizmorcore/zizmor-action@cc914d7f3750a2d13d75c7f184a1060aa0e9d482" # v0.6.4
+
+      # ok: delaunay.github-actions.zizmor-tool-version-pinned
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Ordinary CI may retain uv caching
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true

--- a/uv.lock
+++ b/uv.lock
@@ -1722,30 +1722,30 @@ wheels = [
 
 [[package]]
 name = "polars"
-version = "1.44.1"
+version = "1.44.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "polars-runtime-32" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/73/258a1fe17bb2744a507199566ed712663144fdd0811b615b59a47dfa38d2/polars-1.44.1.tar.gz", hash = "sha256:ef3c89e9ebbbe8eb343c06873f1945683f8b6f97a1bdf001c60551c6c5e3cda1", size = 765660, upload-time = "2026-08-26T07:09:12.704Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/15/e8541eefc22fbc7ca89bcb5112298a153729f73cfbc0cf6a668e509f975c/polars-1.44.2.tar.gz", hash = "sha256:86c8e26b6c2de8c8d344bb910b74dfc47b118ac3fe0f19b44909467990a0b281", size = 766272, upload-time = "2026-09-09T07:42:08.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/f1/59154659081930fbde291ea6225607956b500a71b0ce45d88217b7d32da2/polars-1.44.1-py3-none-any.whl", hash = "sha256:1fa62fc1c88fba77a68b28291b5aabdd69e5f38b34e59721a064ae3169b59bb5", size = 865208, upload-time = "2026-08-26T07:07:44.646Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6d/3014112c7f717d1253223faa13b6db3ac3a64ed00ab2a3bc1b942bc9cdd4/polars-1.44.2-py3-none-any.whl", hash = "sha256:1bb331f17a40d9d931101533dcd33637b66edc61eb377b07020dac16a0f0377b", size = 865768, upload-time = "2026-09-09T07:40:12.053Z" },
 ]
 
 [[package]]
 name = "polars-runtime-32"
-version = "1.44.1"
+version = "1.44.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fd/b2/2a76415d047a45df05489f2334c91ff120a274cf655d4ca030c7f54a8743/polars_runtime_32-1.44.1.tar.gz", hash = "sha256:abd10a54ed1caff42228610fcba0f93251f9870bd7cffb0c78bc26f5e0718ce4", size = 3171156, upload-time = "2026-08-26T07:09:14.243Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/a1/a7eace6587b56f22cf2a21ab4d5e695db372dc23fd96accb68b1ec12660b/polars_runtime_32-1.44.2.tar.gz", hash = "sha256:b84842f7d621aaca7a52e165e19a24f89db45f8aa13744941430218419a14a67", size = 3172205, upload-time = "2026-09-09T07:42:10.851Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/93/ef9344dcec16757cf21027dc907ef989197e50742cfe4407f2e87edb0a7f/polars_runtime_32-1.44.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:1dfccb2b52aa50468a7d28e3e61c8338a13fb5bffc8646e388a649f5bdc6b463", size = 53962370, upload-time = "2026-08-26T07:07:47.21Z" },
-    { url = "https://files.pythonhosted.org/packages/10/da/38b32b7901af33f1fee2172ceaa39e9159825657920064298917392d78fa/polars_runtime_32-1.44.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:0580807dc3eed258f0db70bb65d905dd43f0135392119ec25308033ae24258fb", size = 48620468, upload-time = "2026-08-26T07:07:50.436Z" },
-    { url = "https://files.pythonhosted.org/packages/49/51/185af877d1d2236671493cf72bd3327a6046240eeea69c0696d1af2a5acb/polars_runtime_32-1.44.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0627f9aa82cb869725235e5188f698862fd9ada0c8c1cf65c3dc5a49a4a0ec26", size = 52455947, upload-time = "2026-08-26T07:07:53.776Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/0a/0858f60cb5a6f8f73ec4cdd73eccd9f748d66bfc23304c5c23fa3468094a/polars_runtime_32-1.44.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eea4283be8e60822d890dbda20588fe59b4172b508bd5ebf3471e531ca9f50d7", size = 58561262, upload-time = "2026-08-26T07:07:57.508Z" },
-    { url = "https://files.pythonhosted.org/packages/73/08/de4774b5612d7c8739f89ac01b601486b4f057b1da35a5b876bf9276fd95/polars_runtime_32-1.44.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:04e2c0f46e7a9906fffb1897f18f23b079b74f83c56b50060bace9e7b9b49b1a", size = 52636064, upload-time = "2026-08-26T07:08:06.337Z" },
-    { url = "https://files.pythonhosted.org/packages/98/ac/769c598dd106e2a6647798da3ed25ddeee67f2d12c04f5da316cb3da6360/polars_runtime_32-1.44.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:0956f0cae632d8fad3a04b4315bf2bb69b56d10c83c79a75c2c4c5a13b9ce5cc", size = 56447612, upload-time = "2026-08-26T07:08:12.36Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/ee/98408296e15388020b6183323fdbe78ccab4f72c20d8e0d7092c062d3ad2/polars_runtime_32-1.44.1-cp310-abi3-win_amd64.whl", hash = "sha256:159334184e6fbb074c9f4692221ea19970a5e2bed2a479f9d7bdb00b7f3eedb9", size = 53702970, upload-time = "2026-08-26T07:08:15.398Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/9d/8b17e075aac73c881a50b6c1f690d20df46db2f3bcabc99f600ecdee1290/polars_runtime_32-1.44.1-cp310-abi3-win_arm64.whl", hash = "sha256:3ba28d638d0513e0b4afbcdab5c0059a85021e5f81d62b5f793e7e23badb2cf7", size = 47281050, upload-time = "2026-08-26T07:08:18.43Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5b/a5215f82c3dd443dc5d6911b0d3e937f97056e0ef7753f7e123422481a18/polars_runtime_32-1.44.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:1fd536720668ba203a16a20b08cd6b23057e407a0279cf36b2f35f879d6e3208", size = 48334014, upload-time = "2026-09-09T07:40:16.43Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e0/f3dc93fce4b4e99370db6a89001a1b8d3c606e3560d0d91dda809d6c6324/polars_runtime_32-1.44.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0fd43720c8222ae39919c8ff891636d53b352706087120e62f83544dd3ff782", size = 43331099, upload-time = "2026-09-09T07:40:21.029Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/4f/076626ce93ddd622203c4b27be2a96d034cf5b24110c52e96e6029f0ea33/polars_runtime_32-1.44.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bbf9b45040291dc1c6c588c837019c33557bde25ec536562a9cca9e1f6dfcc45", size = 46590853, upload-time = "2026-09-09T07:40:24.934Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/24/ed9982657c446dd5491b089370eea196725673570cfc61f7225a9fdd7ef0/polars_runtime_32-1.44.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1bafb441e99199a62c63bf1bbdc0ea09ee9776dbac2bf31452b5000fb1df2f7", size = 49912258, upload-time = "2026-09-09T07:40:29.238Z" },
+    { url = "https://files.pythonhosted.org/packages/71/42/5490ab360aa2406119825ad82203a5e2ff27a3a5893ca8e0b93c053a59a3/polars_runtime_32-1.44.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:10c0c695a418407617b5159db7d9a21074a733e4c6d61275b6762f25cb31ca99", size = 46737310, upload-time = "2026-09-09T07:40:33.143Z" },
+    { url = "https://files.pythonhosted.org/packages/06/8f/d741afb1dcd1848161189e017d27972e7e78556d8dce66b94d4235093706/polars_runtime_32-1.44.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c4a09fb14aad711526346efc0cb2015c2fd0555ce4118b6524e5debbaea65ff5", size = 49887654, upload-time = "2026-09-09T07:40:37.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/e7/c61c1c7eea37705920fe7c1302d1dd80d1165db2b928f0da3eae6d1ebb75/polars_runtime_32-1.44.2-cp310-abi3-win_amd64.whl", hash = "sha256:8598e7a20efba70bb74978c7df7af7c606ff4d79b9b48fdd808250b189bc9a13", size = 51297967, upload-time = "2026-09-09T07:40:41.993Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/a0/d0dd0d2ec95fa328dd47055905fae53ba3cd79f11c8973326ebe75a49e4c/polars_runtime_32-1.44.2-cp310-abi3-win_arm64.whl", hash = "sha256:d51040d3ab40157f6db3c62be59cab5b80fb3c8d158924769c4982a1c8eef730", size = 44303345, upload-time = "2026-09-09T07:40:47.081Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Reject unsupported uv versions before dependency or Cargo tool updates, while allowing newer stable versions to become the reconciled pin.
- Share the pinned zizmor version and regular persona between local audits and the GitHub SARIF workflow.
- Resolve local audit credentials from environment variables or GitHub CLI authentication, with an explicit offline fallback.
- Add Semgrep guards for explicit zizmor versions and disabled setup-uv caching in release workflows.
- Update zizmor to 1.30.1, zizmor-action to 0.6.4, and Polars to 1.44.2.
- Clarify Python fixture lint requirements in the development guidance.

Closes #592
Closes #593