### PR TITLE
fix(benchmarks)!: correct proof fixtures and release publication

### DIFF
--- a/.github/workflows/release-benchmarks.yml
+++ b/.github/workflows/release-benchmarks.yml
@@ -5,15 +5,18 @@ name: Release Benchmarks
 # released-version comparisons.
 
 permissions:
-  contents: write
+  contents: read
 
 on:
-  release:
-    types:
-      - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing stable vX.Y.Z tag with a mutable draft release
+        required: true
+        type: string
 
 concurrency:
-  group: release-benchmarks-${{ github.event.release.tag_name }}
+  group: release-benchmarks-${{ inputs.tag }}
   cancel-in-progress: false
 
 env:
@@ -24,13 +27,31 @@ jobs:
   release-baseline:
     runs-on: ubuntu-latest
     timeout-minutes: 150
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.sha }}
+
+      - name: Validate draft release target
+        id: target
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          bash scripts/release_benchmarks.sh preflight
+          cp scripts/release_benchmarks.sh "$RUNNER_TEMP/release_benchmarks.sh"
+
+      - name: Check out exact release commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ steps.target.outputs.commit }}
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -67,15 +88,9 @@ jobs:
 
       - name: Generate release benchmark summary
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-
-          trusted_tag_re='^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
-          if [[ ! "$RELEASE_TAG" =~ $trusted_tag_re ]]; then
-            echo "❌ Release benchmark assets require a semver tag, got: $RELEASE_TAG" >&2
-            exit 1
-          fi
 
           mkdir -p release-benchmark-artifacts
           just bench-latest 3600
@@ -89,7 +104,7 @@ jobs:
       - name: Package release Criterion baseline
         id: package-baseline
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
 
@@ -111,20 +126,21 @@ jobs:
       - name: Upload temporary release benchmark artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: release-benchmark-baseline-${{ github.event.release.tag_name }}
+          name: release-benchmark-baseline-${{ inputs.tag }}
           path: ${{ steps.package-baseline.outputs.asset }}
           retention-days: 30
           if-no-files-found: error
 
-      - name: Attach baseline to GitHub Release
+      - name: Attach baseline and publish draft
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          RELEASE_ASSET: ${{ steps.package-baseline.outputs.asset }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          EXPECTED_RELEASE_ID: ${{ steps.target.outputs.release_id }}
+          EXPECTED_COMMIT: ${{ steps.target.outputs.commit }}
         run: |
           set -euo pipefail
 
-          gh release upload "$RELEASE_TAG" "$RELEASE_ASSET" --clobber
+          bash "$RUNNER_TEMP/release_benchmarks.sh" publish
 
       - name: Release benchmark summary
         env:

--- a/benches/README.md
+++ b/benches/README.md
@@ -36,9 +36,11 @@ under `benches/`. These commands are intentionally cheaper and less formal than
 the release-signal workflow.
 
 Use release-signal benchmarks for release evidence. They are slower, more
-formal, and tied to release artifacts and report metadata. Publishing a GitHub
-Release triggers `.github/workflows/release-benchmarks.yml`, which attaches
-`delaunay-vX.Y.Z-criterion-baseline.tar.gz` to the release. That archive
+formal, and tied to release artifacts and report metadata. Create a draft GitHub
+Release for an existing stable tag, then dispatch
+`.github/workflows/release-benchmarks.yml` with that `tag`. It validates the
+mutable draft, benchmarks the exact tag commit, attaches and digest-verifies
+`delaunay-vX.Y.Z-criterion-baseline.tar.gz`, and publishes only after success. That archive
 contains `PERFORMANCE_RESULTS.md`, `baseline_results.txt`, raw Criterion data
 under `criterion/`, and `metadata.json`.
 
@@ -51,8 +53,8 @@ Common maintainer flows:
 - During release PR preparation: run `just performance-release`, then
   `just performance-readme`, to update the curated report, archive its
   predecessor, and publish the matching README snapshot.
-- After a GitHub Release publishes: confirm the release benchmark workflow
-  attached `delaunay-vX.Y.Z-criterion-baseline.tar.gz`; use
+- After the draft benchmark workflow publishes: confirm the release contains
+  `delaunay-vX.Y.Z-criterion-baseline.tar.gz`; use
   `just performance-github-assets 'current-tag' 'baseline-tag'` when you need a
   report from stored release assets.
 
@@ -64,6 +66,24 @@ and render a Markdown comparison with `just bench-compare <baseline>`.
 `just bench-latest-vs-last` combines the fresh measurement and report rendering
 for the common local saved-baseline case. Use `just performance-local` when you
 want the tool to manage isolated baseline/current worktrees for you.
+
+`just bench-preflight` executes every curated target with Criterion `--test`:
+fixture setup and one operation per case, with a ten-minute ceiling per target
+including compilation. It writes no timing evidence or measurement sidecars.
+`just bench-latest` runs that entire preflight before any full sampling. Fatal
+setup and operation errors always print to stderr, including with
+`bench-logging` disabled or `RUST_LOG=off`.
+
+Draft workflow reruns never overwrite existing evidence. Failures before upload
+can be retried with the same tag. If an archive is already attached, inspect it
+and remove it from the mutable draft before rerunning; published releases are
+always rejected. Follow the full [draft-run-publish sequence](../docs/RELEASING.md).
+
+The corrected proof-aware contract begins at v0.8.2. Establish that release's
+absolute baseline with `just bench-perf-summary` after updating release
+metadata; begin release-to-release comparisons once two comparable releases
+under the new contract exist. Historical reports keep their original version
+labels and are not converted into new-contract evidence.
 
 The canonical `performance-*` release recipes consume local worktrees,
 published release assets, or retained inputs:
@@ -391,15 +411,25 @@ cargo bench --profile perf --bench ci_performance_suite
   topology, Level 4 realization, and Level 5 Delaunay predicate checks
 - incremental vertex insertion into prepared triangulations
 - explicit 2D-5D bistellar flip roundtrips
+- explicit connectivity import and raw-TDS promotion under `Pseudomanifold`
+- Level 5 certification of a `PLManifold` owner retaining construction provenance
+
+The `explicit_import/import_pseudomanifold_*` and
+`proof_boundaries/promote_pseudomanifold_*` cases intentionally measure the
+incidence contract in every dimension. Arbitrary connectivity cannot recover
+high-dimensional PL-manifold construction provenance. The independent
+`proof_boundaries/certify_pl_manifold_*` cases retain their proof-bearing owner
+from point construction. These names distinguish the corrected contracts from
+historical timings; do not relabel old evidence as the new cases.
 
 The current calibrated fixture sizes are:
 
 | Dimension | Fixture vertices | Insert batch |
 |-----------|------------------|--------------|
-| 2D | 4,000 | 10 |
-| 3D | 750 | 10 |
-| 4D | 75 | 6 |
-| 5D | 25 | 4 |
+| 2D | 500 | 10 |
+| 3D | 100 | 10 |
+| 4D | 30 | 6 |
+| 5D | 12 | 4 |
 
 The same fixture sizes are reused for construction, adversarial construction,
 validation, hull extraction, boundary traversal, and insertion bases. This keeps
@@ -421,7 +451,7 @@ benchmark emits only the selected construction metric and exits before sampling:
 ```bash
 DELAUNAY_BENCH_EXPORT_METRICS=1 \
   cargo bench --profile perf --bench ci_performance_suite -- \
-  "tds_new_3d/tds_new/750"
+  "tds_new_3d/tds_new/100"
 ```
 
 Use `just bench-perf-summary` for release summaries; it runs the full perf
@@ -669,8 +699,8 @@ these large random construction fixtures.
 
 Each mode is validated once as an untimed preflight; Criterion measures only
 construction and the selected insertion-time audit cadence. The suite is
-excluded from the pull-request regression set, remains available for manual
-topology-policy work, and is also archived by the release benchmark workflow.
+excluded from the pull-request and curated release-signal sets and remains
+available for manual topology-policy work.
 
 ## Generated Summaries
 

--- a/benches/ci_performance_suite.rs
+++ b/benches/ci_performance_suite.rs
@@ -86,10 +86,10 @@ use flip_workflows::{CandidateFilter, FlipTriangulation};
 /// keeping each normal construction benchmark around one second on release
 /// hardware. The adversarial variants use the same vertex counts and may take
 /// longer.
-const CANARY_COUNT_2D: usize = 4_000;
-const CANARY_COUNT_3D: usize = 750;
-const CANARY_COUNT_4D: usize = 75;
-const CANARY_COUNT_5D: usize = 25;
+const CANARY_COUNT_2D: usize = 500;
+const CANARY_COUNT_3D: usize = 100;
+const CANARY_COUNT_4D: usize = 30;
+const CANARY_COUNT_5D: usize = 12;
 /// Incremental insertion batch sizes are deliberately separate from fixture
 /// sizes: these benchmarks measure adding a small batch into an existing
 /// calibrated triangulation, not rebuilding the full fixture.
@@ -107,6 +107,7 @@ type BenchGenericTriangulation<const D: usize> = Triangulation<AdaptiveKernel<f6
 struct ExplicitImportFixture<const D: usize> {
     vertices: Vec<Vertex<(), D>>,
     simplices: Vec<Vec<usize>>,
+    source: BenchGenericTriangulation<D>,
 }
 
 struct ProofBoundaryFixture<const D: usize> {
@@ -220,26 +221,6 @@ fn insert_benchmark_ids() -> String {
     .join(";")
 }
 
-fn explicit_import_benchmark_ids() -> String {
-    [
-        format!("explicit_import/import_2d/{EXPLICIT_IMPORT_COUNT_2D}"),
-        format!("explicit_import/import_3d/{EXPLICIT_IMPORT_COUNT_3D}"),
-        format!("explicit_import/import_4d/{EXPLICIT_IMPORT_COUNT_4D}"),
-        format!("explicit_import/import_5d/{EXPLICIT_IMPORT_COUNT_5D}"),
-    ]
-    .join(";")
-}
-
-fn proof_boundary_benchmark_ids() -> String {
-    [
-        "proof_boundaries/{promote_default_strict_2d,promote_canonicalizing_2d,certify_2d}",
-        "proof_boundaries/{promote_default_strict_3d,promote_canonicalizing_3d,certify_3d}",
-        "proof_boundaries/{promote_default_strict_4d,promote_canonicalizing_4d,certify_4d}",
-        "proof_boundaries/{promote_default_strict_5d,promote_canonicalizing_5d,certify_5d}",
-    ]
-    .join(";")
-}
-
 fn api_benchmark_entries() -> Vec<ApiBenchmarkEntry> {
     vec![
         ApiBenchmarkEntry {
@@ -288,15 +269,16 @@ fn api_benchmark_entries() -> Vec<ApiBenchmarkEntry> {
             group: "explicit_import",
             public_api: "DelaunayTriangulationBuilder::try_from_vertices_and_simplices(...).build_triangulation",
             dimensions: "2,3,4,5",
-            benchmark_ids: explicit_import_benchmark_ids(),
-            note: "reimport_valid_levels_1_through_4_connectivity_from_public_vertex_and_simplex_iterators",
+            // Exact IDs include simplex counts and are emitted with each fixture.
+            benchmark_ids: String::new(),
+            note: "reimport_levels_1_through_4_connectivity_with_explicit_pseudomanifold_guarantee",
         },
         ApiBenchmarkEntry {
             group: "proof_boundaries",
             public_api: "TriangulationBuilder::new(...).build();DelaunayRefinementBuilder::new(...).build()",
             dimensions: "2,3,4,5",
-            benchmark_ids: proof_boundary_benchmark_ids(),
-            note: "compare_default_strict_and_canonicalizing_level_3_4_promotion_then_measure_strict_level_5_certification_independently",
+            benchmark_ids: String::new(),
+            note: "raw_tds_pseudomanifold_promotion_and_independent_level_5_certification_of_proof_bearing_pl_manifold_owner",
         },
         ApiBenchmarkEntry {
             group: "bistellar_flips",
@@ -344,7 +326,7 @@ fn api_benchmark_entries() -> Vec<ApiBenchmarkEntry> {
 /// ```
 ///
 /// (Use a Criterion filter for individual cases, e.g.
-///  `-- "tds_new_5d/tds_new/25"`)
+///  `-- "tds_new_5d/tds_new/12"`)
 const KNOWN_SEEDS: &[(usize, usize, u64)] = &[
     (2, CANARY_COUNT_2D, 4042),
     (3, CANARY_COUNT_3D, 873),
@@ -515,6 +497,7 @@ where
     ExplicitImportFixture {
         vertices,
         simplices,
+        source: dt.into_triangulation(),
     }
 }
 
@@ -526,16 +509,12 @@ fn prepare_proof_boundary_fixture<const D: usize>(
 where
     AdaptiveKernel<f64>: ExactPredicates<D>,
 {
-    let import = prepare_explicit_import_fixture::<D>(dim_seed, count);
-    let triangulation: BenchGenericTriangulation<D> =
-        DelaunayTriangulationBuilder::try_from_vertices_and_simplices(
-            &import.vertices,
-            &import.simplices,
-        )
-        .or_abort()
-        .build_triangulation()
-        .or_abort();
-    let topology_guarantee = triangulation.topology_guarantee();
+    // Retain construction provenance for Level 5 certification. Raw TDS
+    // promotion cannot recover that provenance, so it measures the explicit
+    // pseudomanifold contract in every dimension instead.
+    let triangulation = prepare_explicit_import_fixture::<D>(dim_seed, count).source;
+    triangulation.validate_realization().or_abort();
+    let topology_guarantee = TopologyGuarantee::Pseudomanifold;
     let global_topology = triangulation.global_topology();
     let simplex_count = triangulation.number_of_simplices();
     let tds = triangulation.clone().into_tds();
@@ -1494,15 +1473,16 @@ fn bench_explicit_import_case<const D: usize>(
     AdaptiveKernel<f64>: ExactPredicates<D>,
 {
     group.throughput(Throughput::Elements(fixture.simplices.len() as u64));
+    let parameter = format!(
+        "vertices_{}_simplices_{}",
+        fixture.vertices.len(),
+        fixture.simplices.len()
+    );
+    println!(
+        "api_benchmark group=explicit_import benchmark_ids=explicit_import/import_pseudomanifold_{D}d/{parameter}"
+    );
     group.bench_function(
-        BenchmarkId::new(
-            format!("import_{D}d"),
-            format!(
-                "vertices_{}_simplices_{}",
-                fixture.vertices.len(),
-                fixture.simplices.len()
-            ),
-        ),
+        BenchmarkId::new(format!("import_pseudomanifold_{D}d"), parameter),
         |b| {
             b.iter(|| {
                 let dt = DelaunayTriangulationBuilder::try_from_vertices_and_simplices(
@@ -1510,6 +1490,7 @@ fn bench_explicit_import_case<const D: usize>(
                     &fixture.simplices,
                 )
                 .or_abort()
+                .topology_guarantee(TopologyGuarantee::Pseudomanifold)
                 .build_triangulation()
                 .or_abort();
                 black_box(dt);
@@ -1523,9 +1504,12 @@ fn bench_proof_boundary_case<const D: usize>(
     fixture: &ProofBoundaryFixture<D>,
 ) {
     let parameter = format!("simplices_{}", fixture.simplex_count);
+    println!(
+        "api_benchmark group=proof_boundaries benchmark_ids=proof_boundaries/{{promote_pseudomanifold_strict_{D}d,promote_pseudomanifold_canonicalizing_{D}d,certify_pl_manifold_{D}d}}/{parameter}"
+    );
     group.throughput(Throughput::Elements(fixture.simplex_count as u64));
     group.bench_function(
-        BenchmarkId::new(format!("promote_default_strict_{D}d"), &parameter),
+        BenchmarkId::new(format!("promote_pseudomanifold_strict_{D}d"), &parameter),
         |b| {
             b.iter_batched(
                 || (fixture.tds.clone(), AdaptiveKernel::new()),
@@ -1543,7 +1527,10 @@ fn bench_proof_boundary_case<const D: usize>(
         },
     );
     group.bench_function(
-        BenchmarkId::new(format!("promote_canonicalizing_{D}d"), &parameter),
+        BenchmarkId::new(
+            format!("promote_pseudomanifold_canonicalizing_{D}d"),
+            &parameter,
+        ),
         |b| {
             b.iter_batched(
                 || (fixture.tds.clone(), AdaptiveKernel::new()),
@@ -1561,19 +1548,22 @@ fn bench_proof_boundary_case<const D: usize>(
             );
         },
     );
-    group.bench_function(BenchmarkId::new(format!("certify_{D}d"), parameter), |b| {
-        b.iter_batched(
-            || fixture.triangulation.clone(),
-            |triangulation| {
-                black_box(
-                    DelaunayRefinementBuilder::new(triangulation)
-                        .build()
-                        .or_abort(),
-                );
-            },
-            BatchSize::LargeInput,
-        );
-    });
+    group.bench_function(
+        BenchmarkId::new(format!("certify_pl_manifold_{D}d"), parameter),
+        |b| {
+            b.iter_batched(
+                || fixture.triangulation.clone(),
+                |triangulation| {
+                    black_box(
+                        DelaunayRefinementBuilder::new(triangulation)
+                            .build()
+                            .or_abort(),
+                    );
+                },
+                BatchSize::LargeInput,
+            );
+        },
+    );
 }
 
 fn benchmark_boundary_facets(c: &mut Criterion) {
@@ -1920,22 +1910,22 @@ fn benchmark_explicit_import(c: &mut Criterion) {
     let mut group = c.benchmark_group("explicit_import");
     group.sample_size(10);
 
-    if benchmark_selected(&filters, "explicit_import/import_2d") {
+    if benchmark_selected(&filters, "explicit_import/import_pseudomanifold_2d") {
         let fixture_2d = prepare_explicit_import_fixture::<2>(42, EXPLICIT_IMPORT_COUNT_2D);
         bench_explicit_import_case(&mut group, &fixture_2d);
     }
 
-    if benchmark_selected(&filters, "explicit_import/import_3d") {
+    if benchmark_selected(&filters, "explicit_import/import_pseudomanifold_3d") {
         let fixture_3d = prepare_explicit_import_fixture::<3>(123, EXPLICIT_IMPORT_COUNT_3D);
         bench_explicit_import_case(&mut group, &fixture_3d);
     }
 
-    if benchmark_selected(&filters, "explicit_import/import_4d") {
+    if benchmark_selected(&filters, "explicit_import/import_pseudomanifold_4d") {
         let fixture_4d = prepare_explicit_import_fixture::<4>(456, EXPLICIT_IMPORT_COUNT_4D);
         bench_explicit_import_case(&mut group, &fixture_4d);
     }
 
-    if benchmark_selected(&filters, "explicit_import/import_5d") {
+    if benchmark_selected(&filters, "explicit_import/import_pseudomanifold_5d") {
         let fixture_5d = prepare_explicit_import_fixture::<5>(789, EXPLICIT_IMPORT_COUNT_5D);
         bench_explicit_import_case(&mut group, &fixture_5d);
     }
@@ -1952,30 +1942,46 @@ fn benchmark_proof_boundaries(c: &mut Criterion) {
     let mut group = c.benchmark_group("proof_boundaries");
     group.sample_size(10);
 
-    if benchmark_selected(&filters, "proof_boundaries/promote_default_strict_2d")
-        || benchmark_selected(&filters, "proof_boundaries/promote_canonicalizing_2d")
-        || benchmark_selected(&filters, "proof_boundaries/certify_2d")
+    if benchmark_selected(
+        &filters,
+        "proof_boundaries/promote_pseudomanifold_strict_2d",
+    ) || benchmark_selected(
+        &filters,
+        "proof_boundaries/promote_pseudomanifold_canonicalizing_2d",
+    ) || benchmark_selected(&filters, "proof_boundaries/certify_pl_manifold_2d")
     {
         let fixture = prepare_proof_boundary_fixture::<2>(42, EXPLICIT_IMPORT_COUNT_2D);
         bench_proof_boundary_case(&mut group, &fixture);
     }
-    if benchmark_selected(&filters, "proof_boundaries/promote_default_strict_3d")
-        || benchmark_selected(&filters, "proof_boundaries/promote_canonicalizing_3d")
-        || benchmark_selected(&filters, "proof_boundaries/certify_3d")
+    if benchmark_selected(
+        &filters,
+        "proof_boundaries/promote_pseudomanifold_strict_3d",
+    ) || benchmark_selected(
+        &filters,
+        "proof_boundaries/promote_pseudomanifold_canonicalizing_3d",
+    ) || benchmark_selected(&filters, "proof_boundaries/certify_pl_manifold_3d")
     {
         let fixture = prepare_proof_boundary_fixture::<3>(123, EXPLICIT_IMPORT_COUNT_3D);
         bench_proof_boundary_case(&mut group, &fixture);
     }
-    if benchmark_selected(&filters, "proof_boundaries/promote_default_strict_4d")
-        || benchmark_selected(&filters, "proof_boundaries/promote_canonicalizing_4d")
-        || benchmark_selected(&filters, "proof_boundaries/certify_4d")
+    if benchmark_selected(
+        &filters,
+        "proof_boundaries/promote_pseudomanifold_strict_4d",
+    ) || benchmark_selected(
+        &filters,
+        "proof_boundaries/promote_pseudomanifold_canonicalizing_4d",
+    ) || benchmark_selected(&filters, "proof_boundaries/certify_pl_manifold_4d")
     {
         let fixture = prepare_proof_boundary_fixture::<4>(456, EXPLICIT_IMPORT_COUNT_4D);
         bench_proof_boundary_case(&mut group, &fixture);
     }
-    if benchmark_selected(&filters, "proof_boundaries/promote_default_strict_5d")
-        || benchmark_selected(&filters, "proof_boundaries/promote_canonicalizing_5d")
-        || benchmark_selected(&filters, "proof_boundaries/certify_5d")
+    if benchmark_selected(
+        &filters,
+        "proof_boundaries/promote_pseudomanifold_strict_5d",
+    ) || benchmark_selected(
+        &filters,
+        "proof_boundaries/promote_pseudomanifold_canonicalizing_5d",
+    ) || benchmark_selected(&filters, "proof_boundaries/certify_pl_manifold_5d")
     {
         let fixture = prepare_proof_boundary_fixture::<5>(789, EXPLICIT_IMPORT_COUNT_5D);
         bench_proof_boundary_case(&mut group, &fixture);

--- a/benches/common/bench_utils.rs
+++ b/benches/common/bench_utils.rs
@@ -6,38 +6,9 @@
 
 use std::{fmt::Display, process};
 
-#[cfg(feature = "bench-logging")]
-use std::sync::Once;
-#[cfg(feature = "bench-logging")]
-use tracing_subscriber::EnvFilter;
-
-/// Installs a default error-level tracing subscriber for fatal setup diagnostics.
-#[cfg(feature = "bench-logging")]
-fn init_tracing() {
-    static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("error"));
-        let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
-    });
-}
-
-/// Leaves benchmark tracing disabled when the `bench-logging` feature is off.
-#[cfg(not(feature = "bench-logging"))]
-#[expect(
-    dead_code,
-    reason = "no-op cfg counterpart documents that tracing setup is intentionally disabled"
-)]
-const fn init_tracing() {}
-
-/// Emits a benchmark setup failure through tracing when `bench-logging` is enabled, then exits.
+/// Prints fatal setup or measured-operation failures regardless of logging configuration.
 pub fn abort_benchmark(message: impl Display) -> ! {
-    #[cfg(feature = "bench-logging")]
-    {
-        init_tracing();
-        tracing::error!("{message}");
-    }
-    #[cfg(not(feature = "bench-logging"))]
-    let _ = message;
+    eprintln!("benchmark failed: {message}");
     process::exit(1);
 }
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -128,6 +128,19 @@ changes. Do not edit generated changelog files manually.
 
 ### 4. Generate the release performance comparison
 
+The corrected proof-aware benchmark contract starts with **v0.8.2**. For that
+first release, after updating package metadata, run `just bench-perf-summary`,
+which preflights the curated fixtures before sampling, to establish fresh
+absolute measurements. Skip the
+release-to-release comparison and README comparison publication in steps 4–5:
+v0.8.1's failed fixtures and earlier case names are not a valid baseline for
+this contract. Keep historical reports labeled with their original versions;
+do not relabel them as v0.8.2 evidence. The draft-run-publish workflow below
+attaches the first complete corrected archive to v0.8.2.
+
+From the following release onward, use two comparable releases under the new
+contract for the comparison and README publication steps.
+
 Run this after the package version has been updated:
 
 ```bash
@@ -141,9 +154,10 @@ the CSV/provenance pair after reloading it, promotes `docs/PERFORMANCE.md`, and
 archives the prior report plus the exact promoted evidence under
 `docs/archive/performance/`.
 
-The release workflow gives each of the five curated benchmark targets a
-two-hour failure ceiling and derives an outer ceiling for the complete plan
-(currently up to ten hours). These ceilings accommodate slow higher-dimensional
+The local comparison workflow gives each of the five curated benchmark targets
+a two-hour sampling ceiling plus a ten-minute preflight ceiling and derives
+an outer ceiling for the complete plan (up to ten hours and fifty minutes).
+These ceilings accommodate slow higher-dimensional
 measurements; they are not expected runtimes. A timeout in any target means the
 measurement failed: rerun the complete `just performance-release` command
 instead of promoting a partial run.
@@ -284,26 +298,44 @@ git push origin "$TAG"
 cargo publish --locked
 ```
 
-### 5. Create the GitHub release
+### 5. Create a draft GitHub release and run benchmarks
 
 ```bash
-gh release create "$TAG" --title "$TAG" --notes-from-tag
+gh release create "$TAG" --title "$TAG" --notes-from-tag --draft --verify-tag
+gh workflow run release-benchmarks.yml --ref main -f tag="$TAG"
 ```
 
-Keep the release title identical to the tag, including its leading `v`.
+Keep the release title identical to the tag, including its leading `v`. The
+workflow must already be merged to `main`. It rejects missing, prerelease,
+published, immutable, or mismatched targets before benchmarking, binds the
+draft release ID and tag commit, and checks out that exact commit.
+
+The workflow preflights every curated benchmark before full sampling, uploads
+`delaunay-$TAG-criterion-baseline.tar.gz` to the draft, verifies its SHA-256
+digest, and only then publishes the release. This ordering is required by
+[GitHub immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases).
+Do not publish the draft manually while the workflow is running.
+
+Failures before publication leave a draft. Rerun the workflow with the same
+tag after fixing the cause when no baseline asset was uploaded. If the baseline asset already
+exists, the workflow fails before measurement and never overwrites it. Inspect
+the retained Actions archive and draft asset; after resolving the failure,
+remove that asset from the still-mutable draft before rerunning. A published
+release is rejected even on a rerun; use a new release version for corrections.
 
 ### 6. Verify the durable Criterion baseline
 
-Publishing the GitHub release triggers the `Release Benchmarks` workflow.
-After it completes, verify that the release contains its long-lived baseline
-archive:
+After the explicitly dispatched `Release Benchmarks` workflow completes,
+verify that it published the release with its long-lived baseline archive:
 
 ```bash
 gh release view "$TAG" --json assets \
   --jq ".assets[] | select(.name == \"delaunay-$TAG-criterion-baseline.tar.gz\") | .name" | cat
+gh release view "$TAG" --json isDraft --jq '.isDraft' | cat
 ```
 
-The command must print `delaunay-$TAG-criterion-baseline.tar.gz`. A short-lived
+The commands must print `delaunay-$TAG-criterion-baseline.tar.gz` and `false`.
+A short-lived
 Actions artifact is not a substitute for this release asset. The archive binds
 the requested clean release tag to its source revision, measurement commands,
 toolchain, host, normalized measurement plan, completed benchmark targets,

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -436,6 +436,7 @@ measurements use the `perf` profile; `performance-doc` and
 just bench
 just bench-ci
 just bench-latest
+just bench-preflight
 just bench-latest-vs-last
 just bench-compare [baseline] [suite] [scope]
 just bench-save-baseline v0.7.8
@@ -522,10 +523,26 @@ checkout, or save an explicit baseline name with the same recipe. Use
 `just performance-local` when you want the tool to manage isolated
 baseline/current worktrees.
 
+`just bench-preflight [bench_timeout]` executes fixture setup and one operation
+for every case in every curated target using Criterion `--test`, without
+sampling, saved baselines, or measurement sidecars. Its default and maximum
+per-target ceiling is 600 seconds including compilation. `bench-latest` and
+other callers of the release plan complete all preflights before sampling the
+first target. Fatal benchmark errors always print to stderr without requiring
+`bench-logging` or an enabled tracing subscriber.
+
+The GitHub release baseline workflow is dispatched explicitly with a stable
+tag after creating its mutable draft release. It validates the target before
+benchmarking, uploads and verifies the archive, then publishes. It refuses
+existing baseline assets and published releases; see the recovery sequence in
+[`../RELEASING.md`](../RELEASING.md).
+
 Manual `just bench-latest` runs use a 30-minute timeout for each target unless
-an override is supplied. The release workflow uses a two-hour failure ceiling
-per target and derives its outer ceiling from all five curated targets
-(currently up to ten hours). A target timeout invalidates the measurement; rerun
+an override is supplied. The local `performance-release` workflow uses a
+two-hour sampling ceiling plus a ten-minute preflight ceiling per target and
+derives its outer ceiling from all five curated targets (up to ten hours and
+fifty minutes). The hosted draft workflow has a 150-minute job ceiling and a
+one-hour sampling ceiling per target. A target timeout invalidates the measurement; rerun
 the complete release workflow rather than treating partial Criterion output as
 release evidence.
 

--- a/docs/dev/rust/reference.md
+++ b/docs/dev/rust/reference.md
@@ -1127,9 +1127,10 @@ This ensures all diagnostic output is:
 - structured and machine-parseable
 - suppressible in production builds
 
-`eprintln!` is acceptable only for short-lived local debugging while
-investigating an issue. Do not leave it in committed code when `tracing`
-or a typed error path is more appropriate.
+`eprintln!` is acceptable for short-lived local debugging and the shared fatal
+benchmark adapter, which must report the underlying error even without an
+optional subscriber or with `RUST_LOG=off`. Other committed diagnostics use
+`tracing` or typed error propagation.
 
 Debug hooks gated on environment variables should still use `tracing`:
 

--- a/justfile
+++ b/justfile
@@ -1401,6 +1401,7 @@ shell-fix: _ensure-shfmt
     set -euo pipefail
     files=()
     while IFS= read -r -d '' file; do
+        [ -e "$file" ] || continue
         files+=("$file")
     done < <(git --no-pager ls-files --cached --others --exclude-standard -z '*.sh')
     if [ "${#files[@]}" -gt 0 ]; then
@@ -1418,6 +1419,7 @@ shell-fmt-check: _ensure-shfmt
     set -euo pipefail
     files=()
     while IFS= read -r -d '' file; do
+        [ -e "$file" ] || continue
         files+=("$file")
     done < <(git --no-pager ls-files --cached --others --exclude-standard -z '*.sh')
     if [ "${#files[@]}" -gt 0 ]; then
@@ -1433,6 +1435,7 @@ shell-lint: _ensure-shellcheck
     set -euo pipefail
     files=()
     while IFS= read -r -d '' file; do
+        [ -e "$file" ] || continue
         files+=("$file")
     done < <(git --no-pager ls-files --cached --others --exclude-standard -z '*.sh')
     if [ "${#files[@]}" -gt 0 ]; then

--- a/justfile
+++ b/justfile
@@ -101,6 +101,11 @@ bench-pachner-stress samples="10": (_bench-pachner-stress samples)
 bench-perf-summary: _ensure-uv
     uv run --locked benchmark-utils generate-summary --run-benchmarks --profile perf --strict
 
+# Execute every curated release fixture once without producing timing evidence.
+[group('benchmarks and performance')]
+bench-preflight bench_timeout="600": _ensure-uv
+    uv run --locked benchmark-utils run-release-signal --preflight-only --bench-timeout {{ bench_timeout }}
+
 # Save a Criterion baseline for a Delaunay benchmark suite.
 [group('benchmarks and performance')]
 bench-save-baseline tag suite="release-signal": _ensure-uv
@@ -1389,7 +1394,7 @@ setup-tools: _ensure-cargo _ensure-chktex _ensure-gh _ensure-jq _ensure-rustup _
 shell-check: shell-lint shell-fmt-check
     @echo "✅ Shell checks complete!"
 
-# Format tracked shell scripts with shfmt.
+# Format tracked and new shell scripts with shfmt.
 [group('validation')]
 shell-fix: _ensure-shfmt
     #!/usr/bin/env bash
@@ -1397,7 +1402,7 @@ shell-fix: _ensure-shfmt
     files=()
     while IFS= read -r -d '' file; do
         files+=("$file")
-    done < <(git ls-files -z '*.sh')
+    done < <(git --no-pager ls-files --cached --others --exclude-standard -z '*.sh')
     if [ "${#files[@]}" -gt 0 ]; then
         echo "🧹 shfmt -w (${#files[@]} files)"
         printf '%s\0' "${files[@]}" | xargs -0 uv run --locked shfmt -w
@@ -1406,7 +1411,7 @@ shell-fix: _ensure-shfmt
     fi
     # Note: justfiles are not shell scripts and are excluded from shellcheck
 
-# Check tracked shell-script formatting with shfmt.
+# Check tracked and new shell-script formatting with shfmt.
 [group('validation')]
 shell-fmt-check: _ensure-shfmt
     #!/usr/bin/env bash
@@ -1414,14 +1419,14 @@ shell-fmt-check: _ensure-shfmt
     files=()
     while IFS= read -r -d '' file; do
         files+=("$file")
-    done < <(git ls-files -z '*.sh')
+    done < <(git --no-pager ls-files --cached --others --exclude-standard -z '*.sh')
     if [ "${#files[@]}" -gt 0 ]; then
         printf '%s\0' "${files[@]}" | xargs -0 uv run --locked shfmt -d
     else
         echo "No shell files found to check."
     fi
 
-# Lint tracked shell scripts with ShellCheck.
+# Lint tracked and new shell scripts with ShellCheck.
 [group('validation')]
 shell-lint: _ensure-shellcheck
     #!/usr/bin/env bash
@@ -1429,7 +1434,7 @@ shell-lint: _ensure-shellcheck
     files=()
     while IFS= read -r -d '' file; do
         files+=("$file")
-    done < <(git ls-files -z '*.sh')
+    done < <(git --no-pager ls-files --cached --others --exclude-standard -z '*.sh')
     if [ "${#files[@]}" -gt 0 ]; then
         printf '%s\0' "${files[@]}" | xargs -0 -n4 uv run --locked shellcheck -x
     else

--- a/scripts/benchmark_utils.py
+++ b/scripts/benchmark_utils.py
@@ -1171,8 +1171,9 @@ def _criterion_result_ids(criterion_dir: Path) -> tuple[str, ...]:
     """Return valid Criterion result IDs, preferring ``new`` over ``base``."""
     # Directory names escape slashes in group/function IDs. Reuse the canonical
     # metadata reader so report coverage and release comparisons agree.
-    samples = _criterion_estimates_by_id(criterion_dir, "base")
-    samples.update(_criterion_estimates_by_id(criterion_dir, "new"))
+    # Stale samples without usable identity metadata cannot contribute coverage.
+    samples = _criterion_estimates_by_id(criterion_dir, "base", skip_invalid_metadata=True)
+    samples.update(_criterion_estimates_by_id(criterion_dir, "new", skip_invalid_metadata=True))
     return tuple(sorted(result_id for result_id, sample in samples.items() if _load_criterion_estimate(sample.estimates) is not None))
 
 
@@ -3270,15 +3271,20 @@ def _criterion_sample(estimates_json: Path, criterion_dir: Path) -> CriterionSam
     return CriterionSample(benchmark_id=full_id, group=group, benchmark=benchmark, estimates=estimates_json)
 
 
-def _criterion_estimates_by_id(criterion_dir: Path, sample: str) -> dict[str, CriterionSample]:
-    """Map Criterion benchmark IDs to estimates files for one sample name."""
+def _criterion_estimates_by_id(criterion_dir: Path, sample: str, *, skip_invalid_metadata: bool = False) -> dict[str, CriterionSample]:
+    """Map sample IDs to estimates, optionally skipping unusable identity metadata."""
     results: dict[str, CriterionSample] = {}
     if not criterion_dir.is_dir():
         return results
     for estimates_json in sorted(criterion_dir.rglob("estimates.json")):
         if estimates_json.parent.name != sample:
             continue
-        criterion_sample = _criterion_sample(estimates_json, criterion_dir)
+        try:
+            criterion_sample = _criterion_sample(estimates_json, criterion_dir)
+        except TypeError, ValueError:
+            if not skip_invalid_metadata:
+                raise
+            continue
         if criterion_sample is not None:
             prior = results.get(criterion_sample.benchmark_id)
             if prior is not None and prior.estimates != criterion_sample.estimates:

--- a/scripts/benchmark_utils.py
+++ b/scripts/benchmark_utils.py
@@ -231,7 +231,7 @@ class BenchmarkTargetMeasurement:
 CI_PERFORMANCE_SUITE_GROUPS = {
     "construction": (
         "Construction",
-        "DelaunayTriangulation::new_with_options",
+        "DelaunayTriangulationBuilder::build",
     ),
     "boundary_facets": (
         "Boundary facets",
@@ -239,7 +239,11 @@ CI_PERFORMANCE_SUITE_GROUPS = {
     ),
     "convex_hull": (
         "Convex hull",
-        "ConvexHull::from_triangulation",
+        "ConvexHull::try_from_triangulation",
+    ),
+    "convex_hull_queries": (
+        "Convex hull queries",
+        "ConvexHull::{is_point_outside,find_visible_facets,find_nearest_visible_facet}",
     ),
     "validation": (
         "Validation",
@@ -247,7 +251,15 @@ CI_PERFORMANCE_SUITE_GROUPS = {
     ),
     "incremental_insert": (
         "Incremental insert",
-        "DelaunayTriangulation::insert",
+        "DelaunayTriangulation::insert_vertex",
+    ),
+    "explicit_import": (
+        "Explicit pseudomanifold import",
+        "DelaunayTriangulationBuilder::try_from_vertices_and_simplices",
+    ),
+    "proof_boundaries": (
+        "Proof boundaries",
+        "TriangulationBuilder::build;DelaunayRefinementBuilder::build",
     ),
     "bistellar_flips": (
         "Bistellar flips",
@@ -259,7 +271,7 @@ CI_PERFORMANCE_SUITE_GROUP_ORDER = tuple(CI_PERFORMANCE_SUITE_GROUPS)
 _CI_PERFORMANCE_SUITE_MANIFEST_IDS_FILE = "ci_performance_suite_manifest_ids.txt"
 _CI_PERFORMANCE_SUITE_METRICS_FILE = "ci_performance_suite_metrics.json"
 _CI_PERFORMANCE_SUITE_RUN_METADATA_FILE = "ci_performance_suite_run_metadata.json"
-PERF_NO_REGRESSIONS_REQUIRED_BENCHMARK_ID = "tds_new_2d/tds_new/4000"
+PERF_NO_REGRESSIONS_REQUIRED_BENCHMARK_ID = "tds_new_2d/tds_new/500"
 MAIN_VS_RELEASE_COMPARISON_RESULTS_FILE = "main_vs_release_compare_results.txt"
 WORKTREE_VS_REF_COMPARISON_RESULTS_TEMPLATE = "worktree_vs_{ref}_compare_results.txt"
 PERF_NO_REGRESSIONS_RELEVANT_PATHS = (
@@ -357,8 +369,9 @@ GITHUB_ASSETS_PERFORMANCE_REPORT = Path("target") / "bench-reports" / "github-as
 DOCS_PERFORMANCE_REPORT = Path("docs") / "PERFORMANCE.md"
 PERFORMANCE_ARCHIVE_DIR = Path("docs") / "archive" / "performance"
 RELEASE_BENCH_TIMEOUT_SECONDS = 7200
+RELEASE_PREFLIGHT_TIMEOUT_SECONDS = 600
 RELEASE_COMMAND_TIMEOUT_SECONDS = 600
-RELEASE_SIGNAL_TIMEOUT_SECONDS = RELEASE_BENCH_TIMEOUT_SECONDS * len(RELEASE_SIGNAL_MEASUREMENT_PLAN)
+RELEASE_SIGNAL_TIMEOUT_SECONDS = (RELEASE_BENCH_TIMEOUT_SECONDS + RELEASE_PREFLIGHT_TIMEOUT_SECONDS) * len(RELEASE_SIGNAL_MEASUREMENT_PLAN)
 DELAUNAY_REPORT_VERSION_RE = re.compile(r"^\*\*delaunay\*\* v(?P<version>[^\s`]+)", re.MULTILINE)
 DELAUNAY_REPORT_BASELINE_RE = re.compile(r"^Comparison against baseline \*\*(?P<baseline>[^*]+)\*\*:", re.MULTILINE)
 SEMVER_IDENTIFIER_RE = r"(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)"
@@ -1156,19 +1169,11 @@ class BenchmarkPlanSectionEvidence:
 
 def _criterion_result_ids(criterion_dir: Path) -> tuple[str, ...]:
     """Return valid Criterion result IDs, preferring ``new`` over ``base``."""
-    results: dict[str, str] = {}
-    for estimates_path in sorted(criterion_dir.glob("**/estimates.json")):
-        sample = estimates_path.parent.name
-        if sample not in {"base", "new"} or _load_criterion_estimate(estimates_path) is None:
-            continue
-        path_parts = estimates_path.relative_to(criterion_dir).parts[:-2]
-        if not path_parts:
-            continue
-        result_id = "/".join(path_parts)
-        previous = results.get(result_id)
-        if previous is None or (previous == "base" and sample == "new"):
-            results[result_id] = sample
-    return tuple(sorted(results))
+    # Directory names escape slashes in group/function IDs. Reuse the canonical
+    # metadata reader so report coverage and release comparisons agree.
+    samples = _criterion_estimates_by_id(criterion_dir, "base")
+    samples.update(_criterion_estimates_by_id(criterion_dir, "new"))
+    return tuple(sorted(result_id for result_id, sample in samples.items() if _load_criterion_estimate(sample.estimates) is not None))
 
 
 def _criterion_group_matches(result_id: str, group_prefix: str) -> bool:
@@ -1246,15 +1251,34 @@ def _sampling_metadata(dev_mode: bool) -> dict[str, str]:
     }
 
 
+def preflight_release_signal(project_root: Path, *, cargo_profile: str, bench_timeout: int) -> None:
+    """Execute every fixture once; do not publish timing or measurement metadata."""
+    for measurement in RELEASE_SIGNAL_MEASUREMENT_PLAN:
+        print(f"🔎 Preflight release-signal target {measurement.target}...", flush=True)
+        run_cargo_command(
+            ["bench", "--profile", cargo_profile, "--bench", measurement.target, "--", "--test"],
+            cwd=project_root,
+            timeout=min(bench_timeout, RELEASE_PREFLIGHT_TIMEOUT_SECONDS),
+            capture_output=False,
+        )
+
+
 def run_release_signal_measurement_plan(
     project_root: Path,
     *,
     cargo_profile: str = BENCHMARK_BUILD_FLAVOR,
     bench_timeout: int = 1800,
     save_baseline: str | None = None,
+    preflight_only: bool = False,
 ) -> dict[str, str]:
-    """Execute the maintained release-signal plan and return stdout by target."""
+    """Preflight every curated fixture before sampling; smoke output is never evidence."""
     _require_positive_int_field("bench_timeout", bench_timeout)
+    if preflight_only and save_baseline is not None:
+        msg = "preflight cannot save a measurement baseline"
+        raise ValueError(msg)
+    preflight_release_signal(project_root, cargo_profile=cargo_profile, bench_timeout=bench_timeout)
+    if preflight_only:
+        return {}
     outputs: dict[str, str] = {}
     for measurement in RELEASE_SIGNAL_MEASUREMENT_PLAN:
         cargo_args = ["bench", "--profile", cargo_profile, "--bench", measurement.target]
@@ -2070,9 +2094,7 @@ class PerformanceSummaryGenerator:
     @staticmethod
     def _ci_suite_input_size(path_parts: tuple[str, ...]) -> str:
         """Extract a human-readable input size from Criterion benchmark path parts."""
-        if path_parts and path_parts[-1].isdigit():
-            return path_parts[-1]
-        return "roundtrip"
+        return path_parts[-1] if len(path_parts) > 2 else "fixed fixture"
 
     @staticmethod
     def _load_criterion_estimate(estimates_path: Path) -> tuple[float, float, float] | None:
@@ -7966,10 +7988,8 @@ def _add_bench_compare_subcommand(subparsers: argparse._SubParsersAction[argpars
     _add_project_root_arg(bench_compare_parser)
 
 
-def _add_benchmark_subcommands(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
-    """Add benchmark-running subcommands."""
-    _add_bench_compare_subcommand(subparsers)
-
+def _add_release_signal_subcommand(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Expose measurement and preflight modes of the shared curated plan."""
     release_signal_parser = subparsers.add_parser(
         "run-release-signal",
         help="Run the maintained release-signal benchmark measurement plan",
@@ -7983,8 +8003,19 @@ def _add_benchmark_subcommands(subparsers: argparse._SubParsersAction[argparse.A
         "--save-baseline",
         help="Also save every planned Criterion result under this baseline name",
     )
+    release_signal_parser.add_argument(
+        "--preflight-only",
+        action="store_true",
+        help="Execute every fixture and one operation per case without Criterion sampling or evidence writes",
+    )
     _add_bench_timeout_arg(release_signal_parser)
     _add_project_root_arg(release_signal_parser)
+
+
+def _add_benchmark_subcommands(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Add benchmark-running subcommands."""
+    _add_bench_compare_subcommand(subparsers)
+    _add_release_signal_subcommand(subparsers)
 
     gen_parser = subparsers.add_parser("generate-baseline", help="Generate performance baseline")
     _add_dev_arg(gen_parser)
@@ -8679,6 +8710,7 @@ def _cmd_run_release_signal(args: argparse.Namespace, project_root: Path) -> Non
             cargo_profile=args.profile,
             bench_timeout=args.bench_timeout,
             save_baseline=args.save_baseline,
+            preflight_only=args.preflight_only,
         )
     except _RECOVERABLE_CLI_ERRORS as error:
         print(f"run-release-signal: {error}", file=sys.stderr)

--- a/scripts/release_benchmarks.sh
+++ b/scripts/release_benchmarks.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Guard the draft-run-upload-publish sequence. All remote writes happen in publish.
+set -euo pipefail
+
+mode="${1:?expected preflight or publish}"
+tag="${RELEASE_TAG:?missing RELEASE_TAG}"
+repo="${GITHUB_REPOSITORY:?missing GITHUB_REPOSITORY}"
+asset="delaunay-${tag}-criterion-baseline.tar.gz"
+
+fail() {
+	echo "Release benchmarks: $*" >&2
+	exit 1
+}
+
+[[ "$mode" == preflight || "$mode" == publish ]] || fail "unknown mode: $mode"
+[[ "$tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || fail "expected a stable vX.Y.Z tag"
+
+# Resolve the remote tag, including annotated tags, without fetching or moving refs.
+resolve_commit() {
+	local object depth=0
+	object="$(gh api "repos/$repo/git/ref/tags/$tag" --jq '.object')"
+	while [[ "$(jq -r '.type' <<<"$object")" == tag ]]; do
+		((depth += 1))
+		((depth <= 10)) || fail "tag nesting exceeds the supported limit"
+		object="$(gh api "repos/$repo/git/tags/$(jq -r '.sha' <<<"$object")" --jq '.object')"
+	done
+	[[ "$(jq -r '.type' <<<"$object")" == commit ]] || fail "tag does not resolve to a commit"
+	jq -er '.sha | select(test("^[0-9a-f]{40}$"))' <<<"$object"
+}
+
+check_draft() {
+	# The by-tag endpoint only promises published releases. Authenticated list
+	# pagination includes drafts and also lets us reject ambiguous tag matches.
+	releases="$(gh api "repos/$repo/releases?per_page=100" --paginate --slurp)"
+	release="$(jq -ce --arg tag "$tag" '
+        [ .[][] | select(.tag_name == $tag) ]
+        | if length == 1 then .[0] else error("expected exactly one release for tag") end
+    ' <<<"$releases")"
+	jq -e --arg tag "$tag" '
+        .tag_name == $tag and .draft == true and .prerelease == false
+        and .immutable == false and .published_at == null
+        and (.id | type == "number" and . > 0)
+    ' <<<"$release" >/dev/null || fail "target must be an unpublished, mutable stable draft"
+	release_id="$(jq -r '.id' <<<"$release")"
+	if [[ -n "${EXPECTED_RELEASE_ID:-}" ]]; then
+		[[ "$release_id" == "$EXPECTED_RELEASE_ID" ]] || fail "draft release identity changed"
+	fi
+	commit="$(resolve_commit)"
+	local_commit="$(git --no-pager rev-parse --verify "refs/tags/$tag^{commit}")"
+	[[ "$commit" == "$local_commit" ]] || fail "remote tag differs from the checked-out tag"
+	if [[ -n "${EXPECTED_COMMIT:-}" ]]; then
+		[[ "$commit" == "$EXPECTED_COMMIT" ]] || fail "tag moved during benchmarking"
+	fi
+}
+
+check_draft
+# Never replace evidence implicitly, even on a mutable draft. A failed run that
+# uploaded successfully requires inspection before the maintainer removes it.
+jq -e --arg asset "$asset" 'all(.assets[]; .name != $asset)' <<<"$release" >/dev/null ||
+	fail "baseline asset already exists; inspect the draft asset before retrying"
+
+if [[ "$mode" == preflight ]]; then
+	{
+		echo "release_id=$release_id"
+		echo "commit=$commit"
+	} >>"${GITHUB_OUTPUT:?missing GITHUB_OUTPUT}"
+	exit 0
+fi
+
+[[ -n "${EXPECTED_RELEASE_ID:-}" && -n "${EXPECTED_COMMIT:-}" ]] || fail "publish requires preflight identity"
+[[ "$(git --no-pager rev-parse HEAD)" == "$EXPECTED_COMMIT" ]] || fail "HEAD differs from the benchmarked tag"
+[[ -s "$asset" ]] || fail "missing or empty baseline archive: $asset"
+digest="sha256:$(sha256sum "$asset" | cut -d ' ' -f 1)"
+gh release upload "$tag" "$asset" --repo "$repo"
+
+# Recheck draft identity and tag after upload, then verify GitHub stored these
+# exact archive bytes before making the release public.
+check_draft
+jq -e --arg asset "$asset" --arg digest "$digest" '
+    [.assets[] | select(.name == $asset and .state == "uploaded" and .size > 0 and .digest == $digest)]
+    | length == 1
+' <<<"$release" >/dev/null || fail "uploaded baseline is missing, incomplete, or has a different digest"
+gh api "repos/$repo/releases/$release_id" --method PATCH -F draft=false >/dev/null

--- a/scripts/tag_release.py
+++ b/scripts/tag_release.py
@@ -504,7 +504,8 @@ def create_tag(tag_version: str, *, force: bool = False) -> None:
         print(f"  1. Force-push the tag: {_BLUE}git push --force origin {tag_version}{_RESET}")
     else:
         print(f"  1. Push the tag: {_BLUE}git push origin {tag_version}{_RESET}")
-    print(f"  2. Create GitHub release: {_BLUE}gh release create {tag_version} --title {tag_version} --notes-from-tag{_RESET}")
+    print(f"  2. Create draft release: {_BLUE}gh release create {tag_version} --title {tag_version} --notes-from-tag --draft --verify-tag{_RESET}")
+    print(f"  3. Benchmark and publish: {_BLUE}gh workflow run release-benchmarks.yml --ref main -f tag={tag_version}{_RESET}")
     if is_truncated:
         print(f"\n{_YELLOW}Note: Tag annotation references CHANGELOG.md due to size (>125KB).{_RESET}")
 

--- a/scripts/tests/test_benchmark_utils.py
+++ b/scripts/tests/test_benchmark_utils.py
@@ -6343,8 +6343,54 @@ Benchmark completed.""",
         write_estimate(tmp_path / "target", ("validation", "validate_2d"), 1_000.0)
         (tmp_path / "target/criterion/validation/validate_2d/base/benchmark.json").unlink()
 
-        with pytest.raises(ValueError, match="could not load Criterion benchmark metadata"):
-            PerformanceSummaryGenerator(tmp_path)._collect_release_signal_section_evidence()
+        sections = PerformanceSummaryGenerator(tmp_path)._collect_release_signal_section_evidence()
+        section = next(section for section in sections if section.target == "ci_performance_suite")
+        assert section.result_ids == ()
+        assert "validation" in section.missing_group_prefixes
+        assert not section.is_complete
+
+    @pytest.mark.parametrize("sample", ["base", "new"])
+    @pytest.mark.parametrize("metadata", [None, "{", "[]", '{"full_id":"","group_id":"obsolete"}', '{"full_id":"standalone","group_id":"standalone"}'])
+    def test_release_signal_coverage_skips_unusable_metadata(self, tmp_path: Path, sample: str, metadata: str | None) -> None:
+        """Unusable cached samples must not hide valid measured report groups."""
+        write_complete_release_signal_coverage(tmp_path)
+        write_named_estimate(tmp_path / "target", ("obsolete", "fixture"), sample, 1_000.0, stat="mean")
+        criterion_dir = tmp_path / "target/criterion"
+        metadata_path = criterion_dir / "obsolete/fixture" / sample / "benchmark.json"
+        if metadata is None:
+            metadata_path.unlink()
+        else:
+            metadata_path.write_text(metadata, encoding=UTF8)
+
+        sections = PerformanceSummaryGenerator(tmp_path)._collect_release_signal_section_evidence()
+        assert all(section.is_complete for section in sections)
+        assert "obsolete/fixture" not in benchmark_utils._criterion_result_ids(criterion_dir)
+        # Comparison and artifact consumers retain the strict default.
+        with pytest.raises((TypeError, ValueError)):
+            benchmark_utils._criterion_estimates_by_id(criterion_dir, sample)
+
+    def test_release_signal_result_ids_preserve_samples_and_sorting(self, tmp_path: Path) -> None:
+        """Collect valid base/new IDs once, with new estimates taking precedence."""
+        write_named_estimate(tmp_path, ("validation", "z_base"), "base", 1_000.0, stat="mean")
+        write_named_estimate(tmp_path, ("validation", "a_new"), "new", 1_000.0, stat="mean")
+        write_named_estimate(tmp_path, ("validation", "shared"), "base", 1_000.0, stat="mean")
+        write_named_estimate(tmp_path, ("validation", "shared"), "new", 2_000.0, stat="mean")
+        write_named_estimate(tmp_path, ("validation", "invalid_new"), "base", 1_000.0, stat="mean")
+        write_named_estimate(tmp_path, ("validation", "invalid_new"), "new", -1.0, stat="mean")
+
+        assert benchmark_utils._criterion_result_ids(tmp_path / "criterion") == (
+            "validation/a_new",
+            "validation/shared",
+            "validation/z_base",
+        )
+
+    def test_release_signal_coverage_still_rejects_duplicate_ids(self, tmp_path: Path) -> None:
+        """Skipping unreadable metadata must not hide ambiguous valid identities."""
+        for directory in ("first", "second"):
+            write_named_estimate(tmp_path, (directory,), "new", 1_000.0, stat="mean", full_id="validation/duplicate", group_id="validation")
+
+        with pytest.raises(ValueError, match="duplicate Criterion full_id"):
+            benchmark_utils._criterion_result_ids(tmp_path / "criterion")
 
     def test_generate_summary_strict_rejects_missing_planned_report_section(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """A planned target without Criterion groups must block strict publication."""

--- a/scripts/tests/test_benchmark_utils.py
+++ b/scripts/tests/test_benchmark_utils.py
@@ -86,6 +86,7 @@ from benchmark_utils import (
     resolve_performance_request,
     write_criterion_comparison_report,
 )
+from subprocess_utils import run_safe_command
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -397,7 +398,7 @@ def write_ci_performance_metrics(target_dir: Path, metrics: dict[str, dict[str, 
     )
 
 
-def cached_ref_baseline_content(*, commit: str = "abc123def456", benchmark_id: str = "tds_new_2d/tds_new/4000") -> str:
+def cached_ref_baseline_content(*, commit: str = "abc123def456", benchmark_id: str = "tds_new_2d/tds_new/500") -> str:
     """Return a minimal parseable local ref baseline fixture."""
     return f"""Date: 2026-05-14 10:00:00 UTC
 Git commit: {commit}
@@ -407,7 +408,7 @@ Hardware Information:
   CPU: Apple M4 Max
   Memory: 64.0 GB
 
-=== 4000 Points (2D) ===
+=== 500 Points (2D) ===
 Benchmark ID: {benchmark_id}
 Time: [100.0, 110.0, 120.0] µs
 Throughput: [18.0, 19.0, 20.0] Kelem/s
@@ -568,20 +569,78 @@ def test_release_measurement_plan_runner_executes_exact_target_order(mock_cargo:
 
     assert tuple(outputs) == benchmark_utils.RELEASE_SIGNAL_BENCH_TARGETS
     assert [call.args[0] for call in mock_cargo.call_args_list] == [
-        list(measurement.command[1:]) for measurement in benchmark_utils.RELEASE_SIGNAL_MEASUREMENT_PLAN
-    ]
-    assert all(call.kwargs["timeout"] == 3600 for call in mock_cargo.call_args_list)
+        [*measurement.command[1:], "--", "--test"] for measurement in benchmark_utils.RELEASE_SIGNAL_MEASUREMENT_PLAN
+    ] + [list(measurement.command[1:]) for measurement in benchmark_utils.RELEASE_SIGNAL_MEASUREMENT_PLAN]
+    preflight_calls = mock_cargo.call_args_list[: len(benchmark_utils.RELEASE_SIGNAL_MEASUREMENT_PLAN)]
+    sampling_calls = mock_cargo.call_args_list[len(benchmark_utils.RELEASE_SIGNAL_MEASUREMENT_PLAN) :]
+    assert all(call.kwargs["timeout"] == benchmark_utils.RELEASE_PREFLIGHT_TIMEOUT_SECONDS for call in preflight_calls)
+    assert all(call.kwargs["timeout"] == 3600 for call in sampling_calls)
 
 
 @patch("benchmark_utils.run_cargo_command")
 def test_release_measurement_plan_runner_stops_at_first_failed_target(mock_cargo: MagicMock, tmp_path: Path) -> None:
     """A failed planned target must prevent later measurements from running."""
-    mock_cargo.return_value = completed_process(returncode=101, stderr="benchmark failed")
+    mock_cargo.side_effect = [
+        *[completed_process() for _ in benchmark_utils.RELEASE_SIGNAL_MEASUREMENT_PLAN],
+        completed_process(returncode=101, stderr="benchmark failed"),
+    ]
 
     with pytest.raises(RuntimeError, match="ci_performance_suite exited with status 101"):
         benchmark_utils.run_release_signal_measurement_plan(tmp_path)
 
-    assert mock_cargo.call_count == 1
+    assert mock_cargo.call_count == len(benchmark_utils.RELEASE_SIGNAL_MEASUREMENT_PLAN) + 1
+
+
+@patch("benchmark_utils.run_cargo_command")
+def test_release_preflight_runs_every_target_without_writing_evidence(mock_cargo: MagicMock, tmp_path: Path) -> None:
+    mock_cargo.return_value = completed_process(stdout=CI_MANIFEST_STDOUT)
+    assert benchmark_utils.run_release_signal_measurement_plan(tmp_path, preflight_only=True) == {}
+    assert [call.args[0] for call in mock_cargo.call_args_list] == [
+        [*measurement.command[1:], "--", "--test"] for measurement in benchmark_utils.RELEASE_SIGNAL_MEASUREMENT_PLAN
+    ]
+    assert list(tmp_path.iterdir()) == []
+
+
+@patch("benchmark_utils.run_cargo_command")
+def test_failed_preflight_prevents_all_sampling(mock_cargo: MagicMock, tmp_path: Path) -> None:
+    mock_cargo.side_effect = [completed_process(), subprocess.CalledProcessError(1, ["cargo", "bench"])]
+    with pytest.raises(subprocess.CalledProcessError):
+        benchmark_utils.run_release_signal_measurement_plan(tmp_path)
+    assert mock_cargo.call_count == 2
+    assert all(call.args[0][-1] == "--test" for call in mock_cargo.call_args_list)
+    assert list(tmp_path.iterdir()) == []
+
+
+@patch("benchmark_utils.run_cargo_command")
+def test_preflight_cannot_be_saved_as_baseline(mock_cargo: MagicMock, tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="preflight cannot save"):
+        benchmark_utils.run_release_signal_measurement_plan(tmp_path, preflight_only=True, save_baseline="last")
+    mock_cargo.assert_not_called()
+
+
+@pytest.mark.parametrize("logging_enabled", [False, True])
+def test_benchmark_abort_prints_underlying_error_without_subscriber(tmp_path: Path, logging_enabled: bool) -> None:
+    """Run the actual shared fatal adapter, including with tracing filtered off."""
+    adapter = Path(__file__).resolve().parents[2] / "benches" / "common" / "bench_utils.rs"
+    source = tmp_path / "abort.rs"
+    source.write_text(
+        f'#[path = "{adapter.as_posix()}"] mod bench_utils;\n'
+        "use bench_utils::OrAbort;\n"
+        "fn main() {\n"
+        '    let result: Result<(), std::io::Error> = Err(std::io::Error::other("fixture contract failed"));\n'
+        "    result.or_abort();\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    binary = tmp_path / ("abort.exe" if os.name == "nt" else "abort")
+    args = [str(source), "--edition", "2024", "-o", str(binary)]
+    if logging_enabled:
+        args.extend(["--cfg", 'feature="bench-logging"'])
+    run_safe_command("rustc", args, timeout=60)
+    result = run_safe_command(str(binary), [], env={**os.environ, "RUST_LOG": "off"}, check=False, timeout=10)
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert result.stderr == "benchmark failed: fixture contract failed\n"
 
 
 def test_release_measurement_plan_digest_binds_per_target_sampling(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2412,6 +2471,30 @@ malformed api_benchmark_metric benchmark_id=ignored vertices=x simplices=y
             assert roundtrip.points is None
             assert roundtrip.dimension == "4D"
             assert roundtrip.throughput_mean is None
+
+    def test_summary_retains_exact_import_proof_and_query_manifest_ids(self, tmp_path: Path) -> None:
+        """Dynamic simplex-count parameters must survive strict summary validation."""
+        target_dir = tmp_path / "target"
+        benchmark_ids = (
+            "explicit_import/import_pseudomanifold_4d/vertices_16_simplices_68",
+            "proof_boundaries/promote_pseudomanifold_strict_4d/simplices_68",
+            "proof_boundaries/promote_pseudomanifold_canonicalizing_4d/simplices_68",
+            "proof_boundaries/certify_pl_manifold_4d/simplices_68",
+            "convex_hull_queries/is_point_outside_3d/100",
+        )
+        for benchmark_id in benchmark_ids:
+            write_estimate(target_dir, tuple(benchmark_id.split("/")), 10_000.0)
+        benchmark_utils._write_ci_performance_manifest_ids(
+            tmp_path,
+            "\n".join(f"api_benchmark benchmark_ids={benchmark_id}" for benchmark_id in benchmark_ids),
+        )
+        generator = PerformanceSummaryGenerator(tmp_path)
+        evidence = generator._collect_ci_performance_summary_evidence()
+        assert evidence.missing_result_ids == ()
+        assert {result.benchmark_id for result in evidence.results} == set(benchmark_ids)
+        assert {result.benchmark_id: result.input_size for result in evidence.results} == {
+            benchmark_id: benchmark_id.rsplit("/", maxsplit=1)[1] for benchmark_id in benchmark_ids
+        }
 
     def test_find_criterion_results_skips_stale_ci_suite_metrics(self) -> None:
         """Test ci_performance_suite simplex counts require matching current inputs."""
@@ -5684,7 +5767,7 @@ OK: Time change -1.8% within acceptable range
 
             assert PUBLIC_API_TITLE in content
             assert "#### Construction" in content
-            assert "Public API: `DelaunayTriangulation::new_with_options`" in content
+            assert "Public API: `DelaunayTriangulationBuilder::build`" in content
             assert "`tds_new_2d/tds_new/10`" in content
             assert "well-conditioned" in content
             assert "#### Boundary facets" in content
@@ -5693,6 +5776,7 @@ OK: Time change -1.8% within acceptable range
             assert "adversarial" in content
             assert "#### Bistellar flips" in content
             assert "`bistellar_flips_4d/k2_roundtrip`" in content
+            assert "| `bistellar_flips_4d/k2_roundtrip` | 4D | fixed fixture |" in content
 
     def test_get_circumsphere_performance_results(self) -> None:
         """Test getting circumsphere performance results."""
@@ -6222,6 +6306,45 @@ Benchmark completed.""",
         assert all(section.is_complete for section in sections)
         for measurement in benchmark_utils.RELEASE_SIGNAL_MEASUREMENT_PLAN:
             assert f"| `{measurement.target}` | {measurement.report_section} |" in rendered
+
+    @pytest.mark.parametrize(
+        ("target", "path_parts", "full_id", "group_id"),
+        [
+            ("circumsphere_containment", ("random_insphere_1000_queries",), "random/insphere_1000_queries", "random/insphere_1000_queries"),
+            ("circumsphere_containment", ("3d_insphere",), "3d/insphere", "3d/insphere"),
+            ("circumsphere_containment", ("circumcenter_solve_path", "regular_lu_3d"), "circumcenter/solve_path/regular_lu_3d", "circumcenter/solve_path"),
+            ("cold_path_predicates", ("predicates_hot", "insphere_3d", "10000"), "predicates/hot/insphere_3d/10000", "predicates/hot"),
+            (
+                "locate",
+                ("locate_no_hint_2d", "locate", "vertices_500_simplices_983"),
+                "locate/no_hint/2d/locate/vertices_500_simplices_983",
+                "locate/no_hint/2d",
+            ),
+        ],
+    )
+    def test_release_signal_coverage_uses_canonical_metadata_ids(
+        self,
+        tmp_path: Path,
+        target: str,
+        path_parts: tuple[str, ...],
+        full_id: str,
+        group_id: str,
+    ) -> None:
+        """Criterion's escaped disk paths must not hide measured release groups."""
+        write_named_estimate(tmp_path / "target", path_parts, "new", 1_000.0, stat="mean", full_id=full_id, group_id=group_id)
+        sections = PerformanceSummaryGenerator(tmp_path)._collect_release_signal_section_evidence()
+        section = next(section for section in sections if section.target == target)
+
+        assert section.result_ids == (full_id,)
+        assert full_id.split("/", maxsplit=1)[0] not in section.missing_group_prefixes
+
+    def test_release_signal_coverage_requires_identity_metadata(self, tmp_path: Path) -> None:
+        """A plausible directory name cannot substitute for missing benchmark identity."""
+        write_estimate(tmp_path / "target", ("validation", "validate_2d"), 1_000.0)
+        (tmp_path / "target/criterion/validation/validate_2d/base/benchmark.json").unlink()
+
+        with pytest.raises(ValueError, match="could not load Criterion benchmark metadata"):
+            PerformanceSummaryGenerator(tmp_path)._collect_release_signal_section_evidence()
 
     def test_generate_summary_strict_rejects_missing_planned_report_section(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """A planned target without Criterion groups must block strict publication."""

--- a/scripts/tests/test_release_benchmarks.py
+++ b/scripts/tests/test_release_benchmarks.py
@@ -1,0 +1,158 @@
+"""Execute the release publication guard against a local fake GitHub transport."""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from subprocess_utils import run_safe_command
+
+if TYPE_CHECKING:
+    import subprocess
+
+SCRIPT = Path(__file__).resolve().parents[1] / "release_benchmarks.sh"
+COMMIT = "a" * 40
+ASSET = "delaunay-v0.8.2-criterion-baseline.tar.gz"
+
+
+@pytest.fixture
+def release_env(tmp_path: Path) -> dict[str, str]:
+    """Provide a draft, tagged commit, archive, and observable fake CLI writes."""
+    archive = b"complete benchmark archive"
+    (tmp_path / ASSET).write_bytes(archive)
+    release = {
+        "id": 42,
+        "tag_name": "v0.8.2",
+        "draft": True,
+        "prerelease": False,
+        "immutable": False,
+        "published_at": None,
+        "assets": [],
+    }
+    (tmp_path / "before.json").write_text(json.dumps(release), encoding="utf-8")
+    release["assets"] = [{"name": ASSET, "state": "uploaded", "size": len(archive), "digest": f"sha256:{hashlib.sha256(archive).hexdigest()}"}]
+    (tmp_path / "after.json").write_text(json.dumps(release), encoding="utf-8")
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    gh = fake_bin / "gh"
+    gh.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "$FAKE_ROOT/calls"
+case "$*" in
+    *'--method PATCH'*) exit "${PUBLISH_STATUS:-0}" ;;
+    'release upload '*)
+        [[ "${UPLOAD_STATUS:-0}" == 0 ]] || exit "$UPLOAD_STATUS"
+        cp "$FAKE_ROOT/after.json" "$FAKE_ROOT/before.json" ;;
+    *'/releases?per_page=100'*)
+        [[ "${MISSING_RELEASE:-0}" == 0 ]] || exit 1
+        jq '[[.]]' "$FAKE_ROOT/before.json" ;;
+    *'/git/ref/tags/'*) printf '{"type":"commit","sha":"%s"}\\n' "$REMOTE_COMMIT" ;;
+    *) exit 99 ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    git = fake_bin / "git"
+    git.write_text('#!/usr/bin/env bash\nprintf "%s\\n" "$LOCAL_COMMIT"\n', encoding="utf-8")
+    gh.chmod(0o755)
+    git.chmod(0o755)
+    return {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_ROOT": str(tmp_path),
+        "GITHUB_OUTPUT": str(tmp_path / "output"),
+        "GITHUB_REPOSITORY": "owner/repo",
+        "RELEASE_TAG": "v0.8.2",
+        "LOCAL_COMMIT": COMMIT,
+        "REMOTE_COMMIT": COMMIT,
+        "EXPECTED_COMMIT": COMMIT,
+        "EXPECTED_RELEASE_ID": "42",
+    }
+
+
+def run_guard(tmp_path: Path, env: dict[str, str], mode: str = "preflight") -> subprocess.CompletedProcess[str]:
+    """Run the actual guard without remote access or Git mutations."""
+    return run_safe_command("bash", [str(SCRIPT), mode], cwd=tmp_path, env=env, check=False, timeout=10)
+
+
+def change_release(tmp_path: Path, field: str, value: object, filename: str = "before.json") -> None:
+    """Change one transport field to exercise a fail-closed boundary."""
+    path = tmp_path / filename
+    release = json.loads(path.read_text(encoding="utf-8"))
+    release[field] = value
+    path.write_text(json.dumps(release), encoding="utf-8")
+
+
+def assert_no_publication(tmp_path: Path) -> None:
+    """Check that no publication request escaped a failed validation."""
+    calls = tmp_path / "calls"
+    assert not calls.exists() or "--method PATCH" not in calls.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("tag", ["main", "v01.2.3", "v1.2.3-rc.1", "v1.2.3+build", "v1.2.3\n", "$(touch injected)"])
+def test_invalid_tag_fails_before_network(tmp_path: Path, release_env: dict[str, str], tag: str) -> None:
+    release_env["RELEASE_TAG"] = tag
+    assert run_guard(tmp_path, release_env).returncode != 0
+    assert not (tmp_path / "calls").exists()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("draft", False), ("prerelease", True), ("immutable", True), ("immutable", None), ("published_at", "2026-09-09"), ("tag_name", "v0.8.1"), ("id", 43)],
+)
+def test_unsuitable_release_never_publishes(tmp_path: Path, release_env: dict[str, str], field: str, value: object) -> None:
+    change_release(tmp_path, field, value)
+    assert run_guard(tmp_path, release_env).returncode != 0
+    assert_no_publication(tmp_path)
+
+
+@pytest.mark.parametrize("failure", ["missing", "moved", "existing"])
+def test_preflight_rejects_missing_or_changed_target(tmp_path: Path, release_env: dict[str, str], failure: str) -> None:
+    if failure == "missing":
+        release_env["MISSING_RELEASE"] = "1"
+    elif failure == "moved":
+        release_env["REMOTE_COMMIT"] = "b" * 40
+    else:
+        change_release(tmp_path, "assets", [{"name": ASSET}])
+    assert run_guard(tmp_path, release_env).returncode != 0
+    assert_no_publication(tmp_path)
+
+
+def test_preflight_binds_release_and_commit_without_writes(tmp_path: Path, release_env: dict[str, str]) -> None:
+    result = run_guard(tmp_path, release_env)
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "output").read_text(encoding="utf-8") == f"release_id=42\ncommit={COMMIT}\n"
+    assert "release upload" not in (tmp_path / "calls").read_text(encoding="utf-8")
+    assert_no_publication(tmp_path)
+
+
+def test_publish_verifies_upload_before_publication(tmp_path: Path, release_env: dict[str, str]) -> None:
+    result = run_guard(tmp_path, release_env, "publish")
+    assert result.returncode == 0, result.stderr
+    calls = (tmp_path / "calls").read_text(encoding="utf-8")
+    assert calls.index("release upload") < calls.rindex("/releases?per_page=100") < calls.index("--method PATCH")
+    assert "-F draft=false" in calls
+    assert "--clobber" not in calls
+
+
+@pytest.mark.parametrize("failure", ["upload", "digest", "absent", "published", "identity", "empty", "missing_identity"])
+def test_failed_publication_leaves_draft_recoverable(tmp_path: Path, release_env: dict[str, str], failure: str) -> None:
+    if failure == "upload":
+        release_env["UPLOAD_STATUS"] = "1"
+    elif failure in {"digest", "absent"}:
+        assets = [] if failure == "absent" else [{"name": ASSET, "state": "uploaded", "size": 1, "digest": "sha256:wrong"}]
+        change_release(tmp_path, "assets", assets, "after.json")
+    elif failure == "published":
+        change_release(tmp_path, "draft", value=False, filename="after.json")
+    elif failure == "identity":
+        change_release(tmp_path, "id", 43, "after.json")
+    elif failure == "empty":
+        (tmp_path / ASSET).write_bytes(b"")
+    else:
+        release_env.pop("EXPECTED_COMMIT")
+    assert run_guard(tmp_path, release_env, "publish").returncode != 0
+    assert_no_publication(tmp_path)

--- a/scripts/tests/test_tag_release.py
+++ b/scripts/tests/test_tag_release.py
@@ -229,7 +229,9 @@ class TestCreateTag:
         ):
             create_tag("v1.2.3")
 
-        assert "gh release create v1.2.3 --title v1.2.3 --notes-from-tag" in capsys.readouterr().out
+        output = capsys.readouterr().out
+        assert "gh release create v1.2.3 --title v1.2.3 --notes-from-tag --draft --verify-tag" in output
+        assert "gh workflow run release-benchmarks.yml --ref main -f tag=v1.2.3" in output
 
     def test_truncated_message_uses_posix_source_url(
         self,


### PR DESCRIPTION
- Separate pseudomanifold import and promotion from PL-manifold certification that retains construction provenance.
- Calibrate fixtures, preflight every curated target before sampling, and always print fatal benchmark errors.
- Align manifests and reports with canonical Criterion IDs, fixture sizes, and all curated benchmark groups.
- Benchmark the exact stable tag on a mutable draft, verify the uploaded archive's SHA-256, and publish only after success. Reject existing baseline assets and published-release reruns.

BREAKING CHANGE: Benchmark IDs and fixture sizes require fresh baselines from v0.8.2 onward; earlier results are not comparable. Release  publication now requires a draft and explicit dispatch of release-benchmarks.yml.

Closes #588
Closes #590